### PR TITLE
Enable py39 builds for conda using variant list

### DIFF
--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -141,7 +141,7 @@ jobs:
           conda activate conda_build
           export BUILD_VERSION=$(python -c "from setuptools_scm import get_version; print(get_version(version_scheme='post-release'))")
           mkdir conda_pkgs_output
-          conda build conda_recipe --output-folder ./conda_pkgs_output
+          conda build conda_recipe --output-folder ./conda_pkgs_output --variants "[{'python':'3.7','numpy':'1.18'},{'python':'3.7','numpy':'1.19'},{'python':'3.8','numpy':'1.18'},{'python':'3.8','numpy':'1.19'},{'python':'3.8','numpy':'1.20'},{'python':'3.9','numpy':'1.18'},{'python':'3.9','numpy':'1.19'},{'python':'3.9','numpy':'1.20'}]"
       - name: Publish artifacts
         env:
          ACTIONS_ALLOW_UNSECURE_COMMANDS: 'true' 


### PR DESCRIPTION
conda-build and it's conda_build_config.yaml file don't have a straightforward way to handle the case where numpy 1.18 doesn't (and won't) have a py39 package build; so you must either stick to py37/py38 or drop support for numpy 1.18. Instead, in the Github CI builds, invoke conda-build with an explicit list of variants to work around this problem until such time we decide to drop numpy 1.18 support.