### PR TITLE
Set source files to text (auto crlf), but keep sln files as crlf always

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,10 @@
+# Based on https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings
+
+* text=auto
+
+*.cpp text
+*.c text
+*.h text
+*.hpp text
+
+*.sln text eol=crlf


### PR DESCRIPTION
Just in case a user doesn't have their global git environment setup yet.