### PR TITLE
Fix partially-uninitialized memory issue in float32 groupby mean/nanmean

### DIFF
--- a/src/GroupBy.cpp
+++ b/src/GroupBy.cpp
@@ -529,7 +529,7 @@ public:
       double* pOut = (double *)WORKSPACE_ALLOC(sizeof(double) * (binHigh - binLow));
       if (pass <= 0) {
          // Clear out memory for our range
-         memset(pOut, 0, sizeof(U) * (binHigh - binLow));
+         memset(pOut, 0, sizeof(double) * (binHigh - binLow));
       }
 
       for (INT64 i = 0; i < len; i++) {
@@ -568,7 +568,7 @@ public:
       double* pOut = (double*)WORKSPACE_ALLOC(sizeof(double) * (binHigh - binLow));
       if (pass <= 0) {
          // Clear out memory for our range
-         memset(pOut + binLow, 0, sizeof(U) * (binHigh - binLow));
+         memset(pOut, 0, sizeof(double) * (binHigh - binLow));
       }
 
       for (INT64 i = 0; i < len; i++) {


### PR DESCRIPTION
After the riptide_cpp build v1.6.16 was released yesterday, I noticed the riptable tests crashing in the CI builds (so no new riptable builds can currently be released). I installed that version and I've been able to reproduce the crashing locally.

riptide_cpp v1.6.15 doesn't appear to have published correctly -- at least, the conda build failed (due to some versioning issue) -- so the last good version was v1.16.14.

I dig a bit of digging, and a few different riptable tests are crashing, all in the groupby nanmean operation for float32; one other test is now failing (but not crashing), and is failing for the groupby mean for float32, which is producing partially-bad results. (The [pytest-randomly](https://github.com/pytest-dev/pytest-randomly) plugin was helpful here -- I ran the test suite multiple times, and each time it ended up crashing in one of these tests, even with the tests running in a different order each time.)

I haven't definitively identified the source of the crashing, but I did spot a couple of bugs in the new mean/nanmean functions for groupby on float32 introduced in 00383ad that could cause this. In the mean operation, memory allocated to hold the intermediate accumulated values was not being completed reset (only half of it was), which meant the first half of the output was valid and the second half was garbage data. The nanmean operation had the same issue _and_ the ``memset()`` operation was writing past the end of the allocated memory. This PR has fixes for both of those issues.