### PR TITLE
Prefer the conda-forge channel

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -126,9 +126,13 @@ jobs:
       - name: Setup Miniconda
         env:
          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true'
-        uses: goanpeca/setup-miniconda@v1
+        uses: conda-incubator/setup-miniconda@v2.0.1
         with:
           activate-environment: ""
+          auto-update-conda: true
+          channels: conda-forge
+          channel-priority: flexible
+          show-channel-urls: true
       - name: Build Package
         shell: bash -l {0}
         run: |


### PR DESCRIPTION
Upgrade to latest version of the setup-miniconda GH action. Specify we want to prefer conda-forge packages over the default channel, as they tend to be more up-to-date.