### PR TITLE
Don't allow the compilers to perform strict aliasing optimizations

### DIFF
--- a/src/setup.py
+++ b/src/setup.py
@@ -50,7 +50,7 @@ if sys.platform == 'linux':
         sources = sources_cpp + sources_zstd,
 
         include_dirs = ['zstd', 'zstd/common', 'zstd/compress', 'zstd/decompress',],
-        extra_compile_args = ['-mavx2', '-mbmi2', '-fpermissive','-Wno-unused-variable','-std=c++11','-pthread','-falign-functions=32','-falign-loops=32'],
+        extra_compile_args = ['-mavx2', '-mbmi2', '-fpermissive','-Wno-unused-variable','-std=c++11','-pthread','-falign-functions=32','-falign-loops=32','-fno-strict-aliasing'],
         extra_link_args = ['-lrt'],
         #libraries = [''],
         )
@@ -63,7 +63,7 @@ if sys.platform == 'darwin':
         extra_link_args = ['lib/libzstd.a'],
         #libraries = ['libzstd.a'],
         #library_dirs = ['lib'],
-        extra_compile_args = ['-mavx2', '-mbmi2', '-fpermissive','-Wno-unused-variable','-std=c++11','-pthread','-falign-functions=32'],
+        extra_compile_args = ['-mavx2', '-mbmi2', '-fpermissive','-Wno-unused-variable','-std=c++11','-pthread','-falign-functions=32','-fno-strict-aliasing'],
         )
 
 


### PR DESCRIPTION
We type pun all over the place, which would cause undefined behaviour and bad code generation.