### PR TITLE
Change to cstdint

### DIFF
--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -60,7 +60,7 @@ PyObject* ConvertFloat32(PyObject* object) {
 static
 PyObject* ConvertInt32(PyObject* object) {
    npy_intp size = Py_SIZE(object);
-   PyArrayObject* pArray = AllocateNumpyArray(1, &size, NPY_INT32);
+   PyArrayObject* pArray = AllocateNumpyArray(1, &size, NPY_INT);
    int32_t* pInt32 = (int32_t*)PyArray_DATA(pArray);
 
    for (int64_t i = 0; i < size; i++) {
@@ -300,7 +300,7 @@ AsAnyArray(PyObject *self, PyObject *args, PyObject *kwargs) {
                   return ConvertBool(object);
                }
                else {
-                  // For Windows allocate NPY_INT32 and if out of range, switch to int64_t
+                  // For Windows allocate NPY_INT and if out of range, switch to int64_t
                   if (sizeof(long) == 4) {
                      PyObject* result=ConvertInt32(object);
                      if (result) return result;

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -60,7 +60,7 @@ PyObject* ConvertFloat32(PyObject* object) {
 static
 PyObject* ConvertInt32(PyObject* object) {
    npy_intp size = Py_SIZE(object);
-   PyArrayObject* pArray = AllocateNumpyArray(1, &size, NPY_INT);
+   PyArrayObject* pArray = AllocateNumpyArray(1, &size, NPY_INT32);
    int32_t* pInt32 = (int32_t*)PyArray_DATA(pArray);
 
    for (int64_t i = 0; i < size; i++) {
@@ -300,7 +300,7 @@ AsAnyArray(PyObject *self, PyObject *args, PyObject *kwargs) {
                   return ConvertBool(object);
                }
                else {
-                  // For Windows allocate NPY_INT and if out of range, switch to int64_t
+                  // For Windows allocate NPY_INT32 and if out of range, switch to int64_t
                   if (sizeof(long) == 4) {
                      PyObject* result=ConvertInt32(object);
                      if (result) return result;

--- a/src/Array.cpp
+++ b/src/Array.cpp
@@ -10,11 +10,11 @@
 #define LOGGING(...)
 
 static
-INT64 FindMaxSize(PyObject* object) {
-   INT64 size = Py_SIZE(object);
-   INT64 maxsize = 0;
-   for (INT64 i = 0; i < size; i++) {
-      INT64 itemsize = Py_SIZE(PyList_GET_ITEM(object, i));
+int64_t FindMaxSize(PyObject* object) {
+   int64_t size = Py_SIZE(object);
+   int64_t maxsize = 0;
+   for (int64_t i = 0; i < size; i++) {
+      int64_t itemsize = Py_SIZE(PyList_GET_ITEM(object, i));
       if (itemsize > maxsize) maxsize = itemsize;
    }
    return maxsize;
@@ -30,7 +30,7 @@ PyObject* ConvertFloat64(PyObject* object) {
    PyArrayObject* pArray = AllocateNumpyArray(1, &size, NPY_FLOAT64);
    double* pFloat64 = (double*)PyArray_DATA(pArray);
 
-   for (INT64 i = 0; i < size; i++) {
+   for (int64_t i = 0; i < size; i++) {
       pFloat64[i] = PyFloat_AsDouble(PyList_GET_ITEM(object, i));
    }
    return (PyObject*)pArray;
@@ -47,7 +47,7 @@ PyObject* ConvertFloat32(PyObject* object) {
    PyArrayObject* pArray = AllocateNumpyArray(1, &size, NPY_FLOAT32);
    float* pFloat32 = (float*)PyArray_DATA(pArray);
 
-   for (INT64 i = 0; i < size; i++) {
+   for (int64_t i = 0; i < size; i++) {
       pFloat32[i] = (float)PyFloat_AsDouble(PyList_GET_ITEM(object, i));
    }
    return (PyObject*)pArray;
@@ -61,17 +61,17 @@ static
 PyObject* ConvertInt32(PyObject* object) {
    npy_intp size = Py_SIZE(object);
    PyArrayObject* pArray = AllocateNumpyArray(1, &size, NPY_INT32);
-   INT32* pInt32 = (INT32*)PyArray_DATA(pArray);
+   int32_t* pInt32 = (int32_t*)PyArray_DATA(pArray);
 
-   for (INT64 i = 0; i < size; i++) {
+   for (int64_t i = 0; i < size; i++) {
       int overflow = 0;
-      INT64 val= PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(object, i), &overflow);
+      int64_t val= PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(object, i), &overflow);
       if (overflow || val < NPY_MIN_INT32 || val > NPY_MAX_INT32) {
          // Failure due to out of range
          Py_DecRef((PyObject*)pArray);
          return NULL;
       }
-      pInt32[i] = (INT32)val;
+      pInt32[i] = (int32_t)val;
    }
    return (PyObject*)pArray;
 }
@@ -82,9 +82,9 @@ static
 PyObject* ConvertInt64(PyObject* object) {
    npy_intp size = Py_SIZE(object);
    PyArrayObject* pArray = AllocateNumpyArray(1, &size, NPY_INT64);
-   INT64* pInt64 = (INT64*)PyArray_DATA(pArray);
+   int64_t* pInt64 = (int64_t*)PyArray_DATA(pArray);
 
-   for (INT64 i = 0; i < size; i++) {
+   for (int64_t i = 0; i < size; i++) {
       int overflow = 0;
       // if overflow consider uint64?
       pInt64[i] = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(object, i), &overflow);
@@ -102,7 +102,7 @@ PyObject* ConvertBool(PyObject* object) {
    PyArrayObject* pArray = AllocateNumpyArray(1, &size, NPY_BOOL);
    bool* pBool = (bool*)PyArray_DATA(pArray);
 
-   for (INT64 i = 0; i < size; i++) {
+   for (int64_t i = 0; i < size; i++) {
       pBool[i] = PyList_GET_ITEM(object, i) == Py_True;
    }
    return (PyObject*)pArray;
@@ -113,13 +113,13 @@ PyObject* ConvertBool(PyObject* object) {
 static
 PyObject* ConvertBytes(PyObject* object) {
    npy_intp size = Py_SIZE(object);
-   INT64 maxsize = FindMaxSize(object);
+   int64_t maxsize = FindMaxSize(object);
    PyArrayObject* pArray = AllocateNumpyArray(1, &size, NPY_STRING, maxsize);
    char* pChar = (char*)PyArray_DATA(pArray);
 
-   for (INT64 i = 0; i < size; i++) {
+   for (int64_t i = 0; i < size; i++) {
       PyObject* item=PyList_GET_ITEM(object, i);
-      INT64 strSize = Py_SIZE(item);
+      int64_t strSize = Py_SIZE(item);
 
       // get pointer to string
       const char* pString = PyBytes_AS_STRING(item);
@@ -142,14 +142,14 @@ PyObject* ConvertBytes(PyObject* object) {
 static
 PyObject* ConvertUnicode(PyObject* object) {
    npy_intp size = Py_SIZE(object);
-   INT64 maxsize = FindMaxSize(object);
+   int64_t maxsize = FindMaxSize(object);
    PyArrayObject* pArray = AllocateNumpyArray(1, &size, NPY_UNICODE, maxsize*4);
-   UINT32* pChar = (UINT32*)PyArray_DATA(pArray);
+   uint32_t* pChar = (uint32_t*)PyArray_DATA(pArray);
 
-   for (INT64 i = 0; i < size; i++) {
+   for (int64_t i = 0; i < size; i++) {
       PyObject* item = PyList_GET_ITEM(object, i);
-      INT64 strSize = Py_SIZE(item);
-      UINT32* pDest = &pChar[i*maxsize];
+      int64_t strSize = Py_SIZE(item);
+      uint32_t* pDest = &pChar[i*maxsize];
 
       // get pointer to string
       PyUnicode_AsUCS4(item, pDest, maxsize, 0);
@@ -281,7 +281,7 @@ AsAnyArray(PyObject *self, PyObject *args, PyObject *kwargs) {
          PyObject* firstObject = PyList_GET_ITEM(object, 0);
          _typeobject* otype = firstObject->ob_type;
 
-         INT64 countsize = size - 1;
+         int64_t countsize = size - 1;
          while (countsize > 0) {
             if (otype != PyList_GET_ITEM(object, countsize)->ob_type) {
                LOGGING("Second type is %s\n", PyList_GET_ITEM(object, countsize)->ob_type->tp_name);
@@ -300,7 +300,7 @@ AsAnyArray(PyObject *self, PyObject *args, PyObject *kwargs) {
                   return ConvertBool(object);
                }
                else {
-                  // For Windows allocate NPY_INT32 and if out of range, switch to INT64
+                  // For Windows allocate NPY_INT32 and if out of range, switch to int64_t
                   if (sizeof(long) == 4) {
                      PyObject* result=ConvertInt32(object);
                      if (result) return result;

--- a/src/BasicMath.cpp
+++ b/src/BasicMath.cpp
@@ -856,12 +856,14 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpFastSymmetric<float, __m256, AddOp<float>, ADD_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFastSymmetric<double, __m256d, AddOp<double>, ADD_OP_256f64>;
          // proof of concept for i32 addition loop
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AddOp<int32_t>, ADD_OP_256i32>;
-      CASE_NPY_INT64:  return SimpleMathOpFastSymmetric<int64_t, __m256i, AddOp<int64_t>, ADD_OP_256i64>;
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AddOp<int32_t>, ADD_OP_256i32>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpFastSymmetric<int64_t, __m256i, AddOp<int64_t>, ADD_OP_256i64>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, AddOp<int16_t>, ADD_OP_256i16>;
       case NPY_INT8:   return SimpleMathOpFastSymmetric<int8_t,  __m256i, AddOp<int8_t>, ADD_OP_256i8>;
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::MUL:
       *wantedOutType = numpyInType1;
@@ -870,18 +872,20 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, AndOp<int8_t>, AND_OP_256>;
       case NPY_FLOAT:  return SimpleMathOpFastSymmetric<float, __m256, MulOp<float>, MUL_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFastSymmetric<double, __m256d, MulOp<double>, MUL_OP_256f64>;
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MulOp<int32_t>, MUL_OP_256i32>;
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MulOp<int32_t>, MUL_OP_256i32>;
 
-      //CASE_NPY_INT64:  return SimpleMathOpFast<int64_t, __m256i, MulOp<int64_t>, MUL_OP_256i64>;
+      //case NPY_INT64:  case NPY_LONGLONG: return SimpleMathOpFast<int64_t, __m256i, MulOp<int64_t>, MUL_OP_256i64>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MulOp<int16_t>, MUL_OP_256i16>;
 
       // Below the intrinsic to multiply is slower so we disabled it (really wants 32bit -> 64bit)
-      //CASE_NPY_UINT32:  return SimpleMathOpFastMul<uint32_t, __m256i>;
+      //case NPY_UINT32:  return SimpleMathOpFastMul<uint32_t, __m256i>;
       // TODO: 64bit multiply can be done with algo..
       // lo1 * lo2 + (lo1 * hi2) << 32 + (hi1 *lo2) << 32)
-      CASE_NPY_UINT64: return SimpleMathOpFastSymmetric<uint64_t, __m256i, MulOp<uint64_t>, MUL_OP_256u64>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return SimpleMathOpFastSymmetric<uint64_t, __m256i, MulOp<uint64_t>, MUL_OP_256u64>;
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::SUB:
       *wantedOutType = numpyInType1;
@@ -889,12 +893,14 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (*wantedOutType) {
       case NPY_FLOAT:  return SimpleMathOpFast<float, __m256, SubOp<float>, SUB_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFast<double, __m256d, SubOp<double>, SUB_OP_256f64>;
-      CASE_NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, SubOp<int32_t>, SUB_OP_256i32>;
-      CASE_NPY_INT64:  return SimpleMathOpFast<int64_t, __m256i, SubOp<int64_t>, SUB_OP_256i64>;
+      case NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, SubOp<int32_t>, SUB_OP_256i32>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpFast<int64_t, __m256i, SubOp<int64_t>, SUB_OP_256i64>;
       case NPY_INT16:  return SimpleMathOpFast<int16_t, __m256i, SubOp<int16_t>, SUB_OP_256i16>;
       case NPY_INT8:   return SimpleMathOpFast<int8_t,  __m256i, SubOp<int8_t>,  SUB_OP_256i8>;
       }
-      return NULL;
+      return nullptr;
 
 
    case MATH_OPERATION::MIN:
@@ -905,14 +911,14 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       // TODO: Vector routine needs to be written
       case NPY_FLOAT:  return SimpleMathOpSlowMin<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMin<double>;
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MinOp<int32_t>, MIN_OPi32>;
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MinOp<int32_t>, MIN_OPi32>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MinOp<int16_t>, MIN_OPi16>;
       case NPY_INT8:   return SimpleMathOpFastSymmetric<int8_t, __m256i, MinOp<int8_t>, MIN_OPi8>;
-      CASE_NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MinOp<uint32_t>, MIN_OPu32>;
+      case NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MinOp<uint32_t>, MIN_OPu32>;
       case NPY_UINT16:  return SimpleMathOpFastSymmetric<uint16_t, __m256i, MinOp<uint16_t>, MIN_OPu16>;
       case NPY_UINT8:   return SimpleMathOpFastSymmetric<uint8_t, __m256i, MinOp<uint8_t>, MIN_OPu8>;
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::MAX:
       // This is max for two arrays
@@ -922,14 +928,14 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       // TODO: Vector routine needs to be written
       case NPY_FLOAT:  return SimpleMathOpSlowMax<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMax<double>;
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MaxOp<int32_t>, MAX_OPi32>;
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MaxOp<int32_t>, MAX_OPi32>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MaxOp<int16_t>, MAX_OPi16>;
       case NPY_INT8:   return SimpleMathOpFastSymmetric<int8_t, __m256i, MaxOp<int8_t>, MAX_OPi8>;
-      CASE_NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MaxOp<uint32_t>, MAX_OPu32>;
+      case NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MaxOp<uint32_t>, MAX_OPu32>;
       case NPY_UINT16:  return SimpleMathOpFastSymmetric<uint16_t, __m256i, MaxOp<uint16_t>, MAX_OPu16>;
       case NPY_UINT8:   return SimpleMathOpFastSymmetric<uint8_t, __m256i, MaxOp<uint8_t>, MAX_OPu8>;
       }
-      return NULL;
+      return nullptr;
 
 
    case MATH_OPERATION::DIV:
@@ -943,9 +949,9 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
       case NPY_FLOAT:  return SimpleMathOpFast<float, __m256, DivOp<float>, DIV_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFast<double, __m256d, DivOp<double>, DIV_OP_256f64>;
-      CASE_NPY_INT32:  return SimpleMathOpFastDivDouble<int32_t, __m128i, __m256d>;
+      case NPY_INT32:  return SimpleMathOpFastDivDouble<int32_t, __m128i, __m256d>;
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::LOGICAL_AND:
       *wantedOutType = numpyInType1;
@@ -953,7 +959,7 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (*wantedOutType) {
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, AndOp<int8_t>, AND_OP_256>;
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::BITWISE_AND:
       *wantedOutType = numpyInType1;
@@ -964,12 +970,15 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, AndOp<int8_t>, AND_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, AndOp<int16_t>, AND_OP_256>;
-      CASE_NPY_UINT32:
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AndOp<int32_t>, AND_OP_256>;
-      CASE_NPY_UINT64:
-      case NPY_INT64:  return SimpleMathOpFastSymmetric<int64_t, __m256i, AndOp<int64_t>, AND_OP_256>;
+      case NPY_UINT32:
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AndOp<int32_t>, AND_OP_256>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpFastSymmetric<int64_t, __m256i, AndOp<int64_t>, AND_OP_256>;
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::LOGICAL_OR:
       *wantedOutType = numpyInType1;
@@ -977,7 +986,7 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (*wantedOutType) {
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, OrOp<int8_t>, OR_OP_256>;
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::BITWISE_OR:
       *wantedOutType = numpyInType1;
@@ -988,12 +997,15 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, OrOp<int8_t>, OR_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, OrOp<int16_t>, OR_OP_256>;
-      CASE_NPY_UINT32:
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, OrOp<int32_t>, OR_OP_256>;
-      CASE_NPY_UINT64:
-      case NPY_INT64:  return SimpleMathOpFastSymmetric<int64_t, __m256i, OrOp<int64_t>, OR_OP_256>;
+      case NPY_UINT32:
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, OrOp<int32_t>, OR_OP_256>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpFastSymmetric<int64_t, __m256i, OrOp<int64_t>, OR_OP_256>;
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::BITWISE_XOR:
       *wantedOutType = numpyInType1;
@@ -1004,12 +1016,15 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, XorOp<int8_t>, XOR_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, XorOp<int16_t>, XOR_OP_256>;
-      CASE_NPY_UINT32:
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
-      CASE_NPY_UINT64:
-      case NPY_INT64:  return SimpleMathOpFastSymmetric<int64_t, __m256i, XorOp<int64_t>, XOR_OP_256>;
+      case NPY_UINT32:
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpFastSymmetric<int64_t, __m256i, XorOp<int64_t>, XOR_OP_256>;
       }
-      return NULL;
+      return nullptr;
 
 
    case MATH_OPERATION::BITWISE_XOR_SPECIAL:
@@ -1021,12 +1036,15 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, XorOp<int8_t>, XOR_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, XorOp<int16_t>, XOR_OP_256>;
-      CASE_NPY_UINT32:
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
-      CASE_NPY_UINT64:
-      case NPY_INT64:  return SimpleMathOpFastSymmetric<int64_t, __m256i, XorOp<int64_t>, XOR_OP_256>;
+      case NPY_UINT32:
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpFastSymmetric<int64_t, __m256i, XorOp<int64_t>, XOR_OP_256>;
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::BITWISE_ANDNOT:
       *wantedOutType = numpyInType1;
@@ -1037,12 +1055,15 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastReverse<int8_t, __m256i, AndNotOp<int8_t>, ANDNOT_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastReverse<int16_t, __m256i, AndNotOp<int16_t>, ANDNOT_OP_256>;
-      CASE_NPY_UINT32:
-      CASE_NPY_INT32:  return SimpleMathOpFastReverse<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
-      CASE_NPY_UINT64:
-      case NPY_INT64:  return SimpleMathOpFastReverse<int64_t, __m256i, AndNotOp<int64_t>, ANDNOT_OP_256>;
+      case NPY_UINT32:
+      case NPY_INT32:  return SimpleMathOpFastReverse<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpFastReverse<int64_t, __m256i, AndNotOp<int64_t>, ANDNOT_OP_256>;
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::BITWISE_NOTAND:
       *wantedOutType = numpyInType1;
@@ -1053,21 +1074,24 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFast<int8_t, __m256i, AndNotOp<int8_t>, ANDNOT_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFast<int16_t, __m256i, AndNotOp<int16_t>, ANDNOT_OP_256>;
-      CASE_NPY_UINT32:
-      CASE_NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
-      CASE_NPY_UINT64:
-      case NPY_INT64:  return SimpleMathOpFast<int64_t, __m256i, AndNotOp<int64_t>, ANDNOT_OP_256>;
+      case NPY_UINT32:
+      case NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpFast<int64_t, __m256i, AndNotOp<int64_t>, ANDNOT_OP_256>;
       }
-      return NULL;
+      return nullptr;
 
    }
 
-   return NULL;
+   return nullptr;
 }
 
 
 //==========================================================
-// May return NULL if it cannot handle type or function
+// May return nullptr if it cannot handle type or function
 static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInType1, int numpyInType2, int numpyOutType, int* wantedOutType) {
    switch (func) {
    case MATH_OPERATION::ADD:
@@ -1078,10 +1102,15 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowAdd<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowAdd<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowAdd<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowAdd<int32_t>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowAdd<int64_t>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowAdd<uint32_t>;
-      CASE_NPY_UINT64: return SimpleMathOpSlowAdd<uint64_t>;
+      case NPY_INT32:  return SimpleMathOpSlowAdd<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpSlowAdd<int64_t>;
+      case NPY_UINT32:
+         return SimpleMathOpSlowAdd<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return SimpleMathOpSlowAdd<uint64_t>;
       case NPY_INT8:   return SimpleMathOpSlowAdd<int8_t>;
       case NPY_INT16:  return SimpleMathOpSlowAdd<int16_t>;
       case NPY_UINT8:  return SimpleMathOpSlowAdd<uint8_t>;
@@ -1098,7 +1127,7 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
          }
          break;
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::SUB:
       *wantedOutType = numpyInType1;
@@ -1108,17 +1137,21 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowSub<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowSub<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowSub<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowSub<int32_t>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowSub<int64_t>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowSub<uint32_t>;
-      CASE_NPY_UINT64: return SimpleMathOpSlowSub<uint64_t>;
+      case NPY_INT32:  return SimpleMathOpSlowSub<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpSlowSub<int64_t>;
+      case NPY_UINT32: return SimpleMathOpSlowSub<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return SimpleMathOpSlowSub<uint64_t>;
       case NPY_INT8:   return SimpleMathOpSlowSub<int8_t>;
       case NPY_INT16:  return SimpleMathOpSlowSub<int16_t>;
       case NPY_UINT8:  return SimpleMathOpSlowSub<uint8_t>;
       case NPY_UINT16: return SimpleMathOpSlowSub<uint16_t>;
 
       }
-      return NULL;
+      return nullptr;
 
 
    case MATH_OPERATION::MUL:
@@ -1129,17 +1162,21 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowMul<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMul<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowMul<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowMul<int32_t>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowMul<int64_t>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowMul<uint32_t>;
-      case NPY_UINT64: return SimpleMathOpSlowMul<uint64_t>;
+      case NPY_INT32:  return SimpleMathOpSlowMul<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpSlowMul<int64_t>;
+      case NPY_UINT32: return SimpleMathOpSlowMul<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return SimpleMathOpSlowMul<uint64_t>;
       case NPY_INT8:   return SimpleMathOpSlowMul<int8_t>;
       case NPY_INT16:  return SimpleMathOpSlowMul<int16_t>;
       case NPY_UINT8:  return SimpleMathOpSlowMul<uint8_t>;
       case NPY_UINT16: return SimpleMathOpSlowMul<uint16_t>;
 
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::DIV:
       *wantedOutType = NPY_DOUBLE;
@@ -1155,35 +1192,44 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowDivFloat<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowDiv<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowDiv<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowDiv<int32_t>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowDiv<int64_t>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowDiv<uint32_t>;
-      CASE_NPY_UINT64: return SimpleMathOpSlowDiv<uint64_t>;
+      case NPY_INT32:  return SimpleMathOpSlowDiv<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpSlowDiv<int64_t>;
+      case NPY_UINT32: return SimpleMathOpSlowDiv<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return SimpleMathOpSlowDiv<uint64_t>;
       case NPY_INT8:   return SimpleMathOpSlowDiv<int8_t>;
       case NPY_INT16:  return SimpleMathOpSlowDiv<int16_t>;
       case NPY_UINT8:  return SimpleMathOpSlowDiv<uint8_t>;
       case NPY_UINT16: return SimpleMathOpSlowDiv<uint16_t>;
 
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::SUBDATETIMES:
       *wantedOutType = NPY_DOUBLE;
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
-      CASE_NPY_INT32:  return SimpleMathOpSubDateTime<int32_t>;
-      CASE_NPY_INT64:  return SimpleMathOpSubDateTime<int64_t>;
+      case NPY_INT32:  return SimpleMathOpSubDateTime<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpSubDateTime<int64_t>;
       }
       printf("bad call to subdatetimes %d %d\n", numpyInType2 , numpyInType1);
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::SUBDATES:
       *wantedOutType = NPY_INT32;
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
-      CASE_NPY_INT32:  return SimpleMathOpSubDates<int32_t>;
-      CASE_NPY_INT64:  *wantedOutType = NPY_INT64; return SimpleMathOpSubDates<int64_t>;
+      case NPY_INT32:  return SimpleMathOpSubDates<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         *wantedOutType = NPY_INT64;
+         return SimpleMathOpSubDates<int64_t>;
       }
       printf("bad call to subdates %d %d\n", numpyInType2, numpyInType1);
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::FLOORDIV:
       *wantedOutType = numpyInType1;
@@ -1194,10 +1240,14 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowFloorDiv<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowFloorDiv<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowFloorDiv<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowFloorDiv<int32_t>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowFloorDiv<int64_t>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowFloorDiv<uint32_t>;
-      case NPY_UINT64: return SimpleMathOpSlowFloorDiv<uint64_t>;
+      case NPY_INT32:  return SimpleMathOpSlowFloorDiv<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpSlowFloorDiv<int64_t>;
+      case NPY_UINT32: return SimpleMathOpSlowFloorDiv<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return SimpleMathOpSlowFloorDiv<uint64_t>;
 
 #ifndef RT_COMPILER_CLANG  // possible error with int8 array and np.floor_divide() with vextractps instruction
       case NPY_INT8:   return SimpleMathOpSlowFloorDiv<int8_t>;
@@ -1206,7 +1256,7 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_UINT16: return SimpleMathOpSlowFloorDiv<uint16_t>;
 #endif
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::MOD:
       *wantedOutType = numpyInType1;
@@ -1216,17 +1266,21 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowRemainder<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowRemainder<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowRemainder<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowMod<int32_t>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowMod<int64_t>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowMod<uint32_t>;
-      CASE_NPY_UINT64: return SimpleMathOpSlowMod<uint64_t>;
+      case NPY_INT32:  return SimpleMathOpSlowMod<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpSlowMod<int64_t>;
+      case NPY_UINT32: return SimpleMathOpSlowMod<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return SimpleMathOpSlowMod<uint64_t>;
       case NPY_INT8:   return SimpleMathOpSlowMod<int8_t>;
       case NPY_INT16:  return SimpleMathOpSlowMod<int16_t>;
       case NPY_UINT8:  return SimpleMathOpSlowMod<uint8_t>;
       case NPY_UINT16: return SimpleMathOpSlowMod<uint16_t>;
 
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::POWER:
       *wantedOutType = numpyInType1;
@@ -1236,17 +1290,21 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowPower<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowPower<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowPower<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowPower<int32_t>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowPower<int64_t>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowPower<uint32_t>;
-      CASE_NPY_UINT64: return SimpleMathOpSlowPower<uint64_t>;
+      case NPY_INT32:  return SimpleMathOpSlowPower<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return SimpleMathOpSlowPower<int64_t>;
+      case NPY_UINT32: return SimpleMathOpSlowPower<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return SimpleMathOpSlowPower<uint64_t>;
       case NPY_INT8:   return SimpleMathOpSlowPower<int8_t>;
       case NPY_INT16:  return SimpleMathOpSlowPower<int16_t>;
       case NPY_UINT8:  return SimpleMathOpSlowPower<uint8_t>;
       case NPY_UINT16: return SimpleMathOpSlowPower<uint16_t>;
 
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::REMAINDER:
       *wantedOutType = numpyInType1;
@@ -1257,7 +1315,7 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_LONGDOUBLE: return SimpleMathOpSlowRemainder<long double>;
 
       }
-      return NULL;
+      return nullptr;
 
    case MATH_OPERATION::FMOD:
       *wantedOutType = numpyInType1;
@@ -1268,11 +1326,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_LONGDOUBLE: return SimpleMathOpSlowFmod<long double>;
 
       }
-      return NULL;
+      return nullptr;
 
    }
 
-   return NULL;
+   return nullptr;
 }
 
 //---------------------------------
@@ -1282,16 +1340,18 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
 // TODO: Replace with call to our FixupDtype() function?
 static int GetNonAmbiguousDtype(int dtype) {
    switch (dtype) {
-   CASE_NPY_INT32:
+   case NPY_INT32:
       dtype = 5;
       break;
-   CASE_NPY_UINT32:
+   case NPY_UINT32:
       dtype = 6;
       break;
-   CASE_NPY_INT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       dtype = 9;
       break;
-   CASE_NPY_UINT64:
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
       dtype = 10;
       break;
    }
@@ -1301,7 +1361,7 @@ static int GetNonAmbiguousDtype(int dtype) {
 //--------------------------------------------------------------------
 // Check to see if we can compute this
 static ANY_TWO_FUNC CheckMathOpTwoInputs(int func, int scalarMode, int numpyInType1, int numpyInType2, int numpyOutType, int* wantedOutType) {
-   ANY_TWO_FUNC pTwoFunc = NULL;
+   ANY_TWO_FUNC pTwoFunc = nullptr;
 
    LOGGING("CheckMathTwo %d  scalar:%d  type1:%d  type2:%d\n", func, scalarMode, numpyInType1, numpyInType2);
 
@@ -1332,7 +1392,7 @@ static ANY_TWO_FUNC CheckMathOpTwoInputs(int func, int scalarMode, int numpyInTy
 
          // Try to get fast one first
          pTwoFunc = GetSimpleMathOpFast(func, scalarMode, numpyInType1, numpyInType2, numpyOutType, wantedOutType);
-         if (pTwoFunc == NULL) {
+         if (pTwoFunc == nullptr) {
             pTwoFunc = GetSimpleMathOpSlow(func, scalarMode, numpyInType1, numpyInType2, numpyOutType, wantedOutType);
          }
          break;
@@ -1345,7 +1405,7 @@ static ANY_TWO_FUNC CheckMathOpTwoInputs(int func, int scalarMode, int numpyInTy
       case MATH_OPERATION::CMP_LT:
       case MATH_OPERATION::CMP_LTE:
          pTwoFunc = GetComparisonOpFast(func, scalarMode, numpyInType1, numpyInType2, numpyOutType, wantedOutType);
-         if (pTwoFunc == NULL) {
+         if (pTwoFunc == nullptr) {
             pTwoFunc = GetComparisonOpSlow(func, scalarMode, numpyInType1, numpyInType2, numpyOutType, wantedOutType);
          }
          break;
@@ -1369,7 +1429,7 @@ static ANY_TWO_FUNC CheckMathOpTwoInputs(int func, int scalarMode, int numpyInTy
 
          // Try to get fast one first
          pTwoFunc = GetSimpleMathOpFast(func, scalarMode, numpyInType1, numpyInType2, numpyOutType, wantedOutType);
-         if (pTwoFunc == NULL) {
+         if (pTwoFunc == nullptr) {
             pTwoFunc = GetSimpleMathOpSlow(func, scalarMode, numpyInType1, numpyInType2, numpyOutType, wantedOutType);
          }
          break;
@@ -1554,7 +1614,7 @@ public:
 
    //-------------------------------------------------------------------
    // 
-   // returns NULL on failure
+   // returns nullptr on failure
    PyObject* PossiblyConvertString(int newType, int oldType, PyObject* inObject) {
       if (newType == NPY_UNICODE && oldType == NPY_STRING) {
          if (PyUnicode_Check(inObject)) {
@@ -1573,7 +1633,7 @@ public:
             }
          }
       } 
-      return NULL;
+      return nullptr;
    }
 
    //-------------------------------------------------------------------
@@ -1602,18 +1662,18 @@ public:
 
    //-------------------------------------------------------------------
    // Arg1: defaultScalarType currently not used
-   // returns FALSE on failure
+   // returns false on failure
    bool CheckInputs(PyObject* args, int defaultScalarType, int64_t funcNumber) {
       if (!PyTuple_CheckExact(args)) {
          PyErr_Format(PyExc_ValueError, "BasicMath arguments needs to be a tuple");
-         return FALSE;
+         return false;
       }
 
       tupleSize = Py_SIZE(args);
 
       if (tupleSize != (expectedTupleSize - 1) && tupleSize != expectedTupleSize) {
          PyErr_Format(PyExc_ValueError, "BasicMath only takes two or three arguments instead of %llu args", tupleSize);
-         return FALSE;
+         return false;
       }
 
       // PyTuple_GetItem will not increment the ref count
@@ -1639,7 +1699,7 @@ public:
       tupleSize = 2;
       inObject1 = input1;
       inObject2 = input2;
-      if (output != NULL) {
+      if (output != nullptr) {
          outputObject = output;
          // This will force the output type
          numpyOutType = PyArray_TYPE((PyArrayObject*)outputObject);
@@ -1650,7 +1710,7 @@ public:
 
    //----------------------------------------
    // Input: numpyInType1 and numpyInType2 must be set
-   // Returns FALSE on error
+   // Returns false on error
    // 
    bool CheckUpcast() {
       // Check if we need to upcast one or both of the arrays
@@ -1684,7 +1744,7 @@ public:
                   PyObject* newarray1 = ConvertSafeInternal(inArr, convertType1);
                   if (!newarray1) {
                      // Failed to convert
-                     return FALSE;
+                     return false;
                   }
                   toDelete3 = newarray1;
                   FillArray1(newarray1);
@@ -1696,7 +1756,7 @@ public:
                   PyObject* newarray2 = ConvertSafeInternal(inArr2, convertType2);
                   if (!newarray2) {
                      // Failed to convert
-                     return FALSE;
+                     return false;
                   }
                   toDelete4 = newarray2;
                   FillArray2(newarray2);
@@ -1704,12 +1764,12 @@ public:
             }
             else {
                LOGGING("BasicMath cannot upcast %d vs %d\n", numpyInType1, numpyInType2);
-               return FALSE;
+               return false;
             }
 
          }
       }
-      return TRUE;
+      return true;
    }
 
 
@@ -1730,12 +1790,12 @@ public:
             LOGGING("Converting object1 to array %s\n", inObject1->ob_type->tp_name);
             // Convert to temp array that must be deleted
             toDelete1 =
-            inObject1 = PyArray_FromAny(inObject1, NULL, 0, 0, NPY_ARRAY_ENSUREARRAY, NULL);
-            if (inObject1 == NULL) {
-               return FALSE;
+            inObject1 = PyArray_FromAny(inObject1, nullptr, 0, 0, NPY_ARRAY_ENSUREARRAY, nullptr);
+            if (inObject1 == nullptr) {
+               return false;
             }
-            isArray1 = TRUE;
-            isScalar1 = FALSE;
+            isArray1 = true;
+            isScalar1 = false;
          }
          else if (isArray2 && !outputObject) {
             // 
@@ -1751,7 +1811,7 @@ public:
                   PyObject* newarray2 = ConvertSafeInternal((PyArrayObject*)inObject2, newType);
                   if (!newarray2) {
                      // Failed to convert
-                     return FALSE;
+                     return false;
                   }
                   // remember to delete temp array
                   toDelete1 =
@@ -1761,9 +1821,9 @@ public:
                else {
                   // Handle conversion from string to unicode here
                   toDelete1 = PossiblyConvertString(newType, oldType, inObject2);
-                  if (!toDelete1) return FALSE;
+                  if (!toDelete1) return false;
                   inObject2 = toDelete1;
-                  return FALSE; // until we handle string compares
+                  return false; // until we handle string compares
                }
             
             }
@@ -1776,12 +1836,12 @@ public:
          if (!isScalar2) {
             LOGGING("Converting object2 to array %s\n", inObject2->ob_type->tp_name);
             toDelete2 =
-            inObject2 = PyArray_FromAny(inObject2, NULL, 0, 0, NPY_ARRAY_ENSUREARRAY, NULL);
-            if (inObject2 == NULL) {
-               return FALSE;
+            inObject2 = PyArray_FromAny(inObject2, nullptr, 0, 0, NPY_ARRAY_ENSUREARRAY, nullptr);
+            if (inObject2 == nullptr) {
+               return false;
             }
-            isArray2 = TRUE;
-            isScalar2 = FALSE;
+            isArray2 = true;
+            isScalar2 = false;
          }
          else if (isArray1 && !outputObject) {
             // 
@@ -1795,7 +1855,7 @@ public:
                   PyObject* newarray1 = ConvertSafeInternal((PyArrayObject*)inObject1, newType);
                   if (!newarray1) {
                      // Failed to convert
-                     return FALSE;
+                     return false;
                   }
                   // remember to delete temp array
                   toDelete2 =
@@ -1804,9 +1864,9 @@ public:
                else {
                   // Handle conversion from string to unicode here
                   toDelete2 =PossiblyConvertString(newType, oldType, inObject1);
-                  if (!toDelete2) return FALSE;
+                  if (!toDelete2) return false;
                   inObject1 = toDelete2;
-                  return FALSE;
+                  return false;
                }
             }
          }
@@ -1840,7 +1900,7 @@ public:
          // TJD added this Dec 11, 2018
          numpyInType1 = numpyInType2;
 
-         if (!bResult) return FALSE;
+         if (!bResult) return false;
 
       }
       else {
@@ -1848,7 +1908,7 @@ public:
          FillArray1(inObject1);
          // Check strides
          if (ndim1 > 0 && itemSize1 != PyArray_STRIDE((PyArrayObject*)inArr, 0)) {
-            return FALSE;
+            return false;
          }
 
          //// check for a scalar passed as array of 1 item
@@ -1861,7 +1921,7 @@ public:
          //      bool bResult =
          //         ConvertSingleItemArray(pDataIn1, GetArrDType(inArr), &m256Scalar1, numpyInType2);
 
-         //      if (!bResult) return FALSE;
+         //      if (!bResult) return false;
          //      pDataIn1 = &m256Scalar1;
          //   }
          //}
@@ -1885,7 +1945,7 @@ public:
 
          LOGGING("Converting second scalar type to %d, bresult: %d,  value: %lld  type: %s\n", numpyInType1, bResult, *(int64_t*)&m256Scalar2, inObject2->ob_type->tp_name);
 
-         if (!bResult) return FALSE;
+         if (!bResult) return false;
 
       }
       else {
@@ -1894,7 +1954,7 @@ public:
 
          // Check strides
          if (ndim2 > 0 && itemSize2 != PyArray_STRIDE((PyArrayObject*)inArr2, 0)) {
-            return FALSE;
+            return false;
          }
 
          //// check for a scalar passed as array of 1 item
@@ -1906,7 +1966,7 @@ public:
          //      bool bResult =
          //         ConvertSingleItemArray(pDataIn1, GetArrDType(inArr), &m256Scalar1, numpyInType2);
 
-         //      if (!bResult) return FALSE;
+         //      if (!bResult) return false;
          //      pDataIn1 = &m256Scalar1;
          //   }
          //}
@@ -1938,7 +1998,7 @@ public:
                   bool bResult =
                      ConvertSingleItemArray(pDataIn1, numpyInType1, &m256Scalar1, convertType1);
 
-                  if (!bResult) return FALSE;
+                  if (!bResult) return false;
                   pDataIn1 = &m256Scalar1;
                   numpyInType1 = convertType1;
 
@@ -1948,7 +2008,7 @@ public:
                      PyObject* newarray2 = ConvertSafeInternal(inArr2, convertType2);
                      if (!newarray2) {
                         // Failed to convert
-                        return FALSE;
+                        return false;
                      }
                      toDelete4 = newarray2;
                      FillArray2(newarray2);
@@ -1956,7 +2016,7 @@ public:
 
                }
                else {
-                  return FALSE;
+                  return false;
                }
 
             }
@@ -1977,7 +2037,7 @@ public:
                   bool bResult =
                      ConvertSingleItemArray(pDataIn2, numpyInType2, &m256Scalar2, convertType2);
 
-                  if (!bResult) return FALSE;
+                  if (!bResult) return false;
                   pDataIn2 = &m256Scalar2;
                   numpyInType2 = convertType2;
 
@@ -1987,7 +2047,7 @@ public:
                      PyObject* newarray1 = ConvertSafeInternal(inArr, convertType1);
                      if (!newarray1) {
                         // Failed to convert
-                        return FALSE;
+                        return false;
                      }
                      toDelete2 = newarray1;
                      FillArray1(newarray1);
@@ -1995,29 +2055,29 @@ public:
 
                }
                else {
-                  return FALSE;
+                  return false;
                }
 
             }
             else {
                LOGGING("BasicMath needs matching 1 dim x 1 dim array   %llu x %llu.  Will punt to numpy.\n", len1, len2);
                //PyErr_Format(PyExc_ValueError, "GenericAnyTwoFunc needs 1 dim x 1 dim array   %d x %d", len1, len2);
-               return FALSE;
+               return false;
             }
          } else {
             // Check if we need to upcast one or both of the arrays
             // bool, NPY_INT8, NPY_UINT8
-            if (!CheckUpcast()) return FALSE;
+            if (!CheckUpcast()) return false;
          }
 
       }
 
 
-      return TRUE;
+      return true;
    }
 
    //-----------------------------------------------------------------------
-   // returns NULL on failure
+   // returns nullptr on failure
    // will ALLOCATE or use an existing numpy array
    PyArrayObject* CheckOutputs(int wantOutType) {
 
@@ -2032,14 +2092,14 @@ public:
          if (!PyArray_Check(outputObject)) {
             LOGGING("BasicMath needs third argument to be an array\n");
             PyErr_Format(PyExc_ValueError, "BasicMath needs third argument to be an array");
-            return NULL;
+            return nullptr;
          }
 
          if (PyArray_TYPE((PyArrayObject*)outputObject) != wantOutType) {
             LOGGING("BasicMath does not match output type %d vs %d\n", PyArray_TYPE((PyArrayObject*)outputObject) ,wantOutType);
             //PyErr_Format(PyExc_ValueError, "BasicMath does not match output type %d vs %d", PyArray_TYPE((PyArrayObject*)outputObject), wantOutType);
             // NOTE: Now handled in FastArray where we will copy result back into array
-            outputObject= NULL;
+            outputObject= nullptr;
          }
          else {
 
@@ -2047,13 +2107,13 @@ public:
             LOGGING("oref %llu  len1:%lld  len2:%lld  len3: %lld\n", outputObject->ob_refcnt, len1, len2, len3);
             if (len3 < len2 || len3 < len1) {
                // something wrong with output size (gonna crash)
-               return NULL;
+               return nullptr;
             }
 
             if (PyArray_ITEMSIZE((PyArrayObject*)outputObject) != PyArray_STRIDE((PyArrayObject*)outputObject, 0)) {
                // output array is strided
                LOGGING("Punting because output array is strided\n");
-               return FALSE;
+               return nullptr;
             }
 
 
@@ -2074,33 +2134,33 @@ public:
          // a[1:] -= a[:-1]
          char* pOutput=PyArray_BYTES(returnObject);
          char* pOutputEnd = pOutput + ArrayLength(returnObject) * PyArray_ITEMSIZE(returnObject);
-         bool bOverlapProblem = FALSE;
+         bool bOverlapProblem = false;
 
          if (len1) {
             if (pDataIn1 > pOutput && pDataIn1 < pOutputEnd) {
                printf("!!!warning: inplace operation has memory overlap in beginning for input1\n");
-               bOverlapProblem = TRUE;
+               bOverlapProblem = true;
             }
             char* pTempEnd = (char*)pDataIn1 + (len1 * itemSize1);
             if (pTempEnd > pOutput && pTempEnd < pOutputEnd) {
                printf("!!!warning: inplace operation has memory overlap at end for input1\n");
-               bOverlapProblem = TRUE;
+               bOverlapProblem = true;
             }
          }
          if (len2) {
             if (pDataIn2 > pOutput && pDataIn2 < pOutputEnd) {
                printf("!!!warning: inplace operation has memory overlap in beginning for input2\n");
-               bOverlapProblem = TRUE;
+               bOverlapProblem = true;
             }
             char* pTempEnd = (char*)pDataIn2 + (len2 * itemSize2);
             if (pTempEnd > pOutput && pTempEnd < pOutputEnd) {
                printf("!!!warning: inplace operation has memory overlap at end for input2\n");
-               bOverlapProblem = TRUE;
+               bOverlapProblem = true;
             }
          }
 
          if (bOverlapProblem) {
-            return FALSE;
+            return nullptr;
          }
       }
       else {
@@ -2134,10 +2194,10 @@ public:
          CHECK_MEMORY_ERROR(returnObject);
       }
 
-      if (returnObject == NULL) {
+      if (returnObject == nullptr) {
          LOGGING("!!! BasicMath has no output\n");
          PyErr_Format(PyExc_ValueError, "BasicMath has no output (possibly out of memory)");
-         return NULL;
+         return nullptr;
       }
 
       LOGGING("Len1 %llu   len2  %llu  scalarmode:%d\n", len1, len2, scalarMode);
@@ -2169,28 +2229,28 @@ public:
    int            flags1 = NPY_ARRAY_F_CONTIGUOUS;
    int            flags2 = NPY_ARRAY_F_CONTIGUOUS;
 
-   void*          pDataIn1 = NULL;
-   void*          pDataIn2 = NULL;
+   void*          pDataIn1 = nullptr;
+   void*          pDataIn2 = nullptr;
 
    // PyTuple_GetItem will not increment the ref count
-   PyObject*      inObject1 = NULL;
-   PyObject*      inObject2 = NULL;
+   PyObject*      inObject1 = nullptr;
+   PyObject*      inObject2 = nullptr;
 
-   PyObject*      toDelete1 = NULL;
-   PyObject*      toDelete2 = NULL;
-   PyObject*      toDelete3 = NULL;
-   PyObject*      toDelete4 = NULL;
+   PyObject*      toDelete1 = nullptr;
+   PyObject*      toDelete2 = nullptr;
+   PyObject*      toDelete3 = nullptr;
+   PyObject*      toDelete4 = nullptr;
 
    // often the same as inObject1/2 
-   PyArrayObject *inArr = NULL;
-   PyArrayObject *inArr2 = NULL;
+   PyArrayObject *inArr = nullptr;
+   PyArrayObject *inArr2 = nullptr;
 
-   PyArrayObject* returnObject = NULL;
-   PyObject*      outputObject = NULL;
+   PyArrayObject* returnObject = nullptr;
+   PyObject*      outputObject = nullptr;
 
    int32_t          scalarMode = SCALAR_MODE::NO_SCALARS;
-   bool           isScalar1 = FALSE;
-   bool           isScalar2 = FALSE;
+   bool           isScalar1 = false;
+   bool           isScalar2 = false;
 
    Py_ssize_t     tupleSize = 0;
 
@@ -2210,7 +2270,7 @@ OLD_CALLBACK bmOldCallback;
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
 static bool BasicMathThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
-   bool didSomeWork = FALSE;
+   bool didSomeWork = false;
    OLD_CALLBACK* OldCallback = (OLD_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    int64_t typeSizeIn = OldCallback->FunctionList->InputItemSize;
@@ -2255,7 +2315,7 @@ static bool BasicMathThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, in
       }
 
       // Indicate we completed a block
-      didSomeWork = TRUE;
+      didSomeWork = true;
 
       // tell others we completed this work block
       pstWorkerItem->CompleteWorkBlock();
@@ -2275,7 +2335,7 @@ void WorkTwoStubCall(FUNCTION_LIST* anyTwoStubCall, void* pDataIn, void* pDataIn
    // Check if we can use worker threads
    stMATH_WORKER_ITEM* pWorkItem = g_cMathWorker->GetWorkItem(len);
 
-   if (pWorkItem == NULL) {
+   if (pWorkItem == nullptr) {
       // Threading not allowed for this work item, call it directly from main thread
       anyTwoStubCall->AnyTwoStubCall(pDataIn, pDataIn2, pDataOut, len, scalarMode);
       return;
@@ -2509,7 +2569,7 @@ PyObject* ConcatTwoUnicodes(
 
 //-------------------------------------------------------------
 // Called when adding two strings
-// May return NULL on failure, else new string array
+// May return nullptr on failure, else new string array
 static PyObject* PossiblyAddUnicode(CTwoInputs&  twoInputs) {
    int32_t inType = -1;
 
@@ -2549,7 +2609,7 @@ static PyObject* PossiblyAddUnicode(CTwoInputs&  twoInputs) {
             twoInputs.len1 >= twoInputs.len2 ? twoInputs.len1 : twoInputs.len2);
       }
    }
-   return NULL;
+   return nullptr;
 }
 
 //-----------------------------------------------------------------------------------
@@ -2572,14 +2632,14 @@ TwoInputsInternal(CTwoInputs&  twoInputs, int64_t funcNumber) {
    }
 
    // Now check if we can perform the function requested
-   ANY_TWO_FUNC pTwoFunc = NULL;
+   ANY_TWO_FUNC pTwoFunc = nullptr;
    int wantedOutputType = -1;
 
    pTwoFunc=
    CheckMathOpTwoInputs((int)funcNumber, twoInputs.scalarMode, twoInputs.numpyInType1, twoInputs.numpyInType2, twoInputs.numpyOutType, &wantedOutputType);
 
    // Place holder for output array
-   PyArrayObject* outputArray = NULL;
+   PyArrayObject* outputArray = nullptr;
 
    //if (pTwoFunc && wantedOutputType != -1 && twoInputs.numpyOutType == wantedOutputType) {
    //   printf("Wanted output type %d does not match %d\n", wantedOutputType, numpyOutputType);
@@ -2651,13 +2711,13 @@ TwoInputsInternal(CTwoInputs&  twoInputs, int64_t funcNumber) {
 // If NONE is returned, punt to numpy
 PyObject *
 BasicMathTwoInputs(PyObject *self, PyObject *args) {
-   PyObject* tuple = NULL;
+   PyObject* tuple = nullptr;
    int64_t funcNumber;
    int64_t numpyOutputType;
 
    if (Py_SIZE(args) != 3) {
       PyErr_Format(PyExc_ValueError, "BasicMathTwoInputs requires three inputs: tuple, long, long");
-      return NULL;
+      return nullptr;
    }
 
    tuple = PyTuple_GET_ITEM(args, 0);
@@ -2666,7 +2726,7 @@ BasicMathTwoInputs(PyObject *self, PyObject *args) {
 
    if (!PyTuple_CheckExact(tuple)) {
       PyErr_Format(PyExc_ValueError, "BasicMathTwoInputs arguments needs to be a tuple");
-      return NULL;
+      return nullptr;
    }
 
    // Examine data
@@ -2687,14 +2747,14 @@ BasicMathTwoInputs(PyObject *self, PyObject *args) {
 
 //-----------------------------------------------------------------------------------
 // Called internally when type class numbermethod called
-// inputOut can be NULL if there is no output array
+// inputOut can be nullptr if there is no output array
 PyObject *
 BasicMathTwoInputsFromNumber(PyObject* input1, PyObject* input2, PyObject* output, int64_t funcNumber) {
 
    CTwoInputs  twoInputs((int)0, (int)funcNumber);
 
    // Check the inputs to see if the user request makes sense
-   bool result = FALSE;
+   bool result = false;
    result = twoInputs.CheckInputs(input1, input2, output, funcNumber);
 
    if (result) {
@@ -2862,7 +2922,7 @@ bool WhereCallback(void* callbackArgT, int core, int64_t start, int64_t length) 
       }
    }
    
-   return TRUE;
+   return true;
 }
 
 //========================================================================
@@ -2927,7 +2987,7 @@ bool WhereCallbackString(void* callbackArgT, int core, int64_t start, int64_t le
    }
    break;
    }
-   return TRUE;
+   return true;
 }
 
 
@@ -2942,8 +3002,8 @@ bool WhereCallbackString(void* callbackArgT, int core, int64_t start, int64_t le
 //
 PyObject *
 Where(PyObject *self, PyObject *args) {
-   PyArrayObject *inBool1 = NULL;
-   PyObject* tuple = NULL;
+   PyArrayObject *inBool1 = nullptr;
+   PyObject* tuple = nullptr;
    int64_t numpyOutputType;
    int64_t numpyItemSize;
 
@@ -2954,17 +3014,17 @@ Where(PyObject *self, PyObject *args) {
       &numpyOutputType,
       &numpyItemSize)) {
 
-      return NULL;
+      return nullptr;
    }
 
    if (!PyTuple_CheckExact(tuple)) {
       PyErr_Format(PyExc_ValueError, "Where: second argument needs to be a tuple");
-      return NULL;
+      return nullptr;
    }
 
    if (PyArray_TYPE(inBool1) != 0) {
       PyErr_Format(PyExc_ValueError, "Where: first argument must be a boolean array");
-      return NULL;
+      return nullptr;
    }
 
    // Examine data
@@ -2977,7 +3037,7 @@ Where(PyObject *self, PyObject *args) {
    LOGGING("Where: Examining data for func types: %d %d\n", twoInputs.numpyInType1, twoInputs.numpyInType2);
 
    // Check the inputs to see if the user request makes sense
-   bool result = FALSE;
+   bool result = false;
 
    result = twoInputs.CheckInputs(tuple, 0, MATH_OPERATION::WHERE);
 
@@ -2986,7 +3046,7 @@ Where(PyObject *self, PyObject *args) {
       LOGGING("Where input: scalarmode: %d  in1:%d in2:%d  out:%d  length: %lld  itemsize: %lld\n", twoInputs.scalarMode, twoInputs.numpyInType1, twoInputs.numpyInType2, twoInputs.numpyOutType, length, numpyItemSize);
 
       // Place holder for output array
-      PyArrayObject* outputArray = NULL;
+      PyArrayObject* outputArray = nullptr;
 
       outputArray =
          AllocateNumpyArray(1, (npy_intp*)&length, (int)numpyOutputType, numpyItemSize);
@@ -3003,8 +3063,8 @@ Where(PyObject *self, PyObject *args) {
          char* pInput1 = (char*)twoInputs.pDataIn1;
          char* pInput2 = (char*)twoInputs.pDataIn2;
 
-         char* extraAlloc1 = NULL;
-         char* extraAlloc2 = NULL;
+         char* extraAlloc1 = nullptr;
+         char* extraAlloc2 = nullptr;
 
          // If we have scalar strings, we must make sure the length is the same
          if (numpyOutputType == NPY_STRING || numpyOutputType == NPY_UNICODE) {
@@ -3068,14 +3128,14 @@ Where(PyObject *self, PyObject *args) {
          if (extraAlloc1) {
             free(extraAlloc1);
          }
-         if (extraAlloc2 == NULL) {
+         if (extraAlloc2 == nullptr) {
             free(extraAlloc2);
          }
          return (PyObject*)outputArray;
       }
 
       PyErr_Format(PyExc_ValueError, "Where could not allocate a numpy array");
-      return NULL;
+      return nullptr;
 
    }
 

--- a/src/BasicMath.cpp
+++ b/src/BasicMath.cpp
@@ -856,7 +856,7 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpFastSymmetric<float, __m256, AddOp<float>, ADD_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFastSymmetric<double, __m256d, AddOp<double>, ADD_OP_256f64>;
          // proof of concept for i32 addition loop
-      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AddOp<int32_t>, ADD_OP_256i32>;
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AddOp<int32_t>, ADD_OP_256i32>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpFastSymmetric<int64_t, __m256i, AddOp<int64_t>, ADD_OP_256i64>;
@@ -872,13 +872,13 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, AndOp<int8_t>, AND_OP_256>;
       case NPY_FLOAT:  return SimpleMathOpFastSymmetric<float, __m256, MulOp<float>, MUL_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFastSymmetric<double, __m256d, MulOp<double>, MUL_OP_256f64>;
-      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MulOp<int32_t>, MUL_OP_256i32>;
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MulOp<int32_t>, MUL_OP_256i32>;
 
       //case NPY_INT64:  case NPY_LONGLONG: return SimpleMathOpFast<int64_t, __m256i, MulOp<int64_t>, MUL_OP_256i64>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MulOp<int16_t>, MUL_OP_256i16>;
 
       // Below the intrinsic to multiply is slower so we disabled it (really wants 32bit -> 64bit)
-      //case NPY_UINT:  return SimpleMathOpFastMul<uint32_t, __m256i>;
+      //case NPY_UINT32:  return SimpleMathOpFastMul<uint32_t, __m256i>;
       // TODO: 64bit multiply can be done with algo..
       // lo1 * lo2 + (lo1 * hi2) << 32 + (hi1 *lo2) << 32)
       case NPY_UINT64:
@@ -893,7 +893,7 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (*wantedOutType) {
       case NPY_FLOAT:  return SimpleMathOpFast<float, __m256, SubOp<float>, SUB_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFast<double, __m256d, SubOp<double>, SUB_OP_256f64>;
-      case NPY_INT:  return SimpleMathOpFast<int32_t, __m256i, SubOp<int32_t>, SUB_OP_256i32>;
+      case NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, SubOp<int32_t>, SUB_OP_256i32>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpFast<int64_t, __m256i, SubOp<int64_t>, SUB_OP_256i64>;
@@ -911,10 +911,10 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       // TODO: Vector routine needs to be written
       case NPY_FLOAT:  return SimpleMathOpSlowMin<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMin<double>;
-      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MinOp<int32_t>, MIN_OPi32>;
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MinOp<int32_t>, MIN_OPi32>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MinOp<int16_t>, MIN_OPi16>;
       case NPY_INT8:   return SimpleMathOpFastSymmetric<int8_t, __m256i, MinOp<int8_t>, MIN_OPi8>;
-      case NPY_UINT:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MinOp<uint32_t>, MIN_OPu32>;
+      case NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MinOp<uint32_t>, MIN_OPu32>;
       case NPY_UINT16:  return SimpleMathOpFastSymmetric<uint16_t, __m256i, MinOp<uint16_t>, MIN_OPu16>;
       case NPY_UINT8:   return SimpleMathOpFastSymmetric<uint8_t, __m256i, MinOp<uint8_t>, MIN_OPu8>;
       }
@@ -928,10 +928,10 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       // TODO: Vector routine needs to be written
       case NPY_FLOAT:  return SimpleMathOpSlowMax<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMax<double>;
-      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MaxOp<int32_t>, MAX_OPi32>;
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MaxOp<int32_t>, MAX_OPi32>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MaxOp<int16_t>, MAX_OPi16>;
       case NPY_INT8:   return SimpleMathOpFastSymmetric<int8_t, __m256i, MaxOp<int8_t>, MAX_OPi8>;
-      case NPY_UINT:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MaxOp<uint32_t>, MAX_OPu32>;
+      case NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MaxOp<uint32_t>, MAX_OPu32>;
       case NPY_UINT16:  return SimpleMathOpFastSymmetric<uint16_t, __m256i, MaxOp<uint16_t>, MAX_OPu16>;
       case NPY_UINT8:   return SimpleMathOpFastSymmetric<uint8_t, __m256i, MaxOp<uint8_t>, MAX_OPu8>;
       }
@@ -949,7 +949,7 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
       case NPY_FLOAT:  return SimpleMathOpFast<float, __m256, DivOp<float>, DIV_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFast<double, __m256d, DivOp<double>, DIV_OP_256f64>;
-      case NPY_INT:  return SimpleMathOpFastDivDouble<int32_t, __m128i, __m256d>;
+      case NPY_INT32:  return SimpleMathOpFastDivDouble<int32_t, __m128i, __m256d>;
       }
       return nullptr;
 
@@ -970,8 +970,8 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, AndOp<int8_t>, AND_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, AndOp<int16_t>, AND_OP_256>;
-      case NPY_UINT:
-      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AndOp<int32_t>, AND_OP_256>;
+      case NPY_UINT32:
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AndOp<int32_t>, AND_OP_256>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
       case NPY_INT64:
@@ -997,8 +997,8 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, OrOp<int8_t>, OR_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, OrOp<int16_t>, OR_OP_256>;
-      case NPY_UINT:
-      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, OrOp<int32_t>, OR_OP_256>;
+      case NPY_UINT32:
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, OrOp<int32_t>, OR_OP_256>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
       case NPY_INT64:
@@ -1016,8 +1016,8 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, XorOp<int8_t>, XOR_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, XorOp<int16_t>, XOR_OP_256>;
-      case NPY_UINT:
-      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
+      case NPY_UINT32:
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
       case NPY_INT64:
@@ -1036,8 +1036,8 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, XorOp<int8_t>, XOR_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, XorOp<int16_t>, XOR_OP_256>;
-      case NPY_UINT:
-      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
+      case NPY_UINT32:
+      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
       case NPY_INT64:
@@ -1055,8 +1055,8 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastReverse<int8_t, __m256i, AndNotOp<int8_t>, ANDNOT_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastReverse<int16_t, __m256i, AndNotOp<int16_t>, ANDNOT_OP_256>;
-      case NPY_UINT:
-      case NPY_INT:  return SimpleMathOpFastReverse<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
+      case NPY_UINT32:
+      case NPY_INT32:  return SimpleMathOpFastReverse<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
       case NPY_INT64:
@@ -1074,8 +1074,8 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFast<int8_t, __m256i, AndNotOp<int8_t>, ANDNOT_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFast<int16_t, __m256i, AndNotOp<int16_t>, ANDNOT_OP_256>;
-      case NPY_UINT:
-      case NPY_INT:  return SimpleMathOpFast<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
+      case NPY_UINT32:
+      case NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
       case NPY_INT64:
@@ -1102,11 +1102,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowAdd<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowAdd<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowAdd<long double>;
-      case NPY_INT:  return SimpleMathOpSlowAdd<int32_t>;
+      case NPY_INT32:  return SimpleMathOpSlowAdd<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowAdd<int64_t>;
-      case NPY_UINT:
+      case NPY_UINT32:
          return SimpleMathOpSlowAdd<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
@@ -1137,11 +1137,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowSub<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowSub<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowSub<long double>;
-      case NPY_INT:  return SimpleMathOpSlowSub<int32_t>;
+      case NPY_INT32:  return SimpleMathOpSlowSub<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowSub<int64_t>;
-      case NPY_UINT: return SimpleMathOpSlowSub<uint32_t>;
+      case NPY_UINT32: return SimpleMathOpSlowSub<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return SimpleMathOpSlowSub<uint64_t>;
@@ -1162,11 +1162,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowMul<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMul<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowMul<long double>;
-      case NPY_INT:  return SimpleMathOpSlowMul<int32_t>;
+      case NPY_INT32:  return SimpleMathOpSlowMul<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowMul<int64_t>;
-      case NPY_UINT: return SimpleMathOpSlowMul<uint32_t>;
+      case NPY_UINT32: return SimpleMathOpSlowMul<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return SimpleMathOpSlowMul<uint64_t>;
@@ -1192,11 +1192,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowDivFloat<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowDiv<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowDiv<long double>;
-      case NPY_INT:  return SimpleMathOpSlowDiv<int32_t>;
+      case NPY_INT32:  return SimpleMathOpSlowDiv<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowDiv<int64_t>;
-      case NPY_UINT: return SimpleMathOpSlowDiv<uint32_t>;
+      case NPY_UINT32: return SimpleMathOpSlowDiv<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return SimpleMathOpSlowDiv<uint64_t>;
@@ -1211,7 +1211,7 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
    case MATH_OPERATION::SUBDATETIMES:
       *wantedOutType = NPY_DOUBLE;
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
-      case NPY_INT:  return SimpleMathOpSubDateTime<int32_t>;
+      case NPY_INT32:  return SimpleMathOpSubDateTime<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSubDateTime<int64_t>;
@@ -1220,9 +1220,9 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       return nullptr;
 
    case MATH_OPERATION::SUBDATES:
-      *wantedOutType = NPY_INT;
+      *wantedOutType = NPY_INT32;
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
-      case NPY_INT:  return SimpleMathOpSubDates<int32_t>;
+      case NPY_INT32:  return SimpleMathOpSubDates<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutType = NPY_INT64;
@@ -1240,11 +1240,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowFloorDiv<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowFloorDiv<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowFloorDiv<long double>;
-      case NPY_INT:  return SimpleMathOpSlowFloorDiv<int32_t>;
+      case NPY_INT32:  return SimpleMathOpSlowFloorDiv<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowFloorDiv<int64_t>;
-      case NPY_UINT: return SimpleMathOpSlowFloorDiv<uint32_t>;
+      case NPY_UINT32: return SimpleMathOpSlowFloorDiv<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return SimpleMathOpSlowFloorDiv<uint64_t>;
@@ -1266,11 +1266,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowRemainder<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowRemainder<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowRemainder<long double>;
-      case NPY_INT:  return SimpleMathOpSlowMod<int32_t>;
+      case NPY_INT32:  return SimpleMathOpSlowMod<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowMod<int64_t>;
-      case NPY_UINT: return SimpleMathOpSlowMod<uint32_t>;
+      case NPY_UINT32: return SimpleMathOpSlowMod<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return SimpleMathOpSlowMod<uint64_t>;
@@ -1290,11 +1290,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowPower<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowPower<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowPower<long double>;
-      case NPY_INT:  return SimpleMathOpSlowPower<int32_t>;
+      case NPY_INT32:  return SimpleMathOpSlowPower<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowPower<int64_t>;
-      case NPY_UINT: return SimpleMathOpSlowPower<uint32_t>;
+      case NPY_UINT32: return SimpleMathOpSlowPower<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return SimpleMathOpSlowPower<uint64_t>;
@@ -1340,10 +1340,10 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
 // TODO: Replace with call to our FixupDtype() function?
 static int GetNonAmbiguousDtype(int dtype) {
    switch (dtype) {
-   case NPY_INT:
+   case NPY_INT32:
       dtype = 5;
       break;
-   case NPY_UINT:
+   case NPY_UINT32:
       dtype = 6;
       break;
    case NPY_INT64:
@@ -1447,8 +1447,8 @@ static ANY_TWO_FUNC CheckMathOpTwoInputs(int func, int scalarMode, int numpyInTy
 static int g_signed_table[65] = {
    NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,
    NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16,
-   NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT,
-   NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT,
+   NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32,
+   NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32,
    NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
    NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
    NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
@@ -1460,9 +1460,9 @@ static int g_signed_table[65] = {
 static int g_mixedsign_table[65] = {
    NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,
    NPY_UINT8, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16,
-   NPY_UINT16,NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT,
-   NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT,
-   NPY_UINT,NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
+   NPY_UINT16,NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32,
+   NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32,
+   NPY_UINT32,NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
    NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
    NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
    NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, 
@@ -1471,9 +1471,9 @@ static int g_mixedsign_table[65] = {
 static int g_bothunsigned_table[65] = {
    NPY_UINT8,  NPY_UINT8,  NPY_UINT8,  NPY_UINT8,  NPY_UINT8,  NPY_UINT8,  NPY_UINT8,  NPY_UINT8,
    NPY_UINT8,  NPY_UINT16, NPY_UINT16, NPY_UINT16, NPY_UINT16, NPY_UINT16, NPY_UINT16, NPY_UINT16,
-   NPY_UINT16, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT,
-   NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT,
-   NPY_UINT, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64,
+   NPY_UINT16, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32,
+   NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32,
+   NPY_UINT32, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64,
    NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64,
    NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64,
    NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, 

--- a/src/BasicMath.cpp
+++ b/src/BasicMath.cpp
@@ -856,7 +856,7 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpFastSymmetric<float, __m256, AddOp<float>, ADD_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFastSymmetric<double, __m256d, AddOp<double>, ADD_OP_256f64>;
          // proof of concept for i32 addition loop
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AddOp<int32_t>, ADD_OP_256i32>;
+      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AddOp<int32_t>, ADD_OP_256i32>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpFastSymmetric<int64_t, __m256i, AddOp<int64_t>, ADD_OP_256i64>;
@@ -872,13 +872,13 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, AndOp<int8_t>, AND_OP_256>;
       case NPY_FLOAT:  return SimpleMathOpFastSymmetric<float, __m256, MulOp<float>, MUL_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFastSymmetric<double, __m256d, MulOp<double>, MUL_OP_256f64>;
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MulOp<int32_t>, MUL_OP_256i32>;
+      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MulOp<int32_t>, MUL_OP_256i32>;
 
       //case NPY_INT64:  case NPY_LONGLONG: return SimpleMathOpFast<int64_t, __m256i, MulOp<int64_t>, MUL_OP_256i64>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MulOp<int16_t>, MUL_OP_256i16>;
 
       // Below the intrinsic to multiply is slower so we disabled it (really wants 32bit -> 64bit)
-      //case NPY_UINT32:  return SimpleMathOpFastMul<uint32_t, __m256i>;
+      //case NPY_UINT:  return SimpleMathOpFastMul<uint32_t, __m256i>;
       // TODO: 64bit multiply can be done with algo..
       // lo1 * lo2 + (lo1 * hi2) << 32 + (hi1 *lo2) << 32)
       case NPY_UINT64:
@@ -893,7 +893,7 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (*wantedOutType) {
       case NPY_FLOAT:  return SimpleMathOpFast<float, __m256, SubOp<float>, SUB_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFast<double, __m256d, SubOp<double>, SUB_OP_256f64>;
-      case NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, SubOp<int32_t>, SUB_OP_256i32>;
+      case NPY_INT:  return SimpleMathOpFast<int32_t, __m256i, SubOp<int32_t>, SUB_OP_256i32>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpFast<int64_t, __m256i, SubOp<int64_t>, SUB_OP_256i64>;
@@ -911,10 +911,10 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       // TODO: Vector routine needs to be written
       case NPY_FLOAT:  return SimpleMathOpSlowMin<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMin<double>;
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MinOp<int32_t>, MIN_OPi32>;
+      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MinOp<int32_t>, MIN_OPi32>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MinOp<int16_t>, MIN_OPi16>;
       case NPY_INT8:   return SimpleMathOpFastSymmetric<int8_t, __m256i, MinOp<int8_t>, MIN_OPi8>;
-      case NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MinOp<uint32_t>, MIN_OPu32>;
+      case NPY_UINT:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MinOp<uint32_t>, MIN_OPu32>;
       case NPY_UINT16:  return SimpleMathOpFastSymmetric<uint16_t, __m256i, MinOp<uint16_t>, MIN_OPu16>;
       case NPY_UINT8:   return SimpleMathOpFastSymmetric<uint8_t, __m256i, MinOp<uint8_t>, MIN_OPu8>;
       }
@@ -928,10 +928,10 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       // TODO: Vector routine needs to be written
       case NPY_FLOAT:  return SimpleMathOpSlowMax<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMax<double>;
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MaxOp<int32_t>, MAX_OPi32>;
+      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MaxOp<int32_t>, MAX_OPi32>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MaxOp<int16_t>, MAX_OPi16>;
       case NPY_INT8:   return SimpleMathOpFastSymmetric<int8_t, __m256i, MaxOp<int8_t>, MAX_OPi8>;
-      case NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MaxOp<uint32_t>, MAX_OPu32>;
+      case NPY_UINT:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MaxOp<uint32_t>, MAX_OPu32>;
       case NPY_UINT16:  return SimpleMathOpFastSymmetric<uint16_t, __m256i, MaxOp<uint16_t>, MAX_OPu16>;
       case NPY_UINT8:   return SimpleMathOpFastSymmetric<uint8_t, __m256i, MaxOp<uint8_t>, MAX_OPu8>;
       }
@@ -949,7 +949,7 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
       case NPY_FLOAT:  return SimpleMathOpFast<float, __m256, DivOp<float>, DIV_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFast<double, __m256d, DivOp<double>, DIV_OP_256f64>;
-      case NPY_INT32:  return SimpleMathOpFastDivDouble<int32_t, __m128i, __m256d>;
+      case NPY_INT:  return SimpleMathOpFastDivDouble<int32_t, __m128i, __m256d>;
       }
       return nullptr;
 
@@ -970,8 +970,8 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, AndOp<int8_t>, AND_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, AndOp<int16_t>, AND_OP_256>;
-      case NPY_UINT32:
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AndOp<int32_t>, AND_OP_256>;
+      case NPY_UINT:
+      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AndOp<int32_t>, AND_OP_256>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
       case NPY_INT64:
@@ -997,8 +997,8 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, OrOp<int8_t>, OR_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, OrOp<int16_t>, OR_OP_256>;
-      case NPY_UINT32:
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, OrOp<int32_t>, OR_OP_256>;
+      case NPY_UINT:
+      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, OrOp<int32_t>, OR_OP_256>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
       case NPY_INT64:
@@ -1016,8 +1016,8 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, XorOp<int8_t>, XOR_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, XorOp<int16_t>, XOR_OP_256>;
-      case NPY_UINT32:
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
+      case NPY_UINT:
+      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
       case NPY_INT64:
@@ -1036,8 +1036,8 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, XorOp<int8_t>, XOR_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, XorOp<int16_t>, XOR_OP_256>;
-      case NPY_UINT32:
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
+      case NPY_UINT:
+      case NPY_INT:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
       case NPY_INT64:
@@ -1055,8 +1055,8 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastReverse<int8_t, __m256i, AndNotOp<int8_t>, ANDNOT_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastReverse<int16_t, __m256i, AndNotOp<int16_t>, ANDNOT_OP_256>;
-      case NPY_UINT32:
-      case NPY_INT32:  return SimpleMathOpFastReverse<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
+      case NPY_UINT:
+      case NPY_INT:  return SimpleMathOpFastReverse<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
       case NPY_INT64:
@@ -1074,8 +1074,8 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFast<int8_t, __m256i, AndNotOp<int8_t>, ANDNOT_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFast<int16_t, __m256i, AndNotOp<int16_t>, ANDNOT_OP_256>;
-      case NPY_UINT32:
-      case NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
+      case NPY_UINT:
+      case NPY_INT:  return SimpleMathOpFast<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
       case NPY_INT64:
@@ -1102,11 +1102,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowAdd<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowAdd<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowAdd<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowAdd<int32_t>;
+      case NPY_INT:  return SimpleMathOpSlowAdd<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowAdd<int64_t>;
-      case NPY_UINT32:
+      case NPY_UINT:
          return SimpleMathOpSlowAdd<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
@@ -1137,11 +1137,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowSub<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowSub<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowSub<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowSub<int32_t>;
+      case NPY_INT:  return SimpleMathOpSlowSub<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowSub<int64_t>;
-      case NPY_UINT32: return SimpleMathOpSlowSub<uint32_t>;
+      case NPY_UINT: return SimpleMathOpSlowSub<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return SimpleMathOpSlowSub<uint64_t>;
@@ -1162,11 +1162,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowMul<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMul<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowMul<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowMul<int32_t>;
+      case NPY_INT:  return SimpleMathOpSlowMul<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowMul<int64_t>;
-      case NPY_UINT32: return SimpleMathOpSlowMul<uint32_t>;
+      case NPY_UINT: return SimpleMathOpSlowMul<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return SimpleMathOpSlowMul<uint64_t>;
@@ -1192,11 +1192,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowDivFloat<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowDiv<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowDiv<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowDiv<int32_t>;
+      case NPY_INT:  return SimpleMathOpSlowDiv<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowDiv<int64_t>;
-      case NPY_UINT32: return SimpleMathOpSlowDiv<uint32_t>;
+      case NPY_UINT: return SimpleMathOpSlowDiv<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return SimpleMathOpSlowDiv<uint64_t>;
@@ -1211,7 +1211,7 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
    case MATH_OPERATION::SUBDATETIMES:
       *wantedOutType = NPY_DOUBLE;
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
-      case NPY_INT32:  return SimpleMathOpSubDateTime<int32_t>;
+      case NPY_INT:  return SimpleMathOpSubDateTime<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSubDateTime<int64_t>;
@@ -1220,9 +1220,9 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       return nullptr;
 
    case MATH_OPERATION::SUBDATES:
-      *wantedOutType = NPY_INT32;
+      *wantedOutType = NPY_INT;
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
-      case NPY_INT32:  return SimpleMathOpSubDates<int32_t>;
+      case NPY_INT:  return SimpleMathOpSubDates<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutType = NPY_INT64;
@@ -1240,11 +1240,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowFloorDiv<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowFloorDiv<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowFloorDiv<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowFloorDiv<int32_t>;
+      case NPY_INT:  return SimpleMathOpSlowFloorDiv<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowFloorDiv<int64_t>;
-      case NPY_UINT32: return SimpleMathOpSlowFloorDiv<uint32_t>;
+      case NPY_UINT: return SimpleMathOpSlowFloorDiv<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return SimpleMathOpSlowFloorDiv<uint64_t>;
@@ -1266,11 +1266,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowRemainder<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowRemainder<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowRemainder<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowMod<int32_t>;
+      case NPY_INT:  return SimpleMathOpSlowMod<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowMod<int64_t>;
-      case NPY_UINT32: return SimpleMathOpSlowMod<uint32_t>;
+      case NPY_UINT: return SimpleMathOpSlowMod<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return SimpleMathOpSlowMod<uint64_t>;
@@ -1290,11 +1290,11 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowPower<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowPower<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowPower<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowPower<int32_t>;
+      case NPY_INT:  return SimpleMathOpSlowPower<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return SimpleMathOpSlowPower<int64_t>;
-      case NPY_UINT32: return SimpleMathOpSlowPower<uint32_t>;
+      case NPY_UINT: return SimpleMathOpSlowPower<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return SimpleMathOpSlowPower<uint64_t>;
@@ -1340,10 +1340,10 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
 // TODO: Replace with call to our FixupDtype() function?
 static int GetNonAmbiguousDtype(int dtype) {
    switch (dtype) {
-   case NPY_INT32:
+   case NPY_INT:
       dtype = 5;
       break;
-   case NPY_UINT32:
+   case NPY_UINT:
       dtype = 6;
       break;
    case NPY_INT64:
@@ -1447,8 +1447,8 @@ static ANY_TWO_FUNC CheckMathOpTwoInputs(int func, int scalarMode, int numpyInTy
 static int g_signed_table[65] = {
    NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,
    NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16,
-   NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32,
-   NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32,
+   NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT,
+   NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT,
    NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
    NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
    NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
@@ -1460,9 +1460,9 @@ static int g_signed_table[65] = {
 static int g_mixedsign_table[65] = {
    NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,  NPY_INT8,
    NPY_UINT8, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16, NPY_INT16,
-   NPY_UINT16,NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32,
-   NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32, NPY_INT32,
-   NPY_UINT32,NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
+   NPY_UINT16,NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT,
+   NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT, NPY_INT,
+   NPY_UINT,NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
    NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
    NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64,
    NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, NPY_INT64, 
@@ -1471,9 +1471,9 @@ static int g_mixedsign_table[65] = {
 static int g_bothunsigned_table[65] = {
    NPY_UINT8,  NPY_UINT8,  NPY_UINT8,  NPY_UINT8,  NPY_UINT8,  NPY_UINT8,  NPY_UINT8,  NPY_UINT8,
    NPY_UINT8,  NPY_UINT16, NPY_UINT16, NPY_UINT16, NPY_UINT16, NPY_UINT16, NPY_UINT16, NPY_UINT16,
-   NPY_UINT16, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32,
-   NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32, NPY_UINT32,
-   NPY_UINT32, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64,
+   NPY_UINT16, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT,
+   NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT, NPY_UINT,
+   NPY_UINT, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64,
    NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64,
    NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64,
    NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, NPY_UINT64, 

--- a/src/BasicMath.cpp
+++ b/src/BasicMath.cpp
@@ -856,9 +856,9 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpFastSymmetric<float, __m256, AddOp<float>, ADD_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFastSymmetric<double, __m256d, AddOp<double>, ADD_OP_256f64>;
          // proof of concept for i32 addition loop
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AddOp<int32_t>, ADD_OP_256i32>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AddOp<int32_t>, ADD_OP_256i32>;
+      CASE_NPY_INT64:
+      
          return SimpleMathOpFastSymmetric<int64_t, __m256i, AddOp<int64_t>, ADD_OP_256i64>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, AddOp<int16_t>, ADD_OP_256i16>;
       case NPY_INT8:   return SimpleMathOpFastSymmetric<int8_t,  __m256i, AddOp<int8_t>, ADD_OP_256i8>;
@@ -872,17 +872,17 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, AndOp<int8_t>, AND_OP_256>;
       case NPY_FLOAT:  return SimpleMathOpFastSymmetric<float, __m256, MulOp<float>, MUL_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFastSymmetric<double, __m256d, MulOp<double>, MUL_OP_256f64>;
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MulOp<int32_t>, MUL_OP_256i32>;
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MulOp<int32_t>, MUL_OP_256i32>;
 
-      //case NPY_INT64:  case NPY_LONGLONG: return SimpleMathOpFast<int64_t, __m256i, MulOp<int64_t>, MUL_OP_256i64>;
+      //CASE_NPY_INT64:   return SimpleMathOpFast<int64_t, __m256i, MulOp<int64_t>, MUL_OP_256i64>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MulOp<int16_t>, MUL_OP_256i16>;
 
       // Below the intrinsic to multiply is slower so we disabled it (really wants 32bit -> 64bit)
-      //case NPY_UINT32:  return SimpleMathOpFastMul<uint32_t, __m256i>;
+      //CASE_NPY_UINT32:  return SimpleMathOpFastMul<uint32_t, __m256i>;
       // TODO: 64bit multiply can be done with algo..
       // lo1 * lo2 + (lo1 * hi2) << 32 + (hi1 *lo2) << 32)
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT64:
+      
          return SimpleMathOpFastSymmetric<uint64_t, __m256i, MulOp<uint64_t>, MUL_OP_256u64>;
       }
       return nullptr;
@@ -893,9 +893,9 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (*wantedOutType) {
       case NPY_FLOAT:  return SimpleMathOpFast<float, __m256, SubOp<float>, SUB_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFast<double, __m256d, SubOp<double>, SUB_OP_256f64>;
-      case NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, SubOp<int32_t>, SUB_OP_256i32>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, SubOp<int32_t>, SUB_OP_256i32>;
+      CASE_NPY_INT64:
+      
          return SimpleMathOpFast<int64_t, __m256i, SubOp<int64_t>, SUB_OP_256i64>;
       case NPY_INT16:  return SimpleMathOpFast<int16_t, __m256i, SubOp<int16_t>, SUB_OP_256i16>;
       case NPY_INT8:   return SimpleMathOpFast<int8_t,  __m256i, SubOp<int8_t>,  SUB_OP_256i8>;
@@ -911,10 +911,10 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       // TODO: Vector routine needs to be written
       case NPY_FLOAT:  return SimpleMathOpSlowMin<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMin<double>;
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MinOp<int32_t>, MIN_OPi32>;
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MinOp<int32_t>, MIN_OPi32>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MinOp<int16_t>, MIN_OPi16>;
       case NPY_INT8:   return SimpleMathOpFastSymmetric<int8_t, __m256i, MinOp<int8_t>, MIN_OPi8>;
-      case NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MinOp<uint32_t>, MIN_OPu32>;
+      CASE_NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MinOp<uint32_t>, MIN_OPu32>;
       case NPY_UINT16:  return SimpleMathOpFastSymmetric<uint16_t, __m256i, MinOp<uint16_t>, MIN_OPu16>;
       case NPY_UINT8:   return SimpleMathOpFastSymmetric<uint8_t, __m256i, MinOp<uint8_t>, MIN_OPu8>;
       }
@@ -928,10 +928,10 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       // TODO: Vector routine needs to be written
       case NPY_FLOAT:  return SimpleMathOpSlowMax<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMax<double>;
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MaxOp<int32_t>, MAX_OPi32>;
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MaxOp<int32_t>, MAX_OPi32>;
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MaxOp<int16_t>, MAX_OPi16>;
       case NPY_INT8:   return SimpleMathOpFastSymmetric<int8_t, __m256i, MaxOp<int8_t>, MAX_OPi8>;
-      case NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MaxOp<uint32_t>, MAX_OPu32>;
+      CASE_NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MaxOp<uint32_t>, MAX_OPu32>;
       case NPY_UINT16:  return SimpleMathOpFastSymmetric<uint16_t, __m256i, MaxOp<uint16_t>, MAX_OPu16>;
       case NPY_UINT8:   return SimpleMathOpFastSymmetric<uint8_t, __m256i, MaxOp<uint8_t>, MAX_OPu8>;
       }
@@ -949,7 +949,7 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
       case NPY_FLOAT:  return SimpleMathOpFast<float, __m256, DivOp<float>, DIV_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFast<double, __m256d, DivOp<double>, DIV_OP_256f64>;
-      case NPY_INT32:  return SimpleMathOpFastDivDouble<int32_t, __m128i, __m256d>;
+      CASE_NPY_INT32:  return SimpleMathOpFastDivDouble<int32_t, __m128i, __m256d>;
       }
       return nullptr;
 
@@ -970,12 +970,12 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, AndOp<int8_t>, AND_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, AndOp<int16_t>, AND_OP_256>;
-      case NPY_UINT32:
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AndOp<int32_t>, AND_OP_256>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_UINT32:
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AndOp<int32_t>, AND_OP_256>;
+      CASE_NPY_UINT64:
+      
+      CASE_NPY_INT64:
+      
          return SimpleMathOpFastSymmetric<int64_t, __m256i, AndOp<int64_t>, AND_OP_256>;
       }
       return nullptr;
@@ -997,12 +997,12 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, OrOp<int8_t>, OR_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, OrOp<int16_t>, OR_OP_256>;
-      case NPY_UINT32:
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, OrOp<int32_t>, OR_OP_256>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_UINT32:
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, OrOp<int32_t>, OR_OP_256>;
+      CASE_NPY_UINT64:
+      
+      CASE_NPY_INT64:
+      
          return SimpleMathOpFastSymmetric<int64_t, __m256i, OrOp<int64_t>, OR_OP_256>;
       }
       return nullptr;
@@ -1016,12 +1016,12 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, XorOp<int8_t>, XOR_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, XorOp<int16_t>, XOR_OP_256>;
-      case NPY_UINT32:
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_UINT32:
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
+      CASE_NPY_UINT64:
+      
+      CASE_NPY_INT64:
+      
          return SimpleMathOpFastSymmetric<int64_t, __m256i, XorOp<int64_t>, XOR_OP_256>;
       }
       return nullptr;
@@ -1036,12 +1036,12 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, XorOp<int8_t>, XOR_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, XorOp<int16_t>, XOR_OP_256>;
-      case NPY_UINT32:
-      case NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_UINT32:
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
+      CASE_NPY_UINT64:
+      
+      CASE_NPY_INT64:
+      
          return SimpleMathOpFastSymmetric<int64_t, __m256i, XorOp<int64_t>, XOR_OP_256>;
       }
       return nullptr;
@@ -1055,12 +1055,12 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFastReverse<int8_t, __m256i, AndNotOp<int8_t>, ANDNOT_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFastReverse<int16_t, __m256i, AndNotOp<int16_t>, ANDNOT_OP_256>;
-      case NPY_UINT32:
-      case NPY_INT32:  return SimpleMathOpFastReverse<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_UINT32:
+      CASE_NPY_INT32:  return SimpleMathOpFastReverse<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
+      CASE_NPY_UINT64:
+      
+      CASE_NPY_INT64:
+      
          return SimpleMathOpFastReverse<int64_t, __m256i, AndNotOp<int64_t>, ANDNOT_OP_256>;
       }
       return nullptr;
@@ -1074,12 +1074,12 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       case NPY_BOOL:   return SimpleMathOpFast<int8_t, __m256i, AndNotOp<int8_t>, ANDNOT_OP_256>;
       case NPY_UINT16:
       case NPY_INT16:  return SimpleMathOpFast<int16_t, __m256i, AndNotOp<int16_t>, ANDNOT_OP_256>;
-      case NPY_UINT32:
-      case NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_UINT32:
+      CASE_NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
+      CASE_NPY_UINT64:
+      
+      CASE_NPY_INT64:
+      
          return SimpleMathOpFast<int64_t, __m256i, AndNotOp<int64_t>, ANDNOT_OP_256>;
       }
       return nullptr;
@@ -1102,14 +1102,14 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowAdd<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowAdd<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowAdd<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowAdd<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return SimpleMathOpSlowAdd<int32_t>;
+      CASE_NPY_INT64:
+      
          return SimpleMathOpSlowAdd<int64_t>;
-      case NPY_UINT32:
+      CASE_NPY_UINT32:
          return SimpleMathOpSlowAdd<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT64:
+      
          return SimpleMathOpSlowAdd<uint64_t>;
       case NPY_INT8:   return SimpleMathOpSlowAdd<int8_t>;
       case NPY_INT16:  return SimpleMathOpSlowAdd<int16_t>;
@@ -1137,13 +1137,13 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowSub<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowSub<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowSub<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowSub<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return SimpleMathOpSlowSub<int32_t>;
+      CASE_NPY_INT64:
+      
          return SimpleMathOpSlowSub<int64_t>;
-      case NPY_UINT32: return SimpleMathOpSlowSub<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return SimpleMathOpSlowSub<uint32_t>;
+      CASE_NPY_UINT64:
+      
          return SimpleMathOpSlowSub<uint64_t>;
       case NPY_INT8:   return SimpleMathOpSlowSub<int8_t>;
       case NPY_INT16:  return SimpleMathOpSlowSub<int16_t>;
@@ -1162,13 +1162,13 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowMul<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMul<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowMul<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowMul<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return SimpleMathOpSlowMul<int32_t>;
+      CASE_NPY_INT64:
+      
          return SimpleMathOpSlowMul<int64_t>;
-      case NPY_UINT32: return SimpleMathOpSlowMul<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return SimpleMathOpSlowMul<uint32_t>;
+      CASE_NPY_UINT64:
+      
          return SimpleMathOpSlowMul<uint64_t>;
       case NPY_INT8:   return SimpleMathOpSlowMul<int8_t>;
       case NPY_INT16:  return SimpleMathOpSlowMul<int16_t>;
@@ -1192,13 +1192,13 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowDivFloat<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowDiv<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowDiv<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowDiv<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return SimpleMathOpSlowDiv<int32_t>;
+      CASE_NPY_INT64:
+      
          return SimpleMathOpSlowDiv<int64_t>;
-      case NPY_UINT32: return SimpleMathOpSlowDiv<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return SimpleMathOpSlowDiv<uint32_t>;
+      CASE_NPY_UINT64:
+      
          return SimpleMathOpSlowDiv<uint64_t>;
       case NPY_INT8:   return SimpleMathOpSlowDiv<int8_t>;
       case NPY_INT16:  return SimpleMathOpSlowDiv<int16_t>;
@@ -1211,9 +1211,9 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
    case MATH_OPERATION::SUBDATETIMES:
       *wantedOutType = NPY_DOUBLE;
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
-      case NPY_INT32:  return SimpleMathOpSubDateTime<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return SimpleMathOpSubDateTime<int32_t>;
+      CASE_NPY_INT64:
+      
          return SimpleMathOpSubDateTime<int64_t>;
       }
       printf("bad call to subdatetimes %d %d\n", numpyInType2 , numpyInType1);
@@ -1222,9 +1222,9 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
    case MATH_OPERATION::SUBDATES:
       *wantedOutType = NPY_INT32;
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
-      case NPY_INT32:  return SimpleMathOpSubDates<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return SimpleMathOpSubDates<int32_t>;
+      CASE_NPY_INT64:
+      
          *wantedOutType = NPY_INT64;
          return SimpleMathOpSubDates<int64_t>;
       }
@@ -1240,13 +1240,13 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowFloorDiv<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowFloorDiv<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowFloorDiv<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowFloorDiv<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return SimpleMathOpSlowFloorDiv<int32_t>;
+      CASE_NPY_INT64:
+      
          return SimpleMathOpSlowFloorDiv<int64_t>;
-      case NPY_UINT32: return SimpleMathOpSlowFloorDiv<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return SimpleMathOpSlowFloorDiv<uint32_t>;
+      CASE_NPY_UINT64:
+      
          return SimpleMathOpSlowFloorDiv<uint64_t>;
 
 #ifndef RT_COMPILER_CLANG  // possible error with int8 array and np.floor_divide() with vextractps instruction
@@ -1266,13 +1266,13 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowRemainder<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowRemainder<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowRemainder<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowMod<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return SimpleMathOpSlowMod<int32_t>;
+      CASE_NPY_INT64:
+      
          return SimpleMathOpSlowMod<int64_t>;
-      case NPY_UINT32: return SimpleMathOpSlowMod<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return SimpleMathOpSlowMod<uint32_t>;
+      CASE_NPY_UINT64:
+      
          return SimpleMathOpSlowMod<uint64_t>;
       case NPY_INT8:   return SimpleMathOpSlowMod<int8_t>;
       case NPY_INT16:  return SimpleMathOpSlowMod<int16_t>;
@@ -1290,13 +1290,13 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowPower<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowPower<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowPower<long double>;
-      case NPY_INT32:  return SimpleMathOpSlowPower<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return SimpleMathOpSlowPower<int32_t>;
+      CASE_NPY_INT64:
+      
          return SimpleMathOpSlowPower<int64_t>;
-      case NPY_UINT32: return SimpleMathOpSlowPower<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return SimpleMathOpSlowPower<uint32_t>;
+      CASE_NPY_UINT64:
+      
          return SimpleMathOpSlowPower<uint64_t>;
       case NPY_INT8:   return SimpleMathOpSlowPower<int8_t>;
       case NPY_INT16:  return SimpleMathOpSlowPower<int16_t>;
@@ -1340,18 +1340,18 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
 // TODO: Replace with call to our FixupDtype() function?
 static int GetNonAmbiguousDtype(int dtype) {
    switch (dtype) {
-   case NPY_INT32:
+   CASE_NPY_INT32:
       dtype = 5;
       break;
-   case NPY_UINT32:
+   CASE_NPY_UINT32:
       dtype = 6;
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       dtype = 9;
       break;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT64:
+   
       dtype = 10;
       break;
    }

--- a/src/BasicMath.cpp
+++ b/src/BasicMath.cpp
@@ -101,21 +101,21 @@ template<typename T> static const inline double MaxOp(double x, double y) { if (
 template<typename T> static const inline T MaxOp(T x, T y) { if (x < y) return y; else return x; }
 //template<typename T> static const inline bool MulOp(bool x, bool y) { return x & y; }
 
-static const INT64 NAN_FOR_INT64 = (INT64)0x8000000000000000LL;
-static const INT64 NAN_FOR_INT32 = (INT32)0x80000000;
+static const int64_t NAN_FOR_INT64 = (int64_t)0x8000000000000000LL;
+static const int64_t NAN_FOR_INT32 = (int32_t)0x80000000;
 
 template<typename T> static const inline double DivOp(T x, T y) { return (double)x / (double)y; }
 template<typename T> static const inline float DivOp(float x, T y) { return x / y; }
 
 // Subtraction only two DateTimeNano subtractions
-template<typename T> static const inline double SubDateTimeOp(INT64 x, INT64 y) {
+template<typename T> static const inline double SubDateTimeOp(int64_t x, int64_t y) {
    if (x == 0 || y ==0 || x == NAN_FOR_INT64 || y == NAN_FOR_INT64) {
       return NAN;
    }
    return (double)( x - y); }
 
 // Subtraction only both sides checked
-template<typename T> static const inline double SubDateTimeOp(INT32 x, INT32 y) {
+template<typename T> static const inline double SubDateTimeOp(int32_t x, int32_t y) {
    if (x == 0 || y ==0 || x == NAN_FOR_INT32 || y == NAN_FOR_INT32) {
       return NAN;
    }
@@ -123,14 +123,14 @@ template<typename T> static const inline double SubDateTimeOp(INT32 x, INT32 y) 
 }
 
 // Subtract two dates to produce a DateSpan
-template<typename T> static const inline INT32 SubDatesOp(INT32 x, INT32 y) {
+template<typename T> static const inline int32_t SubDatesOp(int32_t x, int32_t y) {
    if (x == 0 || y == 0 || x == NAN_FOR_INT32 || y == NAN_FOR_INT32) {
       return 0;
    }
    return (x - y);
 }
 
-template<typename T> static const inline INT64 SubDatesOp(INT64 x, INT64 y) {
+template<typename T> static const inline int64_t SubDatesOp(int64_t x, int64_t y) {
    if (x == 0 || y == 0 || x == NAN_FOR_INT64 || y == NAN_FOR_INT64) {
       return 0;
    }
@@ -238,8 +238,8 @@ static const inline __m256d DIV_OP_256f64(__m256d x, __m256d y) { return _mm256_
 static const inline __m256d CONV_INT32_DOUBLE(__m128i* x) { return _mm256_cvtepi32_pd(*x); }
 
 //static const inline __m256d CONV_INT16_DOUBLE(__m128i x) { return _mm256_cvtepi16_pd(x); }
-//static const inline __m256d DIV_OP_256(const INT32 z, __m128i x, __m128i y) { return _mm256_div_pd(_mm256_cvtepi32_pd(x), _mm256_cvtepi32_pd(y)); }
-//static const inline __m256d DIV_OP_256(const INT64 z, __m128i x, __m128i y) { return _mm256_div_pd(_mm256_cvtepi64_pd(x), _mm256_cvtepi64_pd(y)); }
+//static const inline __m256d DIV_OP_256(const int32_t z, __m128i x, __m128i y) { return _mm256_div_pd(_mm256_cvtepi32_pd(x), _mm256_cvtepi32_pd(y)); }
+//static const inline __m256d DIV_OP_256(const int64_t z, __m128i x, __m128i y) { return _mm256_div_pd(_mm256_cvtepi64_pd(x), _mm256_cvtepi64_pd(y)); }
 
 
 static const inline __m256i AND_OP_256(__m256i x, __m256i y) { return _mm256_and_si256(x, y); }
@@ -249,15 +249,15 @@ static const inline __m256i ANDNOT_OP_256(__m256i x, __m256i y) { return _mm256_
 
 //_asm cvt2q
 //CVTDQ2PD
-//inline __m256d DIV_OP_256(const INT64 z, __m256i x, __m256i y) { return _mm256_div_pd(_mm256_cvtepi64_pd(x), _mm256_cvtepi64_pd(y)); }
+//inline __m256d DIV_OP_256(const int64_t z, __m256i x, __m256i y) { return _mm256_div_pd(_mm256_cvtepi64_pd(x), _mm256_cvtepi64_pd(y)); }
 
 template<typename T, typename U256> static const inline __m256  AddOp256(const float z,U256 x, U256 y) { return _mm256_add_ps(x, y); }
 template<typename T, typename U256> static const inline __m256d AddOp256(const double z, U256 x, U256 y) { return _mm256_add_pd(x, y); }
-template<typename T, typename U256> static const inline __m256i AddOp256(const INT32 z, U256 x, U256 y) { return _mm256_add_epi32(x, y); }
+template<typename T, typename U256> static const inline __m256i AddOp256(const int32_t z, U256 x, U256 y) { return _mm256_add_epi32(x, y); }
 
 
 template<typename T, typename MathFunctionPtr>
-FORCEINLINE void SimpleMathOpSlow(MathFunctionPtr MATH_OP, void* pDataIn1X, void* pDataIn2X, void* pDataOutX, INT64 len, INT32 scalarMode) {
+FORCEINLINE void SimpleMathOpSlow(MathFunctionPtr MATH_OP, void* pDataIn1X, void* pDataIn2X, void* pDataOutX, int64_t len, int32_t scalarMode) {
    T* pDataOut = (T*)pDataOutX;    
    T* pDataIn1 = (T*)pDataIn1X;      
    T* pDataIn2 = (T*)pDataIn2X;      
@@ -267,7 +267,7 @@ FORCEINLINE void SimpleMathOpSlow(MathFunctionPtr MATH_OP, void* pDataIn1X, void
    switch (scalarMode) {
    case SCALAR_MODE::NO_SCALARS:
    {
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          pDataOut[i] = MATH_OP(pDataIn1[i], pDataIn2[i]);
       }
       break;
@@ -275,7 +275,7 @@ FORCEINLINE void SimpleMathOpSlow(MathFunctionPtr MATH_OP, void* pDataIn1X, void
    case SCALAR_MODE::FIRST_ARG_SCALAR:
    {
       T arg1 = *pDataIn1;
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          pDataOut[i] = MATH_OP(arg1, pDataIn2[i]);
       }
       break;
@@ -283,8 +283,8 @@ FORCEINLINE void SimpleMathOpSlow(MathFunctionPtr MATH_OP, void* pDataIn1X, void
    case SCALAR_MODE::SECOND_ARG_SCALAR:
    {
       T arg2 = *pDataIn2;
-      //printf("arg2 = %lld  %lld\n", (INT64)arg2, (INT64)pDataIn1[0]);
-      for (INT64 i = 0; i < len; i++) {
+      //printf("arg2 = %lld  %lld\n", (int64_t)arg2, (int64_t)pDataIn1[0]);
+      for (int64_t i = 0; i < len; i++) {
          pDataOut[i] = MATH_OP(pDataIn1[i], arg2);
       }
       break;
@@ -292,7 +292,7 @@ FORCEINLINE void SimpleMathOpSlow(MathFunctionPtr MATH_OP, void* pDataIn1X, void
    default:
       T arg1 = *pDataIn1;
       T arg2 = *pDataIn2;
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          pDataOut[i] = MATH_OP(arg1, arg2);
       }
       break;
@@ -303,7 +303,7 @@ FORCEINLINE void SimpleMathOpSlow(MathFunctionPtr MATH_OP, void* pDataIn1X, void
 //=====================================================================================================
 // Used in division where the output is a double
 template<typename T, typename MathFunctionPtr>
-FORCEINLINE void SimpleMathOpSlowDouble(MathFunctionPtr MATH_OP, void* pDataIn1X, void* pDataIn2X, void* pDataOutX, INT64 len, INT32 scalarMode) {
+FORCEINLINE void SimpleMathOpSlowDouble(MathFunctionPtr MATH_OP, void* pDataIn1X, void* pDataIn2X, void* pDataOutX, int64_t len, int32_t scalarMode) {
    double* pDataOut = (double*)pDataOutX;
    T* pDataIn1 = (T*)pDataIn1X;
    T* pDataIn2 = (T*)pDataIn2X;
@@ -313,7 +313,7 @@ FORCEINLINE void SimpleMathOpSlowDouble(MathFunctionPtr MATH_OP, void* pDataIn1X
    switch (scalarMode) {
    case SCALAR_MODE::NO_SCALARS:
    {
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          pDataOut[i] = MATH_OP(pDataIn1[i], pDataIn2[i]);
       }
       break;
@@ -321,7 +321,7 @@ FORCEINLINE void SimpleMathOpSlowDouble(MathFunctionPtr MATH_OP, void* pDataIn1X
    case SCALAR_MODE::FIRST_ARG_SCALAR:
    {
       T arg1 = *pDataIn1;
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          pDataOut[i] = MATH_OP(arg1, pDataIn2[i]);
       }
       break;
@@ -329,7 +329,7 @@ FORCEINLINE void SimpleMathOpSlowDouble(MathFunctionPtr MATH_OP, void* pDataIn1X
    case SCALAR_MODE::SECOND_ARG_SCALAR:
    {
       T arg2 = *pDataIn2;
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          pDataOut[i] = MATH_OP(pDataIn1[i], arg2);
       }
       break;
@@ -337,7 +337,7 @@ FORCEINLINE void SimpleMathOpSlowDouble(MathFunctionPtr MATH_OP, void* pDataIn1X
    default:
       T arg1 = *pDataIn1;
       T arg2 = *pDataIn2;
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          pDataOut[i] = MATH_OP(arg1, arg2);
       }
       break;
@@ -350,14 +350,14 @@ FORCEINLINE void SimpleMathOpSlowDouble(MathFunctionPtr MATH_OP, void* pDataIn1X
 //=====================================================================================================
 // Not symmetric -- arg1 must be first, arg2 must be second
 template<typename T, typename U256, const T MATH_OP(T, T), const U256 MATH_OP256(U256, U256)>
-inline void SimpleMathOpFast(void* pDataIn1X, void* pDataIn2X, void* pDataOutX, INT64 datalen, INT32 scalarMode) {
+inline void SimpleMathOpFast(void* pDataIn1X, void* pDataIn2X, void* pDataOutX, int64_t datalen, int32_t scalarMode) {
    T* pDataOut = (T*)pDataOutX;
    T* pDataIn1 = (T*)pDataIn1X;
    T* pDataIn2 = (T*)pDataIn2X;
 
-   const INT64 NUM_LOOPS_UNROLLED = 1;
-   const INT64 chunkSize = NUM_LOOPS_UNROLLED * (sizeof(U256) / sizeof(T));
-   INT64 perReg = sizeof(U256) / sizeof(T);
+   const int64_t NUM_LOOPS_UNROLLED = 1;
+   const int64_t chunkSize = NUM_LOOPS_UNROLLED * (sizeof(U256) / sizeof(T));
+   int64_t perReg = sizeof(U256) / sizeof(T);
 
    LOGGING("mathopfast datalen %llu  chunkSize %llu  perReg %llu\n", datalen, chunkSize, perReg);
 
@@ -391,7 +391,7 @@ inline void SimpleMathOpFast(void* pDataIn1X, void* pDataIn2X, void* pDataOutX, 
       }
 
       datalen = datalen & (chunkSize - 1);
-      for (INT64 i = 0; i < datalen; i++) {
+      for (int64_t i = 0; i < datalen; i++) {
          pDataOut[i] = MATH_OP(pDataIn1[i], pDataIn2[i]);
       }
 
@@ -428,7 +428,7 @@ inline void SimpleMathOpFast(void* pDataIn1X, void* pDataIn2X, void* pDataOutX, 
          pDataOut = (T*)pOut_256;
       }
       datalen = datalen & (chunkSize - 1);
-      for (INT64 i = 0; i < datalen; i++) {
+      for (int64_t i = 0; i < datalen; i++) {
          pDataOut[i] = MATH_OP(arg1, pDataIn2[i]);
       }
       break;
@@ -441,12 +441,12 @@ inline void SimpleMathOpFast(void* pDataIn1X, void* pDataIn2X, void* pDataOutX, 
       if (pDataOut == pDataIn1) {
 
          // align the load to 32 byte boundary
-         INT64 babylen = (INT64)pDataIn1 & 31;
+         int64_t babylen = (int64_t)pDataIn1 & 31;
          if (babylen != 0) {
             // calc how much to align data
             babylen = (32 - babylen) / sizeof(T);
             if (babylen <= datalen) {
-               for (INT64 i = 0; i < babylen; i++) {
+               for (int64_t i = 0; i < babylen; i++) {
                   pDataIn1[i] = MATH_OP(pDataIn1[i], arg2);
                }
                pDataIn1 += babylen;
@@ -473,7 +473,7 @@ inline void SimpleMathOpFast(void* pDataIn1X, void* pDataIn2X, void* pDataOutX, 
             pDataIn1 = (T*)pIn1_256;
          }
          datalen = datalen & (chunkSize - 1);
-         for (INT64 i = 0; i < datalen; i++) {
+         for (int64_t i = 0; i < datalen; i++) {
             pDataIn1[i] = MATH_OP(pDataIn1[i], arg2);
          }
 
@@ -503,7 +503,7 @@ inline void SimpleMathOpFast(void* pDataIn1X, void* pDataIn2X, void* pDataOutX, 
             pDataOut = (T*)pOut_256;
          }
          datalen = datalen & (chunkSize - 1);
-         for (INT64 i = 0; i < datalen; i++) {
+         for (int64_t i = 0; i < datalen; i++) {
             pDataOut[i] = MATH_OP(pDataIn1[i], arg2);
          }
       }
@@ -517,21 +517,21 @@ inline void SimpleMathOpFast(void* pDataIn1X, void* pDataIn2X, void* pDataOutX, 
 //=====================================================================================================
 // Flips arg1 and arg2 around for BITWISE_NOTAND
 template<typename T, typename U256, const T MATH_OP(T, T), const U256 MATH_OP256(U256, U256)>
-inline void SimpleMathOpFastReverse(void* pDataIn1X, void* pDataIn2X, void* pDataOutX, INT64 datalen, INT32 scalarMode) {
+inline void SimpleMathOpFastReverse(void* pDataIn1X, void* pDataIn2X, void* pDataOutX, int64_t datalen, int32_t scalarMode) {
    return SimpleMathOpFast<T, U256, MATH_OP, MATH_OP256>(pDataIn2X, pDataIn1X, pDataOutX, datalen, scalarMode);
 }
 
 //=====================================================================================================
 // Not symmetric -- arg1 must be first, arg2 must be second
 template<typename T, typename U256, const T MATH_OP(T, T), const U256 MATH_OP256(U256, U256)>
-inline void SimpleMathOpFastSymmetric(void* pDataIn1X, void* pDataIn2X, void* pDataOutX, INT64 datalen, INT32 scalarMode) {
+inline void SimpleMathOpFastSymmetric(void* pDataIn1X, void* pDataIn2X, void* pDataOutX, int64_t datalen, int32_t scalarMode) {
    T* pDataOut = (T*)pDataOutX;
    T* pDataIn1 = (T*)pDataIn1X;
    T* pDataIn2 = (T*)pDataIn2X;
 
-   const INT64 NUM_LOOPS_UNROLLED = 1;
-   const INT64 chunkSize = NUM_LOOPS_UNROLLED * (sizeof(U256) / sizeof(T));
-   INT64 perReg = sizeof(U256) / sizeof(T);
+   const int64_t NUM_LOOPS_UNROLLED = 1;
+   const int64_t chunkSize = NUM_LOOPS_UNROLLED * (sizeof(U256) / sizeof(T));
+   int64_t perReg = sizeof(U256) / sizeof(T);
 
    LOGGING("mathopfast datalen %llu  chunkSize %llu  perReg %llu\n", datalen, chunkSize, perReg);
 
@@ -564,7 +564,7 @@ inline void SimpleMathOpFastSymmetric(void* pDataIn1X, void* pDataIn2X, void* pD
       }
 
       datalen = datalen & (chunkSize - 1);
-      for (INT64 i = 0; i < datalen; i++) {
+      for (int64_t i = 0; i < datalen; i++) {
          pDataOut[i] = MATH_OP(pDataIn1[i], pDataIn2[i]);
       }
 
@@ -601,7 +601,7 @@ inline void SimpleMathOpFastSymmetric(void* pDataIn1X, void* pDataIn2X, void* pD
          pDataOut = (T*)pOut_256;
       }
       datalen = datalen & (chunkSize - 1);
-      for (INT64 i = 0; i < datalen; i++) {
+      for (int64_t i = 0; i < datalen; i++) {
          pDataOut[i] = MATH_OP(arg1, pDataIn2[i]);
       }
       break;
@@ -614,12 +614,12 @@ inline void SimpleMathOpFastSymmetric(void* pDataIn1X, void* pDataIn2X, void* pD
       if (pDataOut == pDataIn1) {
 
          // align the load to 32 byte boundary
-         INT64 babylen = (INT64)pDataIn1 & 31;
+         int64_t babylen = (int64_t)pDataIn1 & 31;
          if (babylen != 0) {
             // calc how much to align data
             babylen = (32 - babylen) / sizeof(T);
             if (babylen <= datalen) {
-               for (INT64 i = 0; i < babylen; i++) {
+               for (int64_t i = 0; i < babylen; i++) {
                   pDataIn1[i] = MATH_OP(pDataIn1[i], arg2);
                }
                pDataIn1 += babylen;
@@ -647,7 +647,7 @@ inline void SimpleMathOpFastSymmetric(void* pDataIn1X, void* pDataIn2X, void* pD
             pDataIn1 = (T*)pIn1_256;
          }
          datalen = datalen & (chunkSize - 1);
-         for (INT64 i = 0; i < datalen; i++) {
+         for (int64_t i = 0; i < datalen; i++) {
             pDataIn1[i] = MATH_OP(pDataIn1[i], arg2);
          }
 
@@ -680,7 +680,7 @@ inline void SimpleMathOpFastSymmetric(void* pDataIn1X, void* pDataIn2X, void* pD
             pDataOut = (T*)pOut_256;
          }
          datalen = datalen & (chunkSize - 1);
-         for (INT64 i = 0; i < datalen; i++) {
+         for (int64_t i = 0; i < datalen; i++) {
             pDataOut[i] = MATH_OP(pDataIn1[i], arg2);
          }
       }
@@ -695,14 +695,14 @@ inline void SimpleMathOpFastSymmetric(void* pDataIn1X, void* pDataIn2X, void* pD
 //=====================================================================================================
 
 template<typename T, typename U128, typename U256, typename MathFunctionPtr, typename MathFunctionConvert, typename MathFunctionPtr256>
-inline void SimpleMathOpFastDouble(MathFunctionPtr MATH_OP, MathFunctionConvert MATH_CONV, MathFunctionPtr256 MATH_OP256, void* pDataIn1X, void* pDataIn2X, void* pDataOutX, INT64 len, INT32 scalarMode) {
+inline void SimpleMathOpFastDouble(MathFunctionPtr MATH_OP, MathFunctionConvert MATH_CONV, MathFunctionPtr256 MATH_OP256, void* pDataIn1X, void* pDataIn2X, void* pDataOutX, int64_t len, int32_t scalarMode) {
    double* pDataOut = (double*)pDataOutX;
    T* pDataIn1 = (T*)pDataIn1X;
    T* pDataIn2 = (T*)pDataIn2X;
    const double dummy = 0;
 
-   INT64 chunkSize = (sizeof(U256)) / sizeof(double);
-   INT64 perReg = sizeof(U256) / sizeof(double);
+   int64_t chunkSize = (sizeof(U256)) / sizeof(double);
+   int64_t perReg = sizeof(U256) / sizeof(double);
 
    LOGGING("mathopfastDouble len %llu  chunkSize %llu  perReg %llu\n", len, chunkSize, perReg);
 
@@ -732,7 +732,7 @@ inline void SimpleMathOpFastDouble(MathFunctionPtr MATH_OP, MathFunctionConvert 
       }
 
       len = len & (chunkSize - 1);
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          pDataOut[i] = MATH_OP(pDataIn1[i], pDataIn2[i]);
       }
 
@@ -741,7 +741,7 @@ inline void SimpleMathOpFastDouble(MathFunctionPtr MATH_OP, MathFunctionConvert 
    case SCALAR_MODE::FIRST_ARG_SCALAR:
    {
       T arg1 = *pDataIn1;
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          pDataOut[i] = MATH_OP(arg1, pDataIn2[i]);
       }
       break;
@@ -749,7 +749,7 @@ inline void SimpleMathOpFastDouble(MathFunctionPtr MATH_OP, MathFunctionConvert 
    case SCALAR_MODE::SECOND_ARG_SCALAR:
    {
       T arg2 = *pDataIn2;
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          pDataOut[i] = MATH_OP(pDataIn1[i], arg2);
       }
       break;
@@ -761,7 +761,7 @@ inline void SimpleMathOpFastDouble(MathFunctionPtr MATH_OP, MathFunctionConvert 
 
 
 template<typename T, typename U128, typename U256>
-static void SimpleMathOpFastDivDouble(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpFastDivDouble(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpFastDouble<T, U128, U256, const double(*)(T, T), const U256(*)(U128*), const U256(*)(U256, U256)>(DivOp<T>, CONV_INT32_DOUBLE,  DIV_OP_256f64, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
@@ -769,78 +769,78 @@ static void SimpleMathOpFastDivDouble(void* pDataIn1, void* pDataIn2, void* pDat
 //--------------------------------------------------------------------------------------
 
 template<typename T>
-static void SimpleMathOpSlowAdd(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSlowAdd(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlow<T, const T(*)(T, T)>(AddOp<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 template<typename T>
-static void SimpleMathOpSlowSub(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSlowSub(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlow<T, const T(*)(T, T)>(SubOp<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 template<typename T>
-static void SimpleMathOpSlowMul(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSlowMul(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlow<T, const T(*)(T, T)>(MulOp<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 template<typename T>
-static void SimpleMathOpSlowDivFloat(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSlowDivFloat(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlow<T, const float(*)(float, T)>(DivOp<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 template<typename T>
-static void SimpleMathOpSlowDiv(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSlowDiv(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlowDouble<T, const double(*)(T, T)>(DivOp<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 
 template<typename T>
-static void SimpleMathOpSubDateTime(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSubDateTime(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlowDouble<T, const double(*)(T, T)>(SubDateTimeOp<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 template<typename T>
-static void SimpleMathOpSubDates(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSubDates(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlow<T, const T(*)(T, T)>(SubDatesOp<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 template<typename T>
-static void SimpleMathOpSlowFloorDiv(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSlowFloorDiv(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlow<T, const T(*)(T, T)>(FloorDivOp<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 template<typename T>
-static void SimpleMathOpSlowMod(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSlowMod(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlow<T, const T(*)(T, T)>(ModOp<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 template<typename T>
-static void SimpleMathOpSlowLog(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSlowLog(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlow<T, const T(*)(T, T)>(LogOp<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 template<typename T>
-static void SimpleMathOpSlowPower(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSlowPower(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlow<T, const T(*)(T, T)>(PowerOp<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 template<typename T>
-static void SimpleMathOpSlowRemainder(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSlowRemainder(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlow<T, const T(*)(T, T)>(REMAINDER_OP<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 template<typename T>
-static void SimpleMathOpSlowFmod(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSlowFmod(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlow<T, const T(*)(T, T)>(FMOD_OP<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 template<typename T>
-static void SimpleMathOpSlowMin(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSlowMin(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlow<T, const T(*)(T, T)>(MinOp<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
 template<typename T>
-static void SimpleMathOpSlowMax(void* pDataIn1, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void SimpleMathOpSlowMax(void* pDataIn1, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    return SimpleMathOpSlow<T, const T(*)(T, T)>(MaxOp<T>, pDataIn1, pDataIn2, pDataOut, len, scalarMode);
 }
 
@@ -852,14 +852,14 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       *wantedOutType = numpyInType1;
       if (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR) *wantedOutType = numpyInType2;
       switch (*wantedOutType) {
-      case NPY_BOOL:   return SimpleMathOpFastSymmetric<INT8, __m256i, OrOp<INT8>, OR_OP_256>;
+      case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, OrOp<int8_t>, OR_OP_256>;
       case NPY_FLOAT:  return SimpleMathOpFastSymmetric<float, __m256, AddOp<float>, ADD_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFastSymmetric<double, __m256d, AddOp<double>, ADD_OP_256f64>;
          // proof of concept for i32 addition loop
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<INT32, __m256i, AddOp<INT32>, ADD_OP_256i32>;
-      CASE_NPY_INT64:  return SimpleMathOpFastSymmetric<INT64, __m256i, AddOp<INT64>, ADD_OP_256i64>;
-      case NPY_INT16:  return SimpleMathOpFastSymmetric<INT16, __m256i, AddOp<INT16>, ADD_OP_256i16>;
-      case NPY_INT8:   return SimpleMathOpFastSymmetric<INT8,  __m256i, AddOp<INT8>, ADD_OP_256i8>;
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AddOp<int32_t>, ADD_OP_256i32>;
+      CASE_NPY_INT64:  return SimpleMathOpFastSymmetric<int64_t, __m256i, AddOp<int64_t>, ADD_OP_256i64>;
+      case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, AddOp<int16_t>, ADD_OP_256i16>;
+      case NPY_INT8:   return SimpleMathOpFastSymmetric<int8_t,  __m256i, AddOp<int8_t>, ADD_OP_256i8>;
       }
       return NULL;
 
@@ -867,19 +867,19 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       *wantedOutType = numpyInType1;
       if (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR) *wantedOutType = numpyInType2;
       switch (*wantedOutType) {
-      case NPY_BOOL:   return SimpleMathOpFastSymmetric<INT8, __m256i, AndOp<INT8>, AND_OP_256>;
+      case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, AndOp<int8_t>, AND_OP_256>;
       case NPY_FLOAT:  return SimpleMathOpFastSymmetric<float, __m256, MulOp<float>, MUL_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFastSymmetric<double, __m256d, MulOp<double>, MUL_OP_256f64>;
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<INT32, __m256i, MulOp<INT32>, MUL_OP_256i32>;
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MulOp<int32_t>, MUL_OP_256i32>;
 
-      //CASE_NPY_INT64:  return SimpleMathOpFast<INT64, __m256i, MulOp<INT64>, MUL_OP_256i64>;
-      case NPY_INT16:  return SimpleMathOpFastSymmetric<INT16, __m256i, MulOp<INT16>, MUL_OP_256i16>;
+      //CASE_NPY_INT64:  return SimpleMathOpFast<int64_t, __m256i, MulOp<int64_t>, MUL_OP_256i64>;
+      case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MulOp<int16_t>, MUL_OP_256i16>;
 
       // Below the intrinsic to multiply is slower so we disabled it (really wants 32bit -> 64bit)
-      //CASE_NPY_UINT32:  return SimpleMathOpFastMul<UINT32, __m256i>;
+      //CASE_NPY_UINT32:  return SimpleMathOpFastMul<uint32_t, __m256i>;
       // TODO: 64bit multiply can be done with algo..
       // lo1 * lo2 + (lo1 * hi2) << 32 + (hi1 *lo2) << 32)
-      CASE_NPY_UINT64: return SimpleMathOpFastSymmetric<UINT64, __m256i, MulOp<UINT64>, MUL_OP_256u64>;
+      CASE_NPY_UINT64: return SimpleMathOpFastSymmetric<uint64_t, __m256i, MulOp<uint64_t>, MUL_OP_256u64>;
       }
       return NULL;
 
@@ -889,10 +889,10 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (*wantedOutType) {
       case NPY_FLOAT:  return SimpleMathOpFast<float, __m256, SubOp<float>, SUB_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFast<double, __m256d, SubOp<double>, SUB_OP_256f64>;
-      CASE_NPY_INT32:  return SimpleMathOpFast<INT32, __m256i, SubOp<INT32>, SUB_OP_256i32>;
-      CASE_NPY_INT64:  return SimpleMathOpFast<INT64, __m256i, SubOp<INT64>, SUB_OP_256i64>;
-      case NPY_INT16:  return SimpleMathOpFast<INT16, __m256i, SubOp<INT16>, SUB_OP_256i16>;
-      case NPY_INT8:   return SimpleMathOpFast<INT8,  __m256i, SubOp<INT8>,  SUB_OP_256i8>;
+      CASE_NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, SubOp<int32_t>, SUB_OP_256i32>;
+      CASE_NPY_INT64:  return SimpleMathOpFast<int64_t, __m256i, SubOp<int64_t>, SUB_OP_256i64>;
+      case NPY_INT16:  return SimpleMathOpFast<int16_t, __m256i, SubOp<int16_t>, SUB_OP_256i16>;
+      case NPY_INT8:   return SimpleMathOpFast<int8_t,  __m256i, SubOp<int8_t>,  SUB_OP_256i8>;
       }
       return NULL;
 
@@ -905,12 +905,12 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       // TODO: Vector routine needs to be written
       case NPY_FLOAT:  return SimpleMathOpSlowMin<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMin<double>;
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<INT32, __m256i, MinOp<INT32>, MIN_OPi32>;
-      case NPY_INT16:  return SimpleMathOpFastSymmetric<INT16, __m256i, MinOp<INT16>, MIN_OPi16>;
-      case NPY_INT8:   return SimpleMathOpFastSymmetric<INT8, __m256i, MinOp<INT8>, MIN_OPi8>;
-      CASE_NPY_UINT32:  return SimpleMathOpFastSymmetric<UINT32, __m256i, MinOp<UINT32>, MIN_OPu32>;
-      case NPY_UINT16:  return SimpleMathOpFastSymmetric<UINT16, __m256i, MinOp<UINT16>, MIN_OPu16>;
-      case NPY_UINT8:   return SimpleMathOpFastSymmetric<UINT8, __m256i, MinOp<UINT8>, MIN_OPu8>;
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MinOp<int32_t>, MIN_OPi32>;
+      case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MinOp<int16_t>, MIN_OPi16>;
+      case NPY_INT8:   return SimpleMathOpFastSymmetric<int8_t, __m256i, MinOp<int8_t>, MIN_OPi8>;
+      CASE_NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MinOp<uint32_t>, MIN_OPu32>;
+      case NPY_UINT16:  return SimpleMathOpFastSymmetric<uint16_t, __m256i, MinOp<uint16_t>, MIN_OPu16>;
+      case NPY_UINT8:   return SimpleMathOpFastSymmetric<uint8_t, __m256i, MinOp<uint8_t>, MIN_OPu8>;
       }
       return NULL;
 
@@ -922,12 +922,12 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       // TODO: Vector routine needs to be written
       case NPY_FLOAT:  return SimpleMathOpSlowMax<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMax<double>;
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<INT32, __m256i, MaxOp<INT32>, MAX_OPi32>;
-      case NPY_INT16:  return SimpleMathOpFastSymmetric<INT16, __m256i, MaxOp<INT16>, MAX_OPi16>;
-      case NPY_INT8:   return SimpleMathOpFastSymmetric<INT8, __m256i, MaxOp<INT8>, MAX_OPi8>;
-      CASE_NPY_UINT32:  return SimpleMathOpFastSymmetric<UINT32, __m256i, MaxOp<UINT32>, MAX_OPu32>;
-      case NPY_UINT16:  return SimpleMathOpFastSymmetric<UINT16, __m256i, MaxOp<UINT16>, MAX_OPu16>;
-      case NPY_UINT8:   return SimpleMathOpFastSymmetric<UINT8, __m256i, MaxOp<UINT8>, MAX_OPu8>;
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, MaxOp<int32_t>, MAX_OPi32>;
+      case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, MaxOp<int16_t>, MAX_OPi16>;
+      case NPY_INT8:   return SimpleMathOpFastSymmetric<int8_t, __m256i, MaxOp<int8_t>, MAX_OPi8>;
+      CASE_NPY_UINT32:  return SimpleMathOpFastSymmetric<uint32_t, __m256i, MaxOp<uint32_t>, MAX_OPu32>;
+      case NPY_UINT16:  return SimpleMathOpFastSymmetric<uint16_t, __m256i, MaxOp<uint16_t>, MAX_OPu16>;
+      case NPY_UINT8:   return SimpleMathOpFastSymmetric<uint8_t, __m256i, MaxOp<uint8_t>, MAX_OPu8>;
       }
       return NULL;
 
@@ -943,7 +943,7 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
       case NPY_FLOAT:  return SimpleMathOpFast<float, __m256, DivOp<float>, DIV_OP_256f32>;
       case NPY_DOUBLE: return SimpleMathOpFast<double, __m256d, DivOp<double>, DIV_OP_256f64>;
-      CASE_NPY_INT32:  return SimpleMathOpFastDivDouble<INT32, __m128i, __m256d>;
+      CASE_NPY_INT32:  return SimpleMathOpFastDivDouble<int32_t, __m128i, __m256d>;
       }
       return NULL;
 
@@ -951,7 +951,7 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       *wantedOutType = numpyInType1;
       if (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR) *wantedOutType = numpyInType2;
       switch (*wantedOutType) {
-      case NPY_BOOL:   return SimpleMathOpFastSymmetric<INT8, __m256i, AndOp<INT8>, AND_OP_256>;
+      case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, AndOp<int8_t>, AND_OP_256>;
       }
       return NULL;
 
@@ -961,13 +961,13 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (*wantedOutType) {
       case NPY_INT8:
       case NPY_UINT8:
-      case NPY_BOOL:   return SimpleMathOpFastSymmetric<INT8, __m256i, AndOp<INT8>, AND_OP_256>;
+      case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, AndOp<int8_t>, AND_OP_256>;
       case NPY_UINT16:
-      case NPY_INT16:  return SimpleMathOpFastSymmetric<INT16, __m256i, AndOp<INT16>, AND_OP_256>;
+      case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, AndOp<int16_t>, AND_OP_256>;
       CASE_NPY_UINT32:
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<INT32, __m256i, AndOp<INT32>, AND_OP_256>;
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, AndOp<int32_t>, AND_OP_256>;
       CASE_NPY_UINT64:
-      case NPY_INT64:  return SimpleMathOpFastSymmetric<INT64, __m256i, AndOp<INT64>, AND_OP_256>;
+      case NPY_INT64:  return SimpleMathOpFastSymmetric<int64_t, __m256i, AndOp<int64_t>, AND_OP_256>;
       }
       return NULL;
 
@@ -975,7 +975,7 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       *wantedOutType = numpyInType1;
       if (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR) *wantedOutType = numpyInType2;
       switch (*wantedOutType) {
-      case NPY_BOOL:   return SimpleMathOpFastSymmetric<INT8, __m256i, OrOp<INT8>, OR_OP_256>;
+      case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, OrOp<int8_t>, OR_OP_256>;
       }
       return NULL;
 
@@ -985,13 +985,13 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (*wantedOutType) {
       case NPY_INT8:
       case NPY_UINT8:
-      case NPY_BOOL:   return SimpleMathOpFastSymmetric<INT8, __m256i, OrOp<INT8>, OR_OP_256>;
+      case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, OrOp<int8_t>, OR_OP_256>;
       case NPY_UINT16:
-      case NPY_INT16:  return SimpleMathOpFastSymmetric<INT16, __m256i, OrOp<INT16>, OR_OP_256>;
+      case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, OrOp<int16_t>, OR_OP_256>;
       CASE_NPY_UINT32:
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<INT32, __m256i, OrOp<INT32>, OR_OP_256>;
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, OrOp<int32_t>, OR_OP_256>;
       CASE_NPY_UINT64:
-      case NPY_INT64:  return SimpleMathOpFastSymmetric<INT64, __m256i, OrOp<INT64>, OR_OP_256>;
+      case NPY_INT64:  return SimpleMathOpFastSymmetric<int64_t, __m256i, OrOp<int64_t>, OR_OP_256>;
       }
       return NULL;
 
@@ -1001,13 +1001,13 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (*wantedOutType) {
       case NPY_INT8:
       case NPY_UINT8:
-      case NPY_BOOL:   return SimpleMathOpFastSymmetric<INT8, __m256i, XorOp<INT8>, XOR_OP_256>;
+      case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, XorOp<int8_t>, XOR_OP_256>;
       case NPY_UINT16:
-      case NPY_INT16:  return SimpleMathOpFastSymmetric<INT16, __m256i, XorOp<INT16>, XOR_OP_256>;
+      case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, XorOp<int16_t>, XOR_OP_256>;
       CASE_NPY_UINT32:
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<INT32, __m256i, XorOp<INT32>, XOR_OP_256>;
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
       CASE_NPY_UINT64:
-      case NPY_INT64:  return SimpleMathOpFastSymmetric<INT64, __m256i, XorOp<INT64>, XOR_OP_256>;
+      case NPY_INT64:  return SimpleMathOpFastSymmetric<int64_t, __m256i, XorOp<int64_t>, XOR_OP_256>;
       }
       return NULL;
 
@@ -1018,13 +1018,13 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (*wantedOutType) {
       case NPY_INT8:
       case NPY_UINT8:
-      case NPY_BOOL:   return SimpleMathOpFastSymmetric<INT8, __m256i, XorOp<INT8>, XOR_OP_256>;
+      case NPY_BOOL:   return SimpleMathOpFastSymmetric<int8_t, __m256i, XorOp<int8_t>, XOR_OP_256>;
       case NPY_UINT16:
-      case NPY_INT16:  return SimpleMathOpFastSymmetric<INT16, __m256i, XorOp<INT16>, XOR_OP_256>;
+      case NPY_INT16:  return SimpleMathOpFastSymmetric<int16_t, __m256i, XorOp<int16_t>, XOR_OP_256>;
       CASE_NPY_UINT32:
-      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<INT32, __m256i, XorOp<INT32>, XOR_OP_256>;
+      CASE_NPY_INT32:  return SimpleMathOpFastSymmetric<int32_t, __m256i, XorOp<int32_t>, XOR_OP_256>;
       CASE_NPY_UINT64:
-      case NPY_INT64:  return SimpleMathOpFastSymmetric<INT64, __m256i, XorOp<INT64>, XOR_OP_256>;
+      case NPY_INT64:  return SimpleMathOpFastSymmetric<int64_t, __m256i, XorOp<int64_t>, XOR_OP_256>;
       }
       return NULL;
 
@@ -1034,13 +1034,13 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (*wantedOutType) {
       case NPY_INT8:
       case NPY_UINT8:
-      case NPY_BOOL:   return SimpleMathOpFastReverse<INT8, __m256i, AndNotOp<INT8>, ANDNOT_OP_256>;
+      case NPY_BOOL:   return SimpleMathOpFastReverse<int8_t, __m256i, AndNotOp<int8_t>, ANDNOT_OP_256>;
       case NPY_UINT16:
-      case NPY_INT16:  return SimpleMathOpFastReverse<INT16, __m256i, AndNotOp<INT16>, ANDNOT_OP_256>;
+      case NPY_INT16:  return SimpleMathOpFastReverse<int16_t, __m256i, AndNotOp<int16_t>, ANDNOT_OP_256>;
       CASE_NPY_UINT32:
-      CASE_NPY_INT32:  return SimpleMathOpFastReverse<INT32, __m256i, AndNotOp<INT32>, ANDNOT_OP_256>;
+      CASE_NPY_INT32:  return SimpleMathOpFastReverse<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
       CASE_NPY_UINT64:
-      case NPY_INT64:  return SimpleMathOpFastReverse<INT64, __m256i, AndNotOp<INT64>, ANDNOT_OP_256>;
+      case NPY_INT64:  return SimpleMathOpFastReverse<int64_t, __m256i, AndNotOp<int64_t>, ANDNOT_OP_256>;
       }
       return NULL;
 
@@ -1050,13 +1050,13 @@ static ANY_TWO_FUNC GetSimpleMathOpFast(int func, int scalarMode, int numpyInTyp
       switch (*wantedOutType) {
       case NPY_INT8:
       case NPY_UINT8:
-      case NPY_BOOL:   return SimpleMathOpFast<INT8, __m256i, AndNotOp<INT8>, ANDNOT_OP_256>;
+      case NPY_BOOL:   return SimpleMathOpFast<int8_t, __m256i, AndNotOp<int8_t>, ANDNOT_OP_256>;
       case NPY_UINT16:
-      case NPY_INT16:  return SimpleMathOpFast<INT16, __m256i, AndNotOp<INT16>, ANDNOT_OP_256>;
+      case NPY_INT16:  return SimpleMathOpFast<int16_t, __m256i, AndNotOp<int16_t>, ANDNOT_OP_256>;
       CASE_NPY_UINT32:
-      CASE_NPY_INT32:  return SimpleMathOpFast<INT32, __m256i, AndNotOp<INT32>, ANDNOT_OP_256>;
+      CASE_NPY_INT32:  return SimpleMathOpFast<int32_t, __m256i, AndNotOp<int32_t>, ANDNOT_OP_256>;
       CASE_NPY_UINT64:
-      case NPY_INT64:  return SimpleMathOpFast<INT64, __m256i, AndNotOp<INT64>, ANDNOT_OP_256>;
+      case NPY_INT64:  return SimpleMathOpFast<int64_t, __m256i, AndNotOp<int64_t>, ANDNOT_OP_256>;
       }
       return NULL;
 
@@ -1078,14 +1078,14 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowAdd<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowAdd<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowAdd<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowAdd<INT32>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowAdd<INT64>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowAdd<UINT32>;
-      CASE_NPY_UINT64: return SimpleMathOpSlowAdd<UINT64>;
-      case NPY_INT8:   return SimpleMathOpSlowAdd<INT8>;
-      case NPY_INT16:  return SimpleMathOpSlowAdd<INT16>;
-      case NPY_UINT8:  return SimpleMathOpSlowAdd<UINT8>;
-      case NPY_UINT16: return SimpleMathOpSlowAdd<UINT16>;
+      CASE_NPY_INT32:  return SimpleMathOpSlowAdd<int32_t>;
+      CASE_NPY_INT64:  return SimpleMathOpSlowAdd<int64_t>;
+      CASE_NPY_UINT32: return SimpleMathOpSlowAdd<uint32_t>;
+      CASE_NPY_UINT64: return SimpleMathOpSlowAdd<uint64_t>;
+      case NPY_INT8:   return SimpleMathOpSlowAdd<int8_t>;
+      case NPY_INT16:  return SimpleMathOpSlowAdd<int16_t>;
+      case NPY_UINT8:  return SimpleMathOpSlowAdd<uint8_t>;
+      case NPY_UINT16: return SimpleMathOpSlowAdd<uint16_t>;
       case NPY_STRING:
          if (numpyInType1 == numpyInType2 && scalarMode == SCALAR_MODE::NO_SCALARS) {
 
@@ -1108,14 +1108,14 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowSub<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowSub<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowSub<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowSub<INT32>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowSub<INT64>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowSub<UINT32>;
-      CASE_NPY_UINT64: return SimpleMathOpSlowSub<UINT64>;
-      case NPY_INT8:   return SimpleMathOpSlowSub<INT8>;
-      case NPY_INT16:  return SimpleMathOpSlowSub<INT16>;
-      case NPY_UINT8:  return SimpleMathOpSlowSub<UINT8>;
-      case NPY_UINT16: return SimpleMathOpSlowSub<UINT16>;
+      CASE_NPY_INT32:  return SimpleMathOpSlowSub<int32_t>;
+      CASE_NPY_INT64:  return SimpleMathOpSlowSub<int64_t>;
+      CASE_NPY_UINT32: return SimpleMathOpSlowSub<uint32_t>;
+      CASE_NPY_UINT64: return SimpleMathOpSlowSub<uint64_t>;
+      case NPY_INT8:   return SimpleMathOpSlowSub<int8_t>;
+      case NPY_INT16:  return SimpleMathOpSlowSub<int16_t>;
+      case NPY_UINT8:  return SimpleMathOpSlowSub<uint8_t>;
+      case NPY_UINT16: return SimpleMathOpSlowSub<uint16_t>;
 
       }
       return NULL;
@@ -1129,14 +1129,14 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowMul<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowMul<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowMul<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowMul<INT32>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowMul<INT64>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowMul<UINT32>;
-      case NPY_UINT64: return SimpleMathOpSlowMul<UINT64>;
-      case NPY_INT8:   return SimpleMathOpSlowMul<INT8>;
-      case NPY_INT16:  return SimpleMathOpSlowMul<INT16>;
-      case NPY_UINT8:  return SimpleMathOpSlowMul<UINT8>;
-      case NPY_UINT16: return SimpleMathOpSlowMul<UINT16>;
+      CASE_NPY_INT32:  return SimpleMathOpSlowMul<int32_t>;
+      CASE_NPY_INT64:  return SimpleMathOpSlowMul<int64_t>;
+      CASE_NPY_UINT32: return SimpleMathOpSlowMul<uint32_t>;
+      case NPY_UINT64: return SimpleMathOpSlowMul<uint64_t>;
+      case NPY_INT8:   return SimpleMathOpSlowMul<int8_t>;
+      case NPY_INT16:  return SimpleMathOpSlowMul<int16_t>;
+      case NPY_UINT8:  return SimpleMathOpSlowMul<uint8_t>;
+      case NPY_UINT16: return SimpleMathOpSlowMul<uint16_t>;
 
       }
       return NULL;
@@ -1155,14 +1155,14 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowDivFloat<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowDiv<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowDiv<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowDiv<INT32>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowDiv<INT64>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowDiv<UINT32>;
-      CASE_NPY_UINT64: return SimpleMathOpSlowDiv<UINT64>;
-      case NPY_INT8:   return SimpleMathOpSlowDiv<INT8>;
-      case NPY_INT16:  return SimpleMathOpSlowDiv<INT16>;
-      case NPY_UINT8:  return SimpleMathOpSlowDiv<UINT8>;
-      case NPY_UINT16: return SimpleMathOpSlowDiv<UINT16>;
+      CASE_NPY_INT32:  return SimpleMathOpSlowDiv<int32_t>;
+      CASE_NPY_INT64:  return SimpleMathOpSlowDiv<int64_t>;
+      CASE_NPY_UINT32: return SimpleMathOpSlowDiv<uint32_t>;
+      CASE_NPY_UINT64: return SimpleMathOpSlowDiv<uint64_t>;
+      case NPY_INT8:   return SimpleMathOpSlowDiv<int8_t>;
+      case NPY_INT16:  return SimpleMathOpSlowDiv<int16_t>;
+      case NPY_UINT8:  return SimpleMathOpSlowDiv<uint8_t>;
+      case NPY_UINT16: return SimpleMathOpSlowDiv<uint16_t>;
 
       }
       return NULL;
@@ -1170,8 +1170,8 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
    case MATH_OPERATION::SUBDATETIMES:
       *wantedOutType = NPY_DOUBLE;
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
-      CASE_NPY_INT32:  return SimpleMathOpSubDateTime<INT32>;
-      CASE_NPY_INT64:  return SimpleMathOpSubDateTime<INT64>;
+      CASE_NPY_INT32:  return SimpleMathOpSubDateTime<int32_t>;
+      CASE_NPY_INT64:  return SimpleMathOpSubDateTime<int64_t>;
       }
       printf("bad call to subdatetimes %d %d\n", numpyInType2 , numpyInType1);
       return NULL;
@@ -1179,8 +1179,8 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
    case MATH_OPERATION::SUBDATES:
       *wantedOutType = NPY_INT32;
       switch (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR ? numpyInType2 : numpyInType1) {
-      CASE_NPY_INT32:  return SimpleMathOpSubDates<INT32>;
-      CASE_NPY_INT64:  *wantedOutType = NPY_INT64; return SimpleMathOpSubDates<INT64>;
+      CASE_NPY_INT32:  return SimpleMathOpSubDates<int32_t>;
+      CASE_NPY_INT64:  *wantedOutType = NPY_INT64; return SimpleMathOpSubDates<int64_t>;
       }
       printf("bad call to subdates %d %d\n", numpyInType2, numpyInType1);
       return NULL;
@@ -1194,16 +1194,16 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowFloorDiv<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowFloorDiv<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowFloorDiv<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowFloorDiv<INT32>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowFloorDiv<INT64>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowFloorDiv<UINT32>;
-      case NPY_UINT64: return SimpleMathOpSlowFloorDiv<UINT64>;
+      CASE_NPY_INT32:  return SimpleMathOpSlowFloorDiv<int32_t>;
+      CASE_NPY_INT64:  return SimpleMathOpSlowFloorDiv<int64_t>;
+      CASE_NPY_UINT32: return SimpleMathOpSlowFloorDiv<uint32_t>;
+      case NPY_UINT64: return SimpleMathOpSlowFloorDiv<uint64_t>;
 
 #ifndef RT_COMPILER_CLANG  // possible error with int8 array and np.floor_divide() with vextractps instruction
-      case NPY_INT8:   return SimpleMathOpSlowFloorDiv<INT8>;
-      case NPY_INT16:  return SimpleMathOpSlowFloorDiv<INT16>;
-      case NPY_UINT8:  return SimpleMathOpSlowFloorDiv<UINT8>;
-      case NPY_UINT16: return SimpleMathOpSlowFloorDiv<UINT16>;
+      case NPY_INT8:   return SimpleMathOpSlowFloorDiv<int8_t>;
+      case NPY_INT16:  return SimpleMathOpSlowFloorDiv<int16_t>;
+      case NPY_UINT8:  return SimpleMathOpSlowFloorDiv<uint8_t>;
+      case NPY_UINT16: return SimpleMathOpSlowFloorDiv<uint16_t>;
 #endif
       }
       return NULL;
@@ -1216,14 +1216,14 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowRemainder<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowRemainder<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowRemainder<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowMod<INT32>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowMod<INT64>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowMod<UINT32>;
-      CASE_NPY_UINT64: return SimpleMathOpSlowMod<UINT64>;
-      case NPY_INT8:   return SimpleMathOpSlowMod<INT8>;
-      case NPY_INT16:  return SimpleMathOpSlowMod<INT16>;
-      case NPY_UINT8:  return SimpleMathOpSlowMod<UINT8>;
-      case NPY_UINT16: return SimpleMathOpSlowMod<UINT16>;
+      CASE_NPY_INT32:  return SimpleMathOpSlowMod<int32_t>;
+      CASE_NPY_INT64:  return SimpleMathOpSlowMod<int64_t>;
+      CASE_NPY_UINT32: return SimpleMathOpSlowMod<uint32_t>;
+      CASE_NPY_UINT64: return SimpleMathOpSlowMod<uint64_t>;
+      case NPY_INT8:   return SimpleMathOpSlowMod<int8_t>;
+      case NPY_INT16:  return SimpleMathOpSlowMod<int16_t>;
+      case NPY_UINT8:  return SimpleMathOpSlowMod<uint8_t>;
+      case NPY_UINT16: return SimpleMathOpSlowMod<uint16_t>;
 
       }
       return NULL;
@@ -1236,14 +1236,14 @@ static ANY_TWO_FUNC GetSimpleMathOpSlow(int func, int scalarMode, int numpyInTyp
       case NPY_FLOAT:  return SimpleMathOpSlowPower<float>;
       case NPY_DOUBLE: return SimpleMathOpSlowPower<double>;
       case NPY_LONGDOUBLE: return SimpleMathOpSlowPower<long double>;
-      CASE_NPY_INT32:  return SimpleMathOpSlowPower<INT32>;
-      CASE_NPY_INT64:  return SimpleMathOpSlowPower<INT64>;
-      CASE_NPY_UINT32: return SimpleMathOpSlowPower<UINT32>;
-      CASE_NPY_UINT64: return SimpleMathOpSlowPower<UINT64>;
-      case NPY_INT8:   return SimpleMathOpSlowPower<INT8>;
-      case NPY_INT16:  return SimpleMathOpSlowPower<INT16>;
-      case NPY_UINT8:  return SimpleMathOpSlowPower<UINT8>;
-      case NPY_UINT16: return SimpleMathOpSlowPower<UINT16>;
+      CASE_NPY_INT32:  return SimpleMathOpSlowPower<int32_t>;
+      CASE_NPY_INT64:  return SimpleMathOpSlowPower<int64_t>;
+      CASE_NPY_UINT32: return SimpleMathOpSlowPower<uint32_t>;
+      CASE_NPY_UINT64: return SimpleMathOpSlowPower<uint64_t>;
+      case NPY_INT8:   return SimpleMathOpSlowPower<int8_t>;
+      case NPY_INT16:  return SimpleMathOpSlowPower<int16_t>;
+      case NPY_UINT8:  return SimpleMathOpSlowPower<uint8_t>;
+      case NPY_UINT16: return SimpleMathOpSlowPower<uint16_t>;
 
       }
       return NULL;
@@ -1461,13 +1461,13 @@ public:
          if (dtype <= NPY_ULONGLONG) {
             // this path includes bools
             int overflow = 0;
-            INT64 val = PyLong_AsLongLongAndOverflow(scalarObject, &overflow);
-            INT64 log2 = 64;
+            int64_t val = PyLong_AsLongLongAndOverflow(scalarObject, &overflow);
+            int64_t log2 = 64;
             if (!overflow) {
                int issigned = 0;
                if (val < 0) {
                   issigned = 1;   
-                  // Handle case of -128 which can exist in an INT8
+                  // Handle case of -128 which can exist in an int8_t
                   val = -(val + 1);
                }
                // Check for 0 due to builtin_clz issue
@@ -1497,7 +1497,7 @@ public:
                }
                int convertType1 = dtype;
                int convertType2 = scalar_dtype;
-               BOOL result = GetUpcastType(dtype, scalar_dtype, convertType1, convertType2, funcNumber);
+               bool result = GetUpcastType(dtype, scalar_dtype, convertType1, convertType2, funcNumber);
                LOGGING("Getting upcast %d %d, result %d  convert:%d\n", dtype, scalar_dtype, result, convertType1);
                if (result) {
                   return convertType1;
@@ -1542,7 +1542,7 @@ public:
             LOGGING("scalars dont match %d %d\n", scalarType, dtype);
             int convertType1 = dtype;
             int convertType2 = scalarType;
-            BOOL result = GetUpcastType(dtype, scalarType, convertType1, convertType2, funcNumber);
+            bool result = GetUpcastType(dtype, scalarType, convertType1, convertType2, funcNumber);
             if (result) {
                return convertType1;
             }
@@ -1603,7 +1603,7 @@ public:
    //-------------------------------------------------------------------
    // Arg1: defaultScalarType currently not used
    // returns FALSE on failure
-   BOOL CheckInputs(PyObject* args, int defaultScalarType, INT64 funcNumber) {
+   bool CheckInputs(PyObject* args, int defaultScalarType, int64_t funcNumber) {
       if (!PyTuple_CheckExact(args)) {
          PyErr_Format(PyExc_ValueError, "BasicMath arguments needs to be a tuple");
          return FALSE;
@@ -1635,7 +1635,7 @@ public:
 
    // Called from low level __add__ hook
    // If output is set, it came from an inplace operation and the ref count does not need to be incremented
-   BOOL CheckInputs(PyObject* input1, PyObject* input2, PyObject* output, INT64 funcNumber) {
+   bool CheckInputs(PyObject* input1, PyObject* input2, PyObject* output, int64_t funcNumber) {
       tupleSize = 2;
       inObject1 = input1;
       inObject2 = input2;
@@ -1652,9 +1652,9 @@ public:
    // Input: numpyInType1 and numpyInType2 must be set
    // Returns FALSE on error
    // 
-   BOOL CheckUpcast() {
+   bool CheckUpcast() {
       // Check if we need to upcast one or both of the arrays
-      // BOOL, NPY_INT8, NPY_UINT8
+      // bool, NPY_INT8, NPY_UINT8
       if (numpyInType1 != numpyInType2) {
          // Remove the ambiguous type
          if (numpyInType1 == 7 || numpyInType1 == 8) {
@@ -1676,7 +1676,7 @@ public:
          if (numpyInType1 != numpyInType2) {
             int convertType1 = numpyInType1;
             int convertType2 = numpyInType2;
-            BOOL result = GetUpcastType(numpyInType1, numpyInType2, convertType1, convertType2, funcNumber);
+            bool result = GetUpcastType(numpyInType1, numpyInType2, convertType1, convertType2, funcNumber);
             if (result) {
                if (numpyInType1 != convertType1 && convertType1 <= NPY_LONGDOUBLE) {
                   // Convert
@@ -1716,11 +1716,11 @@ public:
    // Common routine from array_ufunc or lower level slot hook
    // inObject1 is set and will get analyzed
    // inObject2 is set and will get analyzed
-   // funcNumber is passed because certain comparisons with INT64 <-> UINT64 dont need to get upcast to float64
-   BOOL CheckInputsInternal(int defaultScalarType, INT64 funcNumber) {
+   // funcNumber is passed because certain comparisons with int64_t <-> uint64_t dont need to get upcast to float64
+   bool CheckInputsInternal(int defaultScalarType, int64_t funcNumber) {
 
-      BOOL isArray1 = IsFastArrayOrNumpy((PyArrayObject*)inObject1);
-      BOOL isArray2 = IsFastArrayOrNumpy((PyArrayObject*)inObject2);
+      bool isArray1 = IsFastArrayOrNumpy((PyArrayObject*)inObject1);
+      bool isArray2 = IsFastArrayOrNumpy((PyArrayObject*)inObject2);
       isScalar1 = !isArray1;
       isScalar2 = !isArray2;
 
@@ -1832,10 +1832,10 @@ public:
          // Or the scalar is a larger integer and the second array is a small integer, or unisgned
 
          // pDataIn1 will be set pointing to 256 bit value
-         BOOL bResult=
+         bool bResult=
          ConvertScalarObject(inObject1, &m256Scalar1, numpyInType2, &pDataIn1, &itemSize1);
 
-         LOGGING("Converting first scalar type to %d, bresult: %d,  value: %lld  inObject1: %s\n", numpyInType2, bResult, *(INT64*)&m256Scalar1, inObject1->ob_type->tp_name);
+         LOGGING("Converting first scalar type to %d, bresult: %d,  value: %lld  inObject1: %s\n", numpyInType2, bResult, *(int64_t*)&m256Scalar1, inObject1->ob_type->tp_name);
 
          // TJD added this Dec 11, 2018
          numpyInType1 = numpyInType2;
@@ -1858,7 +1858,7 @@ public:
          //      scalarMode = SCALAR_MODE::FIRST_ARG_SCALAR;
 
          //      // NOTE: does not handle single array of bytes/unicode
-         //      BOOL bResult =
+         //      bool bResult =
          //         ConvertSingleItemArray(pDataIn1, GetArrDType(inArr), &m256Scalar1, numpyInType2);
 
          //      if (!bResult) return FALSE;
@@ -1880,10 +1880,10 @@ public:
          numpyInType2 = numpyInType1;
 
          // pDataIn2 will be set pointing to 256 bit value
-         BOOL bResult =
+         bool bResult =
          ConvertScalarObject(inObject2, &m256Scalar2, numpyInType1, &pDataIn2, &itemSize2);
 
-         LOGGING("Converting second scalar type to %d, bresult: %d,  value: %lld  type: %s\n", numpyInType1, bResult, *(INT64*)&m256Scalar2, inObject2->ob_type->tp_name);
+         LOGGING("Converting second scalar type to %d, bresult: %d,  value: %lld  type: %s\n", numpyInType1, bResult, *(int64_t*)&m256Scalar2, inObject2->ob_type->tp_name);
 
          if (!bResult) return FALSE;
 
@@ -1903,7 +1903,7 @@ public:
          //      scalarMode = SCALAR_MODE::SECOND_ARG_SCALAR;
 
          //      // broadcastable check  -- we always checkd for 1?
-         //      BOOL bResult =
+         //      bool bResult =
          //         ConvertSingleItemArray(pDataIn1, GetArrDType(inArr), &m256Scalar1, numpyInType2);
 
          //      if (!bResult) return FALSE;
@@ -1931,11 +1931,11 @@ public:
                numpyInType1 = GetArrDType(inArr);
                int convertType1 = numpyInType1;
                int convertType2 = numpyInType2;
-               BOOL result = GetUpcastType(numpyInType1, numpyInType2, convertType1, convertType2, funcNumber);
+               bool result = GetUpcastType(numpyInType1, numpyInType2, convertType1, convertType2, funcNumber);
                if (result) {
                   LOGGING("setting BM to first arg scalar from %d to %d.  ndim1: %d\n", numpyInType1, convertType1, ndim1);
                   // Convert
-                  BOOL bResult =
+                  bool bResult =
                      ConvertSingleItemArray(pDataIn1, numpyInType1, &m256Scalar1, convertType1);
 
                   if (!bResult) return FALSE;
@@ -1969,12 +1969,12 @@ public:
                numpyInType2 = GetArrDType(inArr2);
                int convertType1 = numpyInType1;
                int convertType2 = numpyInType2;
-               BOOL result = GetUpcastType(numpyInType1, numpyInType2, convertType1, convertType2, funcNumber);
+               bool result = GetUpcastType(numpyInType1, numpyInType2, convertType1, convertType2, funcNumber);
                if (result) {
                   LOGGING("setting BM to second arg scalar from %d to %d.  ndim2: %d\n", numpyInType2, convertType2, ndim2);
 
                   // Convert
-                  BOOL bResult =
+                  bool bResult =
                      ConvertSingleItemArray(pDataIn2, numpyInType2, &m256Scalar2, convertType2);
 
                   if (!bResult) return FALSE;
@@ -2006,7 +2006,7 @@ public:
             }
          } else {
             // Check if we need to upcast one or both of the arrays
-            // BOOL, NPY_INT8, NPY_UINT8
+            // bool, NPY_INT8, NPY_UINT8
             if (!CheckUpcast()) return FALSE;
          }
 
@@ -2043,7 +2043,7 @@ public:
          }
          else {
 
-            INT64 len3 = ArrayLength((PyArrayObject*)outputObject);
+            int64_t len3 = ArrayLength((PyArrayObject*)outputObject);
             LOGGING("oref %llu  len1:%lld  len2:%lld  len3: %lld\n", outputObject->ob_refcnt, len1, len2, len3);
             if (len3 < len2 || len3 < len1) {
                // something wrong with output size (gonna crash)
@@ -2074,7 +2074,7 @@ public:
          // a[1:] -= a[:-1]
          char* pOutput=PyArray_BYTES(returnObject);
          char* pOutputEnd = pOutput + ArrayLength(returnObject) * PyArray_ITEMSIZE(returnObject);
-         BOOL bOverlapProblem = FALSE;
+         bool bOverlapProblem = FALSE;
 
          if (len1) {
             if (pDataIn1 > pOutput && pDataIn1 < pOutputEnd) {
@@ -2114,7 +2114,7 @@ public:
          } else
          // Check for functions that always output a boolean
          if (len1 >= len2) {
-            LOGGING("Going to allocate for len1 type %d  %lld  %lld  %d %lld\n", wantOutType, len1, len2, ndim1, dims1 ? (INT64)dims1[0] : 0);
+            LOGGING("Going to allocate for len1 type %d  %lld  %lld  %d %lld\n", wantOutType, len1, len2, ndim1, dims1 ? (int64_t)dims1[0] : 0);
             if (ndim1 > 1) {
                returnObject = AllocateNumpyArray(ndim1, dims1, wantOutType, 0, (flags1 & flags2 & NPY_ARRAY_F_CONTIGUOUS) == NPY_ARRAY_F_CONTIGUOUS);
             }
@@ -2123,7 +2123,7 @@ public:
             }
          }
          else {
-            LOGGING("Going to allocate for len2 type %d  %lld  %lld  %d %lld\n", wantOutType, len1, len2, ndim2,  dims2 ? (INT64)dims2[0]: 0);
+            LOGGING("Going to allocate for len2 type %d  %lld  %lld  %d %lld\n", wantOutType, len1, len2, ndim2,  dims2 ? (int64_t)dims2[0]: 0);
             if (ndim2 > 1) {
                returnObject = AllocateNumpyArray(ndim2, dims2, wantOutType, 0, (flags1 & flags2 & NPY_ARRAY_F_CONTIGUOUS) == NPY_ARRAY_F_CONTIGUOUS);
             }
@@ -2160,11 +2160,11 @@ public:
    int            numpyInType2 = 0;
    npy_intp*      dims1 = 0;
    npy_intp*      dims2 = 0;
-   INT64          itemSize1 = 0;
-   INT64          itemSize2 = 0;
+   int64_t          itemSize1 = 0;
+   int64_t          itemSize2 = 0;
    // For 2 or 3 dim arrays, should be able to calculate length
-   INT64          len1 = 0;
-   INT64          len2 = 0;
+   int64_t          len1 = 0;
+   int64_t          len2 = 0;
    // flags are ANDED together to see if still F contiguous for > 1 dim output arrays
    int            flags1 = NPY_ARRAY_F_CONTIGUOUS;
    int            flags2 = NPY_ARRAY_F_CONTIGUOUS;
@@ -2188,9 +2188,9 @@ public:
    PyArrayObject* returnObject = NULL;
    PyObject*      outputObject = NULL;
 
-   INT32          scalarMode = SCALAR_MODE::NO_SCALARS;
-   BOOL           isScalar1 = FALSE;
-   BOOL           isScalar2 = FALSE;
+   int32_t          scalarMode = SCALAR_MODE::NO_SCALARS;
+   bool           isScalar1 = FALSE;
+   bool           isScalar2 = FALSE;
 
    Py_ssize_t     tupleSize = 0;
 
@@ -2199,7 +2199,7 @@ public:
 
    // For "where" the array size is already known
    // Set the expected length if known ahead of time
-   INT64          expectedLength = 0;
+   int64_t          expectedLength = 0;
 
 
 };
@@ -2209,26 +2209,26 @@ OLD_CALLBACK bmOldCallback;
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL BasicMathThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
-   BOOL didSomeWork = FALSE;
+static bool BasicMathThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
+   bool didSomeWork = FALSE;
    OLD_CALLBACK* OldCallback = (OLD_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
-   INT64 typeSizeIn = OldCallback->FunctionList->InputItemSize;
-   INT64 typeSizeOut = OldCallback->FunctionList->OutputItemSize;
+   int64_t typeSizeIn = OldCallback->FunctionList->InputItemSize;
+   int64_t typeSizeOut = OldCallback->FunctionList->OutputItemSize;
 
    char* pDataInX = (char *)OldCallback->pDataInBase1;
    char* pDataInX2 = (char *)OldCallback->pDataInBase2;
    char* pDataOutX = (char*)OldCallback->pDataOutBase1;
-   INT64 lenX;
-   INT64 workBlock;
+   int64_t lenX;
+   int64_t workBlock;
 
    // As long as there is work to do
    while ((lenX = pstWorkerItem->GetNextWorkBlock(&workBlock)) > 0) {
 
       // Calculate how much to adjust the pointers to get to the data for this work block
-      INT64 offsetAdj = pstWorkerItem->BlockSize * workBlock * typeSizeIn;
-      INT64 outputAdj = pstWorkerItem->BlockSize * workBlock * typeSizeOut;
-      //INT64 outputAdj = offsetAdj;
+      int64_t offsetAdj = pstWorkerItem->BlockSize * workBlock * typeSizeIn;
+      int64_t outputAdj = pstWorkerItem->BlockSize * workBlock * typeSizeOut;
+      //int64_t outputAdj = offsetAdj;
 
       THREADLOGGING("workblock %llu   len=%llu  offset=%llu \n", workBlock, lenX, offsetAdj);
       switch (OldCallback->ScalarMode) {
@@ -2268,7 +2268,7 @@ static BOOL BasicMathThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, in
 
 //------------------------------------------------------------------------------
 // 
-void WorkTwoStubCall(FUNCTION_LIST* anyTwoStubCall, void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+void WorkTwoStubCall(FUNCTION_LIST* anyTwoStubCall, void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
 
    //printf("worktwostub %d\n", scalarMode);
 
@@ -2302,14 +2302,14 @@ void WorkTwoStubCall(FUNCTION_LIST* anyTwoStubCall, void* pDataIn, void* pDataIn
 // Called when two strings are added
 //
 PyObject* ConcatTwoStrings(
-   INT32 scalarMode,
+   int32_t scalarMode,
    char* pStr1,
    char* pStr2,
-   INT64 itemSize1,
-   INT64 itemSize2,
-   INT64 length) {
+   int64_t itemSize1,
+   int64_t itemSize2,
+   int64_t length) {
 
-   INT64  itemSizeOut = itemSize1 + itemSize2;
+   int64_t  itemSizeOut = itemSize1 + itemSize2;
 
    //printf("concat two strings %lld %lld\n", itemSize1, itemSize2);
 
@@ -2322,7 +2322,7 @@ PyObject* ConcatTwoStrings(
       switch (scalarMode) {
       case SCALAR_MODE::NO_SCALARS:
 
-         for (INT64 i = 0; i < length; i++) {
+         for (int64_t i = 0; i < length; i++) {
             char* pOut1 = pOut + (itemSizeOut *i);
             char* pEndOut1 = pOut1 + itemSizeOut;
             char* pIn1 = pStr1 + (itemSize1 *i);
@@ -2345,7 +2345,7 @@ PyObject* ConcatTwoStrings(
          break;
 
       case SCALAR_MODE::FIRST_ARG_SCALAR:
-         for (INT64 i = 0; i < length; i++) {
+         for (int64_t i = 0; i < length; i++) {
             char* pOut1 = pOut + (itemSizeOut *i);
             char* pEndOut1 = pOut1 + itemSizeOut;
             char* pIn1 = pStr1;
@@ -2368,7 +2368,7 @@ PyObject* ConcatTwoStrings(
          break;
 
       case SCALAR_MODE::SECOND_ARG_SCALAR:
-         for (INT64 i = 0; i < length; i++) {
+         for (int64_t i = 0; i < length; i++) {
             char* pOut1 = pOut + (itemSizeOut *i);
             char* pEndOut1 = pOut1 + itemSizeOut;
             char* pIn1 = pStr1 + (itemSize1 *i);
@@ -2399,17 +2399,17 @@ PyObject* ConcatTwoStrings(
 // Called when two unicode are added
 //
 PyObject* ConcatTwoUnicodes(
-   INT32 scalarMode,
-   UINT32* pStr1,
-   UINT32* pStr2,
-   INT64 itemSize1,
-   INT64 itemSize2,
-   INT64 length) {
+   int32_t scalarMode,
+   uint32_t* pStr1,
+   uint32_t* pStr2,
+   int64_t itemSize1,
+   int64_t itemSize2,
+   int64_t length) {
 
    itemSize1 = itemSize1 / 4;
    itemSize2 = itemSize2 / 4;
 
-   INT64  itemSizeOut = itemSize1 + itemSize2;
+   int64_t  itemSizeOut = itemSize1 + itemSize2;
 
    //printf("concat two unicode %lld %lld\n", itemSize1, itemSize2);
 
@@ -2417,16 +2417,16 @@ PyObject* ConcatTwoUnicodes(
    CHECK_MEMORY_ERROR(pNewString);
 
    if (pNewString) {
-      UINT32 *pOut = (UINT32*)PyArray_BYTES(pNewString);
+      uint32_t *pOut = (uint32_t*)PyArray_BYTES(pNewString);
       switch (scalarMode) {
       case SCALAR_MODE::NO_SCALARS:
-         for (INT64 i = 0; i < length; i++) {
-            UINT32* pOut1 = pOut + (itemSizeOut *i);
-            UINT32* pEndOut1 = pOut1 + itemSizeOut;
-            UINT32* pIn1 = pStr1 + (itemSize1 *i);
-            UINT32* pEnd1 = pIn1 + itemSize1;
-            UINT32* pIn2 = pStr2 + (itemSize2 *i);
-            UINT32* pEnd2 = pIn2 + itemSize2;
+         for (int64_t i = 0; i < length; i++) {
+            uint32_t* pOut1 = pOut + (itemSizeOut *i);
+            uint32_t* pEndOut1 = pOut1 + itemSizeOut;
+            uint32_t* pIn1 = pStr1 + (itemSize1 *i);
+            uint32_t* pEnd1 = pIn1 + itemSize1;
+            uint32_t* pIn2 = pStr2 + (itemSize2 *i);
+            uint32_t* pEnd2 = pIn2 + itemSize2;
 
             //printf("%lld %lld ", i, pEndOut1 - pOut1);
 
@@ -2447,13 +2447,13 @@ PyObject* ConcatTwoUnicodes(
          }
          break;
       case SCALAR_MODE::FIRST_ARG_SCALAR:
-         for (INT64 i = 0; i < length; i++) {
-            UINT32* pOut1 = pOut + (itemSizeOut *i);
-            UINT32* pEndOut1 = pOut1 + itemSizeOut;
-            UINT32* pIn1 = pStr1;
-            UINT32* pEnd1 = pIn1 + itemSize1;
-            UINT32* pIn2 = pStr2 + (itemSize2 *i);
-            UINT32* pEnd2 = pIn2 + itemSize2;
+         for (int64_t i = 0; i < length; i++) {
+            uint32_t* pOut1 = pOut + (itemSizeOut *i);
+            uint32_t* pEndOut1 = pOut1 + itemSizeOut;
+            uint32_t* pIn1 = pStr1;
+            uint32_t* pEnd1 = pIn1 + itemSize1;
+            uint32_t* pIn2 = pStr2 + (itemSize2 *i);
+            uint32_t* pEnd2 = pIn2 + itemSize2;
 
             //printf("%lld %lld ", i, pEndOut1 - pOut1);
 
@@ -2474,13 +2474,13 @@ PyObject* ConcatTwoUnicodes(
          }
          break;
       case SCALAR_MODE::SECOND_ARG_SCALAR:
-         for (INT64 i = 0; i < length; i++) {
-            UINT32* pOut1 = pOut + (itemSizeOut *i);
-            UINT32* pEndOut1 = pOut1 + itemSizeOut;
-            UINT32* pIn1 = pStr1 + (itemSize1 *i);
-            UINT32* pEnd1 = pIn1 + itemSize1;
-            UINT32* pIn2 = pStr2;
-            UINT32* pEnd2 = pIn2 + itemSize2;
+         for (int64_t i = 0; i < length; i++) {
+            uint32_t* pOut1 = pOut + (itemSizeOut *i);
+            uint32_t* pEndOut1 = pOut1 + itemSizeOut;
+            uint32_t* pIn1 = pStr1 + (itemSize1 *i);
+            uint32_t* pEnd1 = pIn1 + itemSize1;
+            uint32_t* pIn2 = pStr2;
+            uint32_t* pEnd2 = pIn2 + itemSize2;
 
             //printf("%lld %lld ", i, pEndOut1 - pOut1);
 
@@ -2511,7 +2511,7 @@ PyObject* ConcatTwoUnicodes(
 // Called when adding two strings
 // May return NULL on failure, else new string array
 static PyObject* PossiblyAddUnicode(CTwoInputs&  twoInputs) {
-   INT32 inType = -1;
+   int32_t inType = -1;
 
    if (twoInputs.scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR && (twoInputs.numpyInType2 == NPY_STRING || twoInputs.numpyInType2 == NPY_UNICODE)) {
       inType = twoInputs.numpyInType2;
@@ -2542,8 +2542,8 @@ static PyObject* PossiblyAddUnicode(CTwoInputs&  twoInputs) {
          //printf("before call\n");
          return ConcatTwoUnicodes(
             twoInputs.scalarMode,
-            (UINT32*)twoInputs.pDataIn1,
-            (UINT32*)twoInputs.pDataIn2,
+            (uint32_t*)twoInputs.pDataIn1,
+            (uint32_t*)twoInputs.pDataIn2,
             twoInputs.itemSize1,
             twoInputs.itemSize2,
             twoInputs.len1 >= twoInputs.len2 ? twoInputs.len1 : twoInputs.len2);
@@ -2563,7 +2563,7 @@ static PyObject* PossiblyAddUnicode(CTwoInputs&  twoInputs) {
 //
 // If NONE is returned, punt to numpy
 PyObject *
-TwoInputsInternal(CTwoInputs&  twoInputs, INT64 funcNumber) {
+TwoInputsInternal(CTwoInputs&  twoInputs, int64_t funcNumber) {
 
    // SPECIAL HOOK FOR ADDING TWO STRINGS -------------------------
    if (funcNumber == MATH_OPERATION::ADD) {
@@ -2652,8 +2652,8 @@ TwoInputsInternal(CTwoInputs&  twoInputs, INT64 funcNumber) {
 PyObject *
 BasicMathTwoInputs(PyObject *self, PyObject *args) {
    PyObject* tuple = NULL;
-   INT64 funcNumber;
-   INT64 numpyOutputType;
+   int64_t funcNumber;
+   int64_t numpyOutputType;
 
    if (Py_SIZE(args) != 3) {
       PyErr_Format(PyExc_ValueError, "BasicMathTwoInputs requires three inputs: tuple, long, long");
@@ -2673,7 +2673,7 @@ BasicMathTwoInputs(PyObject *self, PyObject *args) {
    CTwoInputs  twoInputs((int)numpyOutputType, (int)funcNumber);
 
    // Check the inputs to see if the user request makes sense
-   BOOL result =
+   bool result =
    twoInputs.CheckInputs(tuple, 0, funcNumber);
 
    if (result) {
@@ -2689,12 +2689,12 @@ BasicMathTwoInputs(PyObject *self, PyObject *args) {
 // Called internally when type class numbermethod called
 // inputOut can be NULL if there is no output array
 PyObject *
-BasicMathTwoInputsFromNumber(PyObject* input1, PyObject* input2, PyObject* output, INT64 funcNumber) {
+BasicMathTwoInputsFromNumber(PyObject* input1, PyObject* input2, PyObject* output, int64_t funcNumber) {
 
    CTwoInputs  twoInputs((int)0, (int)funcNumber);
 
    // Check the inputs to see if the user request makes sense
-   BOOL result = FALSE;
+   bool result = FALSE;
    result = twoInputs.CheckInputs(input1, input2, output, funcNumber);
 
    if (result) {
@@ -2709,31 +2709,31 @@ BasicMathTwoInputsFromNumber(PyObject* input1, PyObject* input2, PyObject* outpu
 
 // MT callback
 struct WhereCallbackStruct {
-   INT8*    pBooleanMask;  // condition
+   int8_t*    pBooleanMask;  // condition
    void*    pValuesOut; 
    void*    pChoice1;
    void*    pChoice2;
-   INT64    itemSize;      // of output array, used for strings
-   INT64    strideSize1;
-   INT64    strideSize2;
-   INT64    strideSize3;
-   INT32    scalarMode;
+   int64_t    itemSize;      // of output array, used for strings
+   int64_t    strideSize1;
+   int64_t    strideSize2;
+   int64_t    strideSize3;
+   int32_t    scalarMode;
 };
 
 
 template<typename T>
-BOOL WhereCallback(void* callbackArgT, int core, INT64 start, INT64 length) {
+bool WhereCallback(void* callbackArgT, int core, int64_t start, int64_t length) {
 
    WhereCallbackStruct* pCallback = (WhereCallbackStruct*)callbackArgT;
    bool*   pCondition = (bool*)pCallback->pBooleanMask;
    T*       pOutput = (T*)pCallback->pValuesOut;
    T*       pInput1 = (T*)pCallback->pChoice1;
    T*       pInput2 = (T*)pCallback->pChoice2;
-   INT64    strides1 = pCallback->strideSize1;
-   INT64    strides2 = pCallback->strideSize2;
-   INT64    strides3 = pCallback->strideSize3;
+   int64_t    strides1 = pCallback->strideSize1;
+   int64_t    strides2 = pCallback->strideSize2;
+   int64_t    strides3 = pCallback->strideSize3;
 
-   INT64    itemSize = pCallback->itemSize;
+   int64_t    itemSize = pCallback->itemSize;
    pCondition = &pCondition[start];
    pOutput = &pOutput[start];
 
@@ -2762,18 +2762,18 @@ BOOL WhereCallback(void* callbackArgT, int core, INT64 start, INT64 length) {
 
          // calculate the address delta since we know input1 and input2 are the same itemsize
          // assumes 64bit addressing
-         UINT64 delta = pInput2 - pInput1;
-         UINT64 ulength = (UINT64)length;
+         uint64_t delta = pInput2 - pInput1;
+         uint64_t ulength = (uint64_t)length;
 
-         for (UINT64 i = 0; i < ulength; i++) {
+         for (uint64_t i = 0; i < ulength; i++) {
             // The condition is either 1 or 0.  if 1 we use the address delta to get from input2 to input1
-            UINT64 test = pCondition[i] == 0;
+            uint64_t test = pCondition[i] == 0;
             pOutput[i]= pInput1[i + delta * test];
          }
 
          // This is slower on msft windows compiler
          // does not produce cmove (conditional move instruction)
-         //for (UINT64 i = 0; i < ulength; i++) {
+         //for (uint64_t i = 0; i < ulength; i++) {
          //   // The condition is either 1 or 0.  if 1 we use the address delta to get from input2 to input1
          //   T* address = pCondition[i] ? pInput1 : pInput2;
          //   pOutput[i] = address[i];
@@ -2784,7 +2784,7 @@ BOOL WhereCallback(void* callbackArgT, int core, INT64 start, INT64 length) {
       case SCALAR_MODE::FIRST_ARG_SCALAR:
       {
          T input1 = pInput1[0];
-         for (INT64 i = 0; i < length; i++) {
+         for (int64_t i = 0; i < length; i++) {
             pOutput[i] = pCondition[i] ? input1 : pInput2[i];
          }
       }
@@ -2792,7 +2792,7 @@ BOOL WhereCallback(void* callbackArgT, int core, INT64 start, INT64 length) {
       case SCALAR_MODE::SECOND_ARG_SCALAR:
       {
          T input2 = pInput2[0];
-         for (INT64 i = 0; i < length; i++) {
+         for (int64_t i = 0; i < length; i++) {
             pOutput[i] = pCondition[i] ? pInput1[i] : input2;
          }
       }
@@ -2801,7 +2801,7 @@ BOOL WhereCallback(void* callbackArgT, int core, INT64 start, INT64 length) {
       {
          T input1 = pInput1[0];
          T input2 = pInput2[0];
-         for (INT64 i = 0; i < length; i++) {
+         for (int64_t i = 0; i < length; i++) {
             pOutput[i] = pCondition[i] ? input1 : input2;
          }
       }
@@ -2813,7 +2813,7 @@ BOOL WhereCallback(void* callbackArgT, int core, INT64 start, INT64 length) {
       switch (pCallback->scalarMode) {
       case SCALAR_MODE::NO_SCALARS:
       {
-         for (INT64 i = 0; i < length; i++) {
+         for (int64_t i = 0; i < length; i++) {
             if (pCondition[i]) {
                pOutput[i] = pInput1[i*strides1];
             }
@@ -2825,7 +2825,7 @@ BOOL WhereCallback(void* callbackArgT, int core, INT64 start, INT64 length) {
       break;
       case SCALAR_MODE::FIRST_ARG_SCALAR:
       {
-         for (INT64 i = 0; i < length; i++) {
+         for (int64_t i = 0; i < length; i++) {
             if (pCondition[i]) {
                pOutput[i] = pInput1[0];
             }
@@ -2837,7 +2837,7 @@ BOOL WhereCallback(void* callbackArgT, int core, INT64 start, INT64 length) {
       break;
       case SCALAR_MODE::SECOND_ARG_SCALAR:
       {
-         for (INT64 i = 0; i < length; i++) {
+         for (int64_t i = 0; i < length; i++) {
             if (pCondition[i]) {
                pOutput[i] = pInput1[i*strides1];
             }
@@ -2849,7 +2849,7 @@ BOOL WhereCallback(void* callbackArgT, int core, INT64 start, INT64 length) {
       break;
       case SCALAR_MODE::BOTH_SCALAR:
       {
-         for (INT64 i = 0; i < length; i++) {
+         for (int64_t i = 0; i < length; i++) {
             if (pCondition[i]) {
                pOutput[i] = pInput1[0];
             }
@@ -2867,20 +2867,20 @@ BOOL WhereCallback(void* callbackArgT, int core, INT64 start, INT64 length) {
 
 //========================================================================
 // callback return for strings or odd itemsizes
-BOOL WhereCallbackString(void* callbackArgT, int core, INT64 start, INT64 length) {
+bool WhereCallbackString(void* callbackArgT, int core, int64_t start, int64_t length) {
 
    WhereCallbackStruct* pCallback = (WhereCallbackStruct*)callbackArgT;
-   INT8*    pCondition = pCallback->pBooleanMask;
+   int8_t*    pCondition = pCallback->pBooleanMask;
    char*    pOutput = (char*)pCallback->pValuesOut;
    char*    pInput1 = (char*)pCallback->pChoice1;
    char*    pInput2 = (char*)pCallback->pChoice2;
-   INT64    itemSize = pCallback->itemSize;
+   int64_t    itemSize = pCallback->itemSize;
 
    // BUG BUG what if... itemsize is small?
    switch (pCallback->scalarMode) {
    case SCALAR_MODE::NO_SCALARS:
    {
-      for (INT64 i = start; i < (start + length); i++) {
+      for (int64_t i = start; i < (start + length); i++) {
          if (pCondition[i]) {
             memcpy(&pOutput[i*itemSize], &pInput1[i*itemSize], itemSize);
          }
@@ -2892,7 +2892,7 @@ BOOL WhereCallbackString(void* callbackArgT, int core, INT64 start, INT64 length
    break;
    case SCALAR_MODE::FIRST_ARG_SCALAR:
    {
-      for (INT64 i = start; i < (start + length); i++) {
+      for (int64_t i = start; i < (start + length); i++) {
          if (pCondition[i]) {
             memcpy(&pOutput[i*itemSize], pInput1, itemSize);
          }
@@ -2904,7 +2904,7 @@ BOOL WhereCallbackString(void* callbackArgT, int core, INT64 start, INT64 length
    break;
    case SCALAR_MODE::SECOND_ARG_SCALAR:
    {
-      for (INT64 i = start; i < (start + length); i++) {
+      for (int64_t i = start; i < (start + length); i++) {
          if (pCondition[i]) {
             memcpy(&pOutput[i*itemSize], &pInput1[i*itemSize], itemSize);
          }
@@ -2916,7 +2916,7 @@ BOOL WhereCallbackString(void* callbackArgT, int core, INT64 start, INT64 length
    break;
    case SCALAR_MODE::BOTH_SCALAR:
    {
-      for (INT64 i = start; i < (start + length); i++) {
+      for (int64_t i = start; i < (start + length); i++) {
          if (pCondition[i]) {
             memcpy(&pOutput[i*itemSize], pInput1, itemSize);
          }
@@ -2944,8 +2944,8 @@ PyObject *
 Where(PyObject *self, PyObject *args) {
    PyArrayObject *inBool1 = NULL;
    PyObject* tuple = NULL;
-   INT64 numpyOutputType;
-   INT64 numpyItemSize;
+   int64_t numpyOutputType;
+   int64_t numpyItemSize;
 
    if (!PyArg_ParseTuple(
       args, "O!OLL",
@@ -2971,13 +2971,13 @@ Where(PyObject *self, PyObject *args) {
    CTwoInputs  twoInputs( (int)numpyOutputType, 0);
 
    // get length of boolean array
-   INT64 length = ArrayLength(inBool1);
+   int64_t length = ArrayLength(inBool1);
    twoInputs.expectedLength = length;
 
    LOGGING("Where: Examining data for func types: %d %d\n", twoInputs.numpyInType1, twoInputs.numpyInType2);
 
    // Check the inputs to see if the user request makes sense
-   BOOL result = FALSE;
+   bool result = FALSE;
 
    result = twoInputs.CheckInputs(tuple, 0, MATH_OPERATION::WHERE);
 
@@ -2994,12 +2994,12 @@ Where(PyObject *self, PyObject *args) {
       CHECK_MEMORY_ERROR(outputArray);
 
       if (outputArray) {
-         INT8* pCondition = (INT8*)PyArray_BYTES(inBool1);
+         int8_t* pCondition = (int8_t*)PyArray_BYTES(inBool1);
          void* pOutput = PyArray_BYTES(outputArray);
 
          // for scalar strings, the item size is twoInputs.itemSize1
-         INT64 itemSize1 = twoInputs.itemSize1;
-         INT64 itemSize2 = twoInputs.itemSize2;
+         int64_t itemSize1 = twoInputs.itemSize1;
+         int64_t itemSize2 = twoInputs.itemSize2;
          char* pInput1 = (char*)twoInputs.pDataIn1;
          char* pInput2 = (char*)twoInputs.pDataIn2;
 
@@ -3048,16 +3048,16 @@ Where(PyObject *self, PyObject *args) {
 
          switch (numpyItemSize) {
          case 1:
-            g_cMathWorker->DoMultiThreadedChunkWork(length, WhereCallback<INT8>, &WCBS);
+            g_cMathWorker->DoMultiThreadedChunkWork(length, WhereCallback<int8_t>, &WCBS);
             break;
          case 2:
-            g_cMathWorker->DoMultiThreadedChunkWork(length, WhereCallback<INT16>, &WCBS);
+            g_cMathWorker->DoMultiThreadedChunkWork(length, WhereCallback<int16_t>, &WCBS);
             break;
          case 4:
-            g_cMathWorker->DoMultiThreadedChunkWork(length, WhereCallback<INT32>, &WCBS);
+            g_cMathWorker->DoMultiThreadedChunkWork(length, WhereCallback<int32_t>, &WCBS);
             break;
          case 8:
-            g_cMathWorker->DoMultiThreadedChunkWork(length, WhereCallback<INT64>, &WCBS);
+            g_cMathWorker->DoMultiThreadedChunkWork(length, WhereCallback<int64_t>, &WCBS);
             break;
          default:
             g_cMathWorker->DoMultiThreadedChunkWork(length, WhereCallbackString, &WCBS);

--- a/src/BasicMath.h
+++ b/src/BasicMath.h
@@ -5,7 +5,7 @@ PyObject *
 BasicMathTwoInputs(PyObject *self, PyObject *args);
 
 PyObject *
-BasicMathTwoInputsFromNumber(PyObject* input1, PyObject* input2, PyObject* output, INT64 funcNumber);
+BasicMathTwoInputsFromNumber(PyObject* input1, PyObject* input2, PyObject* output, int64_t funcNumber);
 
 PyObject *
 Where(PyObject *self, PyObject *args);

--- a/src/Bins.cpp
+++ b/src/Bins.cpp
@@ -82,8 +82,8 @@ REINDEXCALLBACK ReIndexer(int64_t itemSize, int dtypeIndex) {
    // Get the dtype for the INDEXER (should be int32_t or INT64)
    switch (dtypeIndex) {
 
-   case NPY_INT32:
-   case NPY_UINT32:
+   case NPY_INT:
+   case NPY_UINT:
       return ReIndexDataStep1<int32_t>(itemSize);
    case NPY_UINT64:
    case NPY_ULONGLONG:
@@ -247,7 +247,7 @@ REMAP_INDEX ReMapIndexStep1(int numpyOutputType) {
    case NPY_INT16:
       return ReMapIndex<T, int16_t>;
       break;
-   case NPY_INT32:
+   case NPY_INT:
       return ReMapIndex<T, int32_t>;
       break;
    case NPY_INT64:
@@ -286,7 +286,7 @@ PyObject* ReMapIndex(PyObject *self, PyObject *args) {
       &PyArray_Type, &remapArr1)) return NULL;
 
 
-   if (PyArray_TYPE(remapArr1) != NPY_INT32) {
+   if (PyArray_TYPE(remapArr1) != NPY_INT) {
 
       PyErr_Format(PyExc_ValueError, "third arg array must be NPY_int32_t -- not %d", PyArray_TYPE(remapArr1));
    }
@@ -303,7 +303,7 @@ PyObject* ReMapIndex(PyObject *self, PyObject *args) {
       case NPY_INT16:
          func = ReMapIndexStep1<int16_t>(numpyOutType);
          break;
-      case NPY_INT32:
+      case NPY_INT:
          func = ReMapIndexStep1<int32_t>(numpyOutType);
          break;
       case NPY_INT64:
@@ -425,7 +425,7 @@ GetNanInfCount(int numpyInType) {
    case NPY_INT16:
       result = NanInfCount<int16_t, U>;
       break;
-   case NPY_INT32:
+   case NPY_INT:
       result = NanInfCount<int32_t, U>;
       break;
    case NPY_INT64:
@@ -438,7 +438,7 @@ GetNanInfCount(int numpyInType) {
    case NPY_UINT16:
       result = NanInfCount<uint16_t, U>;
       break;
-   case NPY_UINT32:
+   case NPY_UINT:
       result = NanInfCount<uint32_t, U>;
       break;
    case NPY_UINT64:
@@ -481,7 +481,7 @@ PyObject* NanInfCountFromSort(PyObject *self, PyObject *args) {
          NAN_INF_COUNT func = nullptr;
 
          switch (numpyIndexType) {
-         case NPY_INT32:
+         case NPY_INT:
             func = GetNanInfCount<int32_t>(numpyInType);
             break;
          case NPY_INT64:
@@ -628,7 +628,7 @@ GetMakeBinsSorted(int numpyInType) {
    case NPY_INT16:
       result = MakeBinsSorted<int16_t, U, V>;
       break;
-   case NPY_INT32:
+   case NPY_INT:
       result = MakeBinsSorted<int32_t, U, V>;
       break;
    case NPY_INT64:
@@ -641,7 +641,7 @@ GetMakeBinsSorted(int numpyInType) {
    case NPY_UINT16:
       result = MakeBinsSorted<uint16_t, U, V>;
       break;
-   case NPY_UINT32:
+   case NPY_UINT:
       result = MakeBinsSorted<uint32_t, U, V>;
       break;
    case NPY_UINT64:
@@ -721,7 +721,7 @@ PyObject* BinsToCutsSorted(PyObject *self, PyObject *args) {
       MAKE_BINS_SORTED func = NULL;
 
       switch (numpyIndexType) {
-      case NPY_INT32:
+      case NPY_INT:
          switch (binmode) {
          case 0:
             func = GetMakeBinsSorted<int32_t, int8_t>(numpyInType);
@@ -767,7 +767,7 @@ PyObject* BinsToCutsSorted(PyObject *self, PyObject *args) {
             result = AllocateLikeNumpyArray(inArr1, NPY_INT16);
             break;
          case 2:
-            result = AllocateLikeNumpyArray(inArr1, NPY_INT32);
+            result = AllocateLikeNumpyArray(inArr1, NPY_INT);
             break;
          case 3:
             result = AllocateLikeNumpyArray(inArr1, NPY_INT64);
@@ -1456,7 +1456,7 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_INT16:
          result = MakeBinsBSearch<int16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_INT32:
+      case NPY_INT:
          result = MakeBinsBSearch<int32_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_INT64:
@@ -1469,7 +1469,7 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_UINT16:
          result = MakeBinsBSearch<uint16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_UINT32:
+      case NPY_UINT:
          result = MakeBinsBSearch<uint32_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT64:
@@ -1500,7 +1500,7 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_INT16:
          result = SearchSortedLeft<int16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_INT32:
+      case NPY_INT:
          result = SearchSortedLeft<int32_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_INT64:
@@ -1513,7 +1513,7 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_UINT16:
          result = SearchSortedLeft<uint16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_UINT32:
+      case NPY_UINT:
          result = SearchSortedLeft<uint32_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT64:
@@ -1544,7 +1544,7 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_INT16:
          result = SearchSortedRight<int16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_INT32:
+      case NPY_INT:
          result = SearchSortedRight<int32_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_INT64:
@@ -1557,7 +1557,7 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_UINT16:
          result = SearchSortedRight<uint16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_UINT32:
+      case NPY_UINT:
          result = SearchSortedRight<uint32_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT64:
@@ -1594,7 +1594,7 @@ GetMakeBinsBSearch(int numpyInType, int binType, int searchMode) {
    case NPY_INT16:
       result = GetMakeBinsBSearchPart2<OUT_TYPE, int16_t>(numpyInType, searchMode);
       break;
-   case NPY_INT32:
+   case NPY_INT:
       result = GetMakeBinsBSearchPart2<OUT_TYPE, int32_t>(numpyInType, searchMode);
       break;
       // NO UINT8/16/32?
@@ -1698,7 +1698,7 @@ PyObject* BinsToCutsBSearch(PyObject *self, PyObject *args) {
          result = AllocateLikeNumpyArray(inArr1, NPY_INT16);
          break;
       case 2:
-         result = AllocateLikeNumpyArray(inArr1, NPY_INT32);
+         result = AllocateLikeNumpyArray(inArr1, NPY_INT);
          break;
       case 3:
          result = AllocateLikeNumpyArray(inArr1, NPY_INT64);

--- a/src/Bins.cpp
+++ b/src/Bins.cpp
@@ -82,8 +82,8 @@ REINDEXCALLBACK ReIndexer(int64_t itemSize, int dtypeIndex) {
    // Get the dtype for the INDEXER (should be int32_t or INT64)
    switch (dtypeIndex) {
 
-   case NPY_INT:
-   case NPY_UINT:
+   case NPY_INT32:
+   case NPY_UINT32:
       return ReIndexDataStep1<int32_t>(itemSize);
    case NPY_UINT64:
    case NPY_ULONGLONG:
@@ -247,7 +247,7 @@ REMAP_INDEX ReMapIndexStep1(int numpyOutputType) {
    case NPY_INT16:
       return ReMapIndex<T, int16_t>;
       break;
-   case NPY_INT:
+   case NPY_INT32:
       return ReMapIndex<T, int32_t>;
       break;
    case NPY_INT64:
@@ -286,7 +286,7 @@ PyObject* ReMapIndex(PyObject *self, PyObject *args) {
       &PyArray_Type, &remapArr1)) return NULL;
 
 
-   if (PyArray_TYPE(remapArr1) != NPY_INT) {
+   if (PyArray_TYPE(remapArr1) != NPY_INT32) {
 
       PyErr_Format(PyExc_ValueError, "third arg array must be NPY_int32_t -- not %d", PyArray_TYPE(remapArr1));
    }
@@ -303,7 +303,7 @@ PyObject* ReMapIndex(PyObject *self, PyObject *args) {
       case NPY_INT16:
          func = ReMapIndexStep1<int16_t>(numpyOutType);
          break;
-      case NPY_INT:
+      case NPY_INT32:
          func = ReMapIndexStep1<int32_t>(numpyOutType);
          break;
       case NPY_INT64:
@@ -425,7 +425,7 @@ GetNanInfCount(int numpyInType) {
    case NPY_INT16:
       result = NanInfCount<int16_t, U>;
       break;
-   case NPY_INT:
+   case NPY_INT32:
       result = NanInfCount<int32_t, U>;
       break;
    case NPY_INT64:
@@ -438,7 +438,7 @@ GetNanInfCount(int numpyInType) {
    case NPY_UINT16:
       result = NanInfCount<uint16_t, U>;
       break;
-   case NPY_UINT:
+   case NPY_UINT32:
       result = NanInfCount<uint32_t, U>;
       break;
    case NPY_UINT64:
@@ -481,7 +481,7 @@ PyObject* NanInfCountFromSort(PyObject *self, PyObject *args) {
          NAN_INF_COUNT func = nullptr;
 
          switch (numpyIndexType) {
-         case NPY_INT:
+         case NPY_INT32:
             func = GetNanInfCount<int32_t>(numpyInType);
             break;
          case NPY_INT64:
@@ -628,7 +628,7 @@ GetMakeBinsSorted(int numpyInType) {
    case NPY_INT16:
       result = MakeBinsSorted<int16_t, U, V>;
       break;
-   case NPY_INT:
+   case NPY_INT32:
       result = MakeBinsSorted<int32_t, U, V>;
       break;
    case NPY_INT64:
@@ -641,7 +641,7 @@ GetMakeBinsSorted(int numpyInType) {
    case NPY_UINT16:
       result = MakeBinsSorted<uint16_t, U, V>;
       break;
-   case NPY_UINT:
+   case NPY_UINT32:
       result = MakeBinsSorted<uint32_t, U, V>;
       break;
    case NPY_UINT64:
@@ -721,7 +721,7 @@ PyObject* BinsToCutsSorted(PyObject *self, PyObject *args) {
       MAKE_BINS_SORTED func = NULL;
 
       switch (numpyIndexType) {
-      case NPY_INT:
+      case NPY_INT32:
          switch (binmode) {
          case 0:
             func = GetMakeBinsSorted<int32_t, int8_t>(numpyInType);
@@ -767,7 +767,7 @@ PyObject* BinsToCutsSorted(PyObject *self, PyObject *args) {
             result = AllocateLikeNumpyArray(inArr1, NPY_INT16);
             break;
          case 2:
-            result = AllocateLikeNumpyArray(inArr1, NPY_INT);
+            result = AllocateLikeNumpyArray(inArr1, NPY_INT32);
             break;
          case 3:
             result = AllocateLikeNumpyArray(inArr1, NPY_INT64);
@@ -1456,7 +1456,7 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_INT16:
          result = MakeBinsBSearch<int16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_INT:
+      case NPY_INT32:
          result = MakeBinsBSearch<int32_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_INT64:
@@ -1469,7 +1469,7 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_UINT16:
          result = MakeBinsBSearch<uint16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_UINT:
+      case NPY_UINT32:
          result = MakeBinsBSearch<uint32_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT64:
@@ -1500,7 +1500,7 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_INT16:
          result = SearchSortedLeft<int16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_INT:
+      case NPY_INT32:
          result = SearchSortedLeft<int32_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_INT64:
@@ -1513,7 +1513,7 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_UINT16:
          result = SearchSortedLeft<uint16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_UINT:
+      case NPY_UINT32:
          result = SearchSortedLeft<uint32_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT64:
@@ -1544,7 +1544,7 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_INT16:
          result = SearchSortedRight<int16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_INT:
+      case NPY_INT32:
          result = SearchSortedRight<int32_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_INT64:
@@ -1557,7 +1557,7 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_UINT16:
          result = SearchSortedRight<uint16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_UINT:
+      case NPY_UINT32:
          result = SearchSortedRight<uint32_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT64:
@@ -1594,7 +1594,7 @@ GetMakeBinsBSearch(int numpyInType, int binType, int searchMode) {
    case NPY_INT16:
       result = GetMakeBinsBSearchPart2<OUT_TYPE, int16_t>(numpyInType, searchMode);
       break;
-   case NPY_INT:
+   case NPY_INT32:
       result = GetMakeBinsBSearchPart2<OUT_TYPE, int32_t>(numpyInType, searchMode);
       break;
       // NO UINT8/16/32?
@@ -1698,7 +1698,7 @@ PyObject* BinsToCutsBSearch(PyObject *self, PyObject *args) {
          result = AllocateLikeNumpyArray(inArr1, NPY_INT16);
          break;
       case 2:
-         result = AllocateLikeNumpyArray(inArr1, NPY_INT);
+         result = AllocateLikeNumpyArray(inArr1, NPY_INT32);
          break;
       case 3:
          result = AllocateLikeNumpyArray(inArr1, NPY_INT64);

--- a/src/Bins.cpp
+++ b/src/Bins.cpp
@@ -10,23 +10,23 @@
 //#define LOGGING printf
 
 //--------------------------------------------------------------------------
-typedef  void(*REINDEXCALLBACK)(void* pDataOut, void* pDataIn, void* pIndex1, INT64 indexLen, INT64 itemSize);
+typedef  void(*REINDEXCALLBACK)(void* pDataOut, void* pDataIn, void* pIndex1, int64_t indexLen, int64_t itemSize);
 
 //===============================================================================================================
 //--------------------------------------------------------
-// T is the type of the index -- usually INT32 or INT64
+// T is the type of the index -- usually int32_t or INT64
 // U is a datatype = to the itemsize
 // The INDEXER is auto incremented by its type size
 // The Out is auto incremented by itemsize
 // The pDataIn MUST be passed as the base pointer
 // size is the block size
 template<typename T, typename U>
-void ReIndexData(void* pDataOut, void* pDataIn, void* pIndex1, INT64 size, INT64 itemSize) {
+void ReIndexData(void* pDataOut, void* pDataIn, void* pIndex1, int64_t size, int64_t itemSize) {
    U* pOut = (U*)pDataOut;
    U* pIn = (U*)pDataIn;
    T* pIndex = (T*)pIndex1;
 
-   for (INT64 i = 0; i < size; i++) {
+   for (int64_t i = 0; i < size; i++) {
       T index = pIndex[i];
       pOut[i] = pIn[index];
    }
@@ -34,18 +34,18 @@ void ReIndexData(void* pDataOut, void* pDataIn, void* pIndex1, INT64 size, INT64
 }
 
 //--------------------------------------------------------
-// T is the type of the index -- usually INT32 or INT64
+// T is the type of the index -- usually int32_t or INT64
 // U is a datatype = to the itemsize
 template<typename T>
-void ReIndexData(void* pDataOut, void* pDataIn, void* pIndex1, INT64 size, INT64 itemSize) {
+void ReIndexData(void* pDataOut, void* pDataIn, void* pIndex1, int64_t size, int64_t itemSize) {
    char* pOut = (char*)pDataOut;
    char* pIn = (char*)pDataIn;
    T* pIndex = (T*)pIndex1;
 
-   for (INT64 i = 0; i < size; i++) {
+   for (int64_t i = 0; i < size; i++) {
       T index = pIndex[i];
 
-      for (INT64 j = 0; j < itemSize; j++) {
+      for (int64_t j = 0; j < itemSize; j++) {
          pOut[i*itemSize + j] = pIn[index*itemSize + j];
 
       }
@@ -55,14 +55,14 @@ void ReIndexData(void* pDataOut, void* pDataIn, void* pIndex1, INT64 size, INT64
 
 
 //--------------------------------------------------------
-// T is the type of the index -- usually INT32 or INT64
+// T is the type of the index -- usually int32_t or INT64
 template<typename T>
-REINDEXCALLBACK ReIndexDataStep1(INT64 itemSize) {
+REINDEXCALLBACK ReIndexDataStep1(int64_t itemSize) {
    switch (itemSize) {
    case 1:
-      return ReIndexData<T, BYTE>;
+      return ReIndexData<T, int8_t>;
    case 2:
-      return ReIndexData<T, INT16>;
+      return ReIndexData<T, int16_t>;
    case 4:
       return ReIndexData<T, float>;
    case 8:
@@ -77,17 +77,19 @@ REINDEXCALLBACK ReIndexDataStep1(INT64 itemSize) {
 }
 
 //=========================================================
-REINDEXCALLBACK ReIndexer(INT64 itemSize, int dtypeIndex) {
+REINDEXCALLBACK ReIndexer(int64_t itemSize, int dtypeIndex) {
 
-   // Get the dtype for the INDEXER (should be INT32 or INT64)
+   // Get the dtype for the INDEXER (should be int32_t or INT64)
    switch (dtypeIndex) {
 
-   CASE_NPY_INT32:
-   CASE_NPY_UINT32:
-      return ReIndexDataStep1<INT32>(itemSize);
-   CASE_NPY_UINT64:
-   CASE_NPY_INT64:
-      return ReIndexDataStep1<INT64>(itemSize);
+   case NPY_INT32:
+   case NPY_UINT32:
+      return ReIndexDataStep1<int32_t>(itemSize);
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+   case NPY_INT64:
+   case NPY_LONGLONG:
+      return ReIndexDataStep1<int64_t>(itemSize);
    case NPY_FLOAT:
       // allow matlab style float indexing?
       //return ReIndexDataStep1<float>(pDataOut, pDataIn, pIndex, size, itemSize);
@@ -108,10 +110,10 @@ struct RIDX_CALLBACK {
    char* pDataOut;
    char* pDataIn;
    char* pIndex1;
-   INT64 indexLen;
-   INT64 itemSize;
+   int64_t indexLen;
+   int64_t itemSize;
 
-   INT64 indexTypeSize;
+   int64_t indexTypeSize;
 
 } stRICallback;
 
@@ -119,26 +121,26 @@ struct RIDX_CALLBACK {
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL ReIndexThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
-   BOOL didSomeWork = FALSE;
+static bool ReIndexThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
+   bool didSomeWork = false;
    RIDX_CALLBACK* OldCallback = (RIDX_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    char* pDataIn = (char *)OldCallback->pDataIn;
    char* pDataIndex = (char *)OldCallback->pIndex1;
    char* pDataOut = (char*)OldCallback->pDataOut;
-   INT64 lenX;
-   INT64 workBlock;
+   int64_t lenX;
+   int64_t workBlock;
 
    // As long as there is work to do
    while ((lenX = pstWorkerItem->GetNextWorkBlock(&workBlock)) > 0) {
 
-      INT64 offsetAdj = pstWorkerItem->BlockSize * workBlock * OldCallback->itemSize;
-      INT64 indexAdj = pstWorkerItem->BlockSize * workBlock * OldCallback->indexTypeSize;
+      int64_t offsetAdj = pstWorkerItem->BlockSize * workBlock * OldCallback->itemSize;
+      int64_t indexAdj = pstWorkerItem->BlockSize * workBlock * OldCallback->indexTypeSize;
 
       OldCallback->reIndexCallback(pDataOut + offsetAdj, pDataIn, pDataIndex + indexAdj, lenX, stRICallback.itemSize);
 
       // Indicate we completed a block
-      didSomeWork = TRUE;
+      didSomeWork = true;
 
       // tell others we completed this work block
       pstWorkerItem->CompleteWorkBlock();
@@ -161,7 +163,7 @@ PyObject* ReIndex(PyObject *self, PyObject *args) {
    if (mlp.aInfo && mlp.tupleSize > 1) {
 
       // Bug bug -- arraysize should come from first arg and must <= second arg
-      INT64 arraySize1 = mlp.totalRows;
+      int64_t arraySize1 = mlp.totalRows;
 
       PyArrayObject* result = AllocateLikeResize(mlp.aInfo[1].pObject, arraySize1);
 
@@ -217,16 +219,16 @@ PyObject* ReIndex(PyObject *self, PyObject *args) {
 
 
 //=================================================================================================================
-typedef void(*REMAP_INDEX)(void* pInput1, void* pOutput1, INT64 length, INT32* pMapper, INT64 maplength);
+typedef void(*REMAP_INDEX)(void* pInput1, void* pOutput1, int64_t length, int32_t* pMapper, int64_t maplength);
 
 //--------------------------------------------------------------------------------
 template<typename T, typename U>
-void ReMapIndex(void* pInput1, void* pOutput1, INT64 length, INT32* pMapper, INT64 maplength) {
+void ReMapIndex(void* pInput1, void* pOutput1, int64_t length, int32_t* pMapper, int64_t maplength) {
 
    T* pInput = (T*)pInput1;
    U* pOutput = (U*)pOutput1;
 
-   for (INT64 i = 0; i < length; i++) {
+   for (int64_t i = 0; i < length; i++) {
       pOutput[i] = (U)(pMapper[pInput[i]]);
    }
 
@@ -234,22 +236,23 @@ void ReMapIndex(void* pInput1, void* pOutput1, INT64 length, INT32* pMapper, INT
 
 
 //--------------------------------------------------------
-// T is the type of the index -- usually INT32 or INT64
+// T is the type of the index -- usually int32_t or INT64
 template<typename T>
 REMAP_INDEX ReMapIndexStep1(int numpyOutputType) {
 
    switch (numpyOutputType) {
    case NPY_INT8:
-      return ReMapIndex<T, INT8>;
+      return ReMapIndex<T, int8_t>;
       break;
    case NPY_INT16:
-      return ReMapIndex<T, INT16>;
+      return ReMapIndex<T, int16_t>;
       break;
-   CASE_NPY_INT32:
-      return ReMapIndex<T, INT32>;
+   case NPY_INT32:
+      return ReMapIndex<T, int32_t>;
       break;
-   CASE_NPY_INT64:
-      return ReMapIndex<T, INT64>;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+      return ReMapIndex<T, int64_t>;
       break;
    default:
       printf("ReMapIndexStep1 does not understand type %d\n", numpyOutputType);
@@ -285,7 +288,7 @@ PyObject* ReMapIndex(PyObject *self, PyObject *args) {
 
    if (PyArray_TYPE(remapArr1) != NPY_INT32) {
 
-      PyErr_Format(PyExc_ValueError, "third arg array must be NPY_INT32 -- not %d", PyArray_TYPE(remapArr1));
+      PyErr_Format(PyExc_ValueError, "third arg array must be NPY_int32_t -- not %d", PyArray_TYPE(remapArr1));
    }
    else {
       int numpyInType = PyArray_TYPE(inArr1);
@@ -295,16 +298,17 @@ PyObject* ReMapIndex(PyObject *self, PyObject *args) {
 
       switch (numpyInType) {
       case NPY_INT8:
-         func = ReMapIndexStep1<INT8>(numpyOutType);
+         func = ReMapIndexStep1<int8_t>(numpyOutType);
          break;
       case NPY_INT16:
-         func = ReMapIndexStep1<INT16>(numpyOutType);
+         func = ReMapIndexStep1<int16_t>(numpyOutType);
          break;
-      CASE_NPY_INT32:
-         func = ReMapIndexStep1<INT32>(numpyOutType);
+      case NPY_INT32:
+         func = ReMapIndexStep1<int32_t>(numpyOutType);
          break;
-      CASE_NPY_INT64:
-         func = ReMapIndexStep1<INT64>(numpyOutType);
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         func = ReMapIndexStep1<int64_t>(numpyOutType);
          break;
       default:
          printf("ReMapIndexStep1 does not understand type %d\n", numpyOutType);
@@ -315,10 +319,10 @@ PyObject* ReMapIndex(PyObject *self, PyObject *args) {
          void *pInput = PyArray_BYTES(inArr1);
          void *pOutput = PyArray_BYTES(outArr1);
          void* pRemap = PyArray_BYTES(remapArr1);
-         INT64 length = ArrayLength(inArr1);
-         INT64 mapLength = ArrayLength(remapArr1);
+         int64_t length = ArrayLength(inArr1);
+         int64_t mapLength = ArrayLength(remapArr1);
 
-         func(pInput, pOutput, length, (INT32*)pRemap, mapLength);
+         func(pInput, pOutput, length, (int32_t*)pRemap, mapLength);
       }
    }
 
@@ -331,14 +335,14 @@ PyObject* ReMapIndex(PyObject *self, PyObject *args) {
 
 
 //=================================================================================================================
-typedef PyObject*(*NAN_INF_COUNT)(void* pDataIn1, void* pIndex, INT64 arraySize1, int numpyInType);
+typedef PyObject*(*NAN_INF_COUNT)(void* pDataIn1, void* pIndex, int64_t arraySize1, int numpyInType);
 
 //--------------------------------------------------------
 // T is the value type (int,float, bool) and matches numpyInType
-// U is the type of the index -- usually INT32 or INT64
+// U is the type of the index -- usually int32_t or INT64
 //-----------------------------------------------------------------------------------------------
 template <typename T, typename U> PyObject*
-NanInfCount(void* pDataIn1, void* pIndex1, INT64 arraySize1, int numpyInType) {
+NanInfCount(void* pDataIn1, void* pIndex1, int64_t arraySize1, int numpyInType) {
 
    void* pDefault = GetDefaultForType(numpyInType);
    T defaultNan = *(T*)pDefault;
@@ -346,13 +350,13 @@ NanInfCount(void* pDataIn1, void* pIndex1, INT64 arraySize1, int numpyInType) {
    T* pData = (T*)pDataIn1;
    U* pIndex = (U*)pIndex1;
 
-   INT64 nancount = 0;
-   INT64 posInfCount = 0;
-   INT64 negInfCount = 0;
+   int64_t nancount = 0;
+   int64_t posInfCount = 0;
+   int64_t negInfCount = 0;
 
 
    if (numpyInType == NPY_FLOAT || numpyInType == NPY_DOUBLE || numpyInType == NPY_LONGDOUBLE) {
-      INT64 i = arraySize1 - 1;
+      int64_t i = arraySize1 - 1;
 
       // Scan from back
       while ((i >= 0) && pData[pIndex[i]] != pData[pIndex[i]]) {
@@ -374,14 +378,14 @@ NanInfCount(void* pDataIn1, void* pIndex1, INT64 arraySize1, int numpyInType) {
 
    }
 
-   // BOOL cannot have invalid
+   // bool cannot have invalid
    else if (numpyInType > 0) {
 
       // check for integer which can have invalid in front     
       if (numpyInType & 1) {
          // SCAN FORWARD
          //printf("***scan forward\n");
-         INT64 i = arraySize1 - 1;
+         int64_t i = arraySize1 - 1;
          int j = 0;
 
          while ((j <= i) && pData[pIndex[j]] == defaultNan) {
@@ -391,7 +395,7 @@ NanInfCount(void* pDataIn1, void* pIndex1, INT64 arraySize1, int numpyInType) {
       }
       else {
          //printf("***scan backward\n");
-         INT64 i = arraySize1 - 1;
+         int64_t i = arraySize1 - 1;
 
          // check for default value?
          while ((i >= 0) && pData[pIndex[i]] == defaultNan) {
@@ -407,7 +411,7 @@ NanInfCount(void* pDataIn1, void* pIndex1, INT64 arraySize1, int numpyInType) {
 }
 
 //------------------------------------------------------------------------------
-// U is the index type: INT32 or INT64
+// U is the index type: int32_t or INT64
 // Returns NULL if no routine
 template<typename U> NAN_INF_COUNT
 GetNanInfCount(int numpyInType) {
@@ -416,28 +420,30 @@ GetNanInfCount(int numpyInType) {
    switch (numpyInType) {
    case NPY_BOOL:
    case NPY_INT8:
-      result = NanInfCount<INT8, U>;
+      result = NanInfCount<int8_t, U>;
       break;
    case NPY_INT16:
-      result = NanInfCount<INT16, U>;
+      result = NanInfCount<int16_t, U>;
       break;
-   CASE_NPY_INT32:
-      result = NanInfCount<INT32, U>;
+   case NPY_INT32:
+      result = NanInfCount<int32_t, U>;
       break;
-   CASE_NPY_INT64:
-      result = NanInfCount<INT64, U>;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+      result = NanInfCount<int64_t, U>;
       break;
    case NPY_UINT8:
-      result = NanInfCount<UINT8, U>;
+      result = NanInfCount<uint8_t, U>;
       break;
    case NPY_UINT16:
-      result = NanInfCount<UINT16, U>;
+      result = NanInfCount<uint16_t, U>;
       break;
-   CASE_NPY_UINT32:
-      result = NanInfCount<UINT32, U>;
+   case NPY_UINT32:
+      result = NanInfCount<uint32_t, U>;
       break;
-   CASE_NPY_UINT64:
-      result = NanInfCount<UINT64, U>;
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+      result = NanInfCount<uint64_t, U>;
       break;
    case NPY_FLOAT:
       result = NanInfCount<float, U>;
@@ -468,22 +474,23 @@ PyObject* NanInfCountFromSort(PyObject *self, PyObject *args) {
       if (mlp.aInfo[0].ArrayLength == mlp.aInfo[1].ArrayLength) {
          void* pDataIn1 = mlp.aInfo[0].pData;
          void* pIndex1 = mlp.aInfo[1].pData;
-         INT64 arraySize1 = mlp.aInfo[0].ArrayLength;
+         int64_t arraySize1 = mlp.aInfo[0].ArrayLength;
          int numpyInType = mlp.aInfo[0].NumpyDType;
          int numpyIndexType = mlp.aInfo[1].NumpyDType;
 
-         NAN_INF_COUNT func = NULL;
+         NAN_INF_COUNT func = nullptr;
 
          switch (numpyIndexType) {
-         CASE_NPY_INT32:
-            func = GetNanInfCount<INT32>(numpyInType);
+         case NPY_INT32:
+            func = GetNanInfCount<int32_t>(numpyInType);
             break;
-         CASE_NPY_INT64:
-            func = GetNanInfCount<INT64>(numpyInType);
+         case NPY_INT64:
+         case NPY_LONGLONG:
+            func = GetNanInfCount<int64_t>(numpyInType);
             break;
          }
 
-         if (func != NULL) {
+         if (func != nullptr) {
             return func(pDataIn1, pIndex1, arraySize1, numpyInType);
          }
 
@@ -508,8 +515,8 @@ PyObject* NanInfCountFromSort(PyObject *self, PyObject *args) {
 //=================================================================================================
 //=================================================================================================
 
-typedef void(*MAKE_BINS_SORTED)(void* pDataIn1, void* pIndex1, void* pOut1, INT64 length, double* pBin1, INT64 maxbin, INT64 nancount, INT64 infcount, INT64 neginfcount);
-typedef void(*MAKE_BINS_BSEARCH)(void* pDataIn1, void* pOut1, INT64 start, INT64 length, void* pBin1, INT64 maxbin, int numpyInType);
+typedef void(*MAKE_BINS_SORTED)(void* pDataIn1, void* pIndex1, void* pOut1, int64_t length, double* pBin1, int64_t maxbin, int64_t nancount, int64_t infcount, int64_t neginfcount);
+typedef void(*MAKE_BINS_BSEARCH)(void* pDataIn1, void* pOut1, int64_t start, int64_t length, void* pBin1, int64_t maxbin, int numpyInType);
 
 
 //=================================================================================================
@@ -517,14 +524,14 @@ typedef void(*MAKE_BINS_BSEARCH)(void* pDataIn1, void* pOut1, INT64 start, INT64
 // U is the sort index type (often INT32)
 // Returns pOut1 wihch can be INT8,INT16,INT32
 //
-// NOTE: Uses double to separate bins but this does not have resolution for INT64 nanos
+// NOTE: Uses double to separate bins but this does not have resolution for int64_t nanos
 template<typename T, typename U, typename V>
-void MakeBinsSorted(void* pDataIn1, void* pSortIndex1, void* pOut1, INT64 length, double* pBin1, INT64 maxbin, INT64 nancount, INT64 infcount, INT64 neginfcount) {
+void MakeBinsSorted(void* pDataIn1, void* pSortIndex1, void* pOut1, int64_t length, double* pBin1, int64_t maxbin, int64_t nancount, int64_t infcount, int64_t neginfcount) {
    T* pData = (T*)pDataIn1;
    U* pIndex = (U*)pSortIndex1;
    V* pOut = (V*)pOut1;
 
-   INT64 i = 0;
+   int64_t i = 0;
 
    LOGGING("Array length %lld   bin length %lld   nancount %lld  neginfcount%lld\n", length, maxbin, nancount, neginfcount);
 
@@ -543,7 +550,7 @@ void MakeBinsSorted(void* pDataIn1, void* pSortIndex1, void* pOut1, INT64 length
    }
 
    // TODO: multithread optimize this section
-   INT64 newlength = length - (nancount + infcount);
+   int64_t newlength = length - (nancount + infcount);
    V bin = 0;
    double compare = pBin1[bin];
    //printf("comparing0 to %lld  %lf\n", (INT64)bin, compare);
@@ -587,7 +594,7 @@ void MakeBinsSorted(void* pDataIn1, void* pSortIndex1, void* pOut1, INT64 length
             // move to next bin
             ++bin;
             compare = pBin1[bin];
-            LOGGING("comparing to %lld %lld  %lf  %lf\n", i, (INT64)bin, (double)pData[index], compare);
+            LOGGING("comparing to %lld %lld  %lf  %lf\n", i, (int64_t)bin, (double)pData[index], compare);
          }
          if (bin >= maxbin) {
             break;
@@ -606,7 +613,7 @@ void MakeBinsSorted(void* pDataIn1, void* pSortIndex1, void* pOut1, INT64 length
 }
 
 //------------------------------------------------------------------------------
-// U is the value index type: INT32 or INT64
+// U is the value index type: int32_t or INT64
 // V is the bin index type: INT8, INT16, INT32, INT64
 // Returns NULL if no routine
 template<typename U, typename V> MAKE_BINS_SORTED
@@ -616,28 +623,30 @@ GetMakeBinsSorted(int numpyInType) {
    switch (numpyInType) {
    case NPY_BOOL:
    case NPY_INT8:
-      result = MakeBinsSorted<INT8, U, V>;
+      result = MakeBinsSorted<int8_t, U, V>;
       break;
    case NPY_INT16:
-      result = MakeBinsSorted<INT16, U, V>;
+      result = MakeBinsSorted<int16_t, U, V>;
       break;
-   CASE_NPY_INT32:
-      result = MakeBinsSorted<INT32, U, V>;
+   case NPY_INT32:
+      result = MakeBinsSorted<int32_t, U, V>;
       break;
-   CASE_NPY_INT64:
-      result = MakeBinsSorted<INT64, U, V>;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+      result = MakeBinsSorted<int64_t, U, V>;
       break;
    case NPY_UINT8:
-      result = MakeBinsSorted<UINT8, U, V>;
+      result = MakeBinsSorted<uint8_t, U, V>;
       break;
    case NPY_UINT16:
-      result = MakeBinsSorted<UINT16, U, V>;
+      result = MakeBinsSorted<uint16_t, U, V>;
       break;
-   CASE_NPY_UINT32:
-      result = MakeBinsSorted<UINT32, U, V>;
+   case NPY_UINT32:
+      result = MakeBinsSorted<uint32_t, U, V>;
       break;
-   CASE_NPY_UINT64:
-      result = MakeBinsSorted<UINT64, U, V>;
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+      result = MakeBinsSorted<uint64_t, U, V>;
       break;
    case NPY_FLOAT:
       result = MakeBinsSorted<float, U, V>;
@@ -680,9 +689,9 @@ PyObject* BinsToCutsSorted(PyObject *self, PyObject *args) {
       &PyTuple_Type, &counts,
       &binMode)) return NULL;
 
-   INT64 nancount = 0;
-   INT64 infcount = 0;
-   INT64 neginfcount = 0;
+   int64_t nancount = 0;
+   int64_t infcount = 0;
+   int64_t neginfcount = 0;
 
    if (!PyArg_ParseTuple((PyObject*)counts, "LLL", &nancount, &infcount, &neginfcount)) return NULL;
 
@@ -696,9 +705,9 @@ PyObject* BinsToCutsSorted(PyObject *self, PyObject *args) {
 
       int numpyInType = PyArray_TYPE(inArr1);
       int numpyIndexType = PyArray_TYPE(indexArr1);
-      INT64 binSize = ArrayLength(binArr1);
+      int64_t binSize = ArrayLength(binArr1);
 
-      // Choose INT8,INT16,INT32 for bin mode
+      // Choose INT8,INT16,int32_t for bin mode
       int binmode = 0;
       if (binSize > 100) {
          binmode = 1;
@@ -712,36 +721,37 @@ PyObject* BinsToCutsSorted(PyObject *self, PyObject *args) {
       MAKE_BINS_SORTED func = NULL;
 
       switch (numpyIndexType) {
-      CASE_NPY_INT32:
+      case NPY_INT32:
          switch (binmode) {
          case 0:
-            func = GetMakeBinsSorted<INT32, INT8>(numpyInType);
+            func = GetMakeBinsSorted<int32_t, int8_t>(numpyInType);
             break;
          case 1:
-            func = GetMakeBinsSorted<INT32, INT16>(numpyInType);
+            func = GetMakeBinsSorted<int32_t, int16_t>(numpyInType);
             break;
          case 2:
-            func = GetMakeBinsSorted<INT32, INT32>(numpyInType);
+            func = GetMakeBinsSorted<int32_t, int32_t>(numpyInType);
             break;
          case 3:
-            func = GetMakeBinsSorted<INT32, INT64>(numpyInType);
+            func = GetMakeBinsSorted<int32_t, int64_t>(numpyInType);
             break;
          }
          break;
 
-      CASE_NPY_INT64:
+      case NPY_INT64:
+      case NPY_LONGLONG:
          switch (binmode) {
          case 0:
-            func = GetMakeBinsSorted<INT64, INT8>(numpyInType);
+            func = GetMakeBinsSorted<int64_t, int8_t>(numpyInType);
             break;
          case 1:
-            func = GetMakeBinsSorted<INT64, INT16>(numpyInType);
+            func = GetMakeBinsSorted<int64_t, int16_t>(numpyInType);
             break;
          case 2:
-            func = GetMakeBinsSorted<INT64, INT32>(numpyInType);
+            func = GetMakeBinsSorted<int64_t, int32_t>(numpyInType);
             break;
          case 3:
-            func = GetMakeBinsSorted<INT64, INT64>(numpyInType);
+            func = GetMakeBinsSorted<int64_t, int64_t>(numpyInType);
             break;
          }
          break;
@@ -788,9 +798,9 @@ PyObject* BinsToCutsSorted(PyObject *self, PyObject *args) {
 // U is the index type (often INT32)
 // Returns pOut1 wihch can be INT8,INT16,INT32
 //
-// NOTE: Uses double to separate bins but this does not have resolution for INT64 nanos
+// NOTE: Uses double to separate bins but this does not have resolution for int64_t nanos
 template<typename T, typename V, typename BINTYPE>
-void SearchSortedRight(void* pDataIn1, void* pOut1, const INT64 start, const INT64 length, void* pBin1T, INT64 maxbin1, int numpyInType) {
+void SearchSortedRight(void* pDataIn1, void* pOut1, const int64_t start, const int64_t length, void* pBin1T, int64_t maxbin1, int numpyInType) {
    const T* pData = (const T*)pDataIn1;
    pData = &pData[start];
 
@@ -808,7 +818,7 @@ void SearchSortedRight(void* pDataIn1, void* pOut1, const INT64 start, const INT
    LOGGING("SearchSortedLeft Array length %lld   bin length %lld\n", length, (long long)maxbin);
 
    // Now assign a valid bin to the good data in the middle
-   for (INT64 i = 0; i < length; i++) {
+   for (int64_t i = 0; i < length; i++) {
 
       const T value = pData[i];
 
@@ -869,9 +879,9 @@ void SearchSortedRight(void* pDataIn1, void* pOut1, const INT64 start, const INT
 // U is the index type (often INT32)
 // Returns pOut1 wihch can be INT8,INT16,INT32
 //
-// NOTE: Uses double to separate bins but this does not have resolution for INT64 nanos
+// NOTE: Uses double to separate bins but this does not have resolution for int64_t nanos
 template<typename T, typename V, typename BINTYPE>
-void SearchSortedLeft(void* pDataIn1, void* pOut1, const INT64 start, const INT64 length, void* pBin1T, INT64 maxbin1, int numpyInType) {
+void SearchSortedLeft(void* pDataIn1, void* pOut1, const int64_t start, const int64_t length, void* pBin1T, int64_t maxbin1, int numpyInType) {
    const T* pData = (const T*)pDataIn1;
    pData = &pData[start];
 
@@ -889,7 +899,7 @@ void SearchSortedLeft(void* pDataIn1, void* pOut1, const INT64 start, const INT6
    LOGGING("SearchSortedLeft Array length %lld   bin length %lld\n", length, (long long)maxbin);
 
    // Now assign a valid bin to the good data in the middle
-   for (INT64 i = 0; i < length; i++) {
+   for (int64_t i = 0; i < length; i++) {
 
       const T value = pData[i];
 
@@ -947,11 +957,11 @@ void SearchSortedLeft(void* pDataIn1, void* pOut1, const INT64 start, const INT6
 
 
 NPY_INLINE static int
-STRING_LTEQ(const char *s1, const char *s2, INT64 len1, INT64 len2)
+STRING_LTEQ(const char *s1, const char *s2, int64_t len1, int64_t len2)
 {
    const unsigned char *c1 = (unsigned char *)s1;
    const unsigned char *c2 = (unsigned char *)s2;
-   INT64 i;
+   int64_t i;
    if (len1 == len2) {
       for (i = 0; i < len1; ++i) {
          if (c1[i] != c2[i]) {
@@ -985,11 +995,11 @@ STRING_LTEQ(const char *s1, const char *s2, INT64 len1, INT64 len2)
 
 
 NPY_INLINE static int
-STRING_LT(const char *s1, const char *s2, INT64 len1, INT64 len2)
+STRING_LT(const char *s1, const char *s2, int64_t len1, int64_t len2)
 {
    const unsigned char *c1 = (unsigned char *)s1;
    const unsigned char *c2 = (unsigned char *)s2;
-   INT64 i;
+   int64_t i;
    if (len1 == len2) {
       for (i = 0; i < len1; ++i) {
          if (c1[i] != c2[i]) {
@@ -1022,11 +1032,11 @@ STRING_LT(const char *s1, const char *s2, INT64 len1, INT64 len2)
 
 
 NPY_INLINE static int
-STRING_GTEQ(const char *s1, const char *s2, INT64 len1, INT64 len2)
+STRING_GTEQ(const char *s1, const char *s2, int64_t len1, int64_t len2)
 {
    const unsigned char *c1 = (unsigned char *)s1;
    const unsigned char *c2 = (unsigned char *)s2;
-   INT64 i;
+   int64_t i;
    if (len1 == len2) {
       for (i = 0; i < len1; ++i) {
          if (c1[i] != c2[i]) {
@@ -1060,11 +1070,11 @@ STRING_GTEQ(const char *s1, const char *s2, INT64 len1, INT64 len2)
 
 
 NPY_INLINE static int
-STRING_GT(const char *s1, const char *s2, INT64 len1, INT64 len2)
+STRING_GT(const char *s1, const char *s2, int64_t len1, int64_t len2)
 {
    const unsigned char *c1 = (unsigned char *)s1;
    const unsigned char *c2 = (unsigned char *)s2;
-   INT64 i;
+   int64_t i;
    if (len1 == len2) {
       for (i = 0; i < len1; ++i) {
          if (c1[i] != c2[i]) {
@@ -1102,9 +1112,9 @@ STRING_GT(const char *s1, const char *s2, INT64 len1, INT64 len2)
 // OUT_TYPE is the output index type
 // Returns pOut1 wihch can be INT8,INT16,INT32,INT64
 //
-// NOTE: Uses double to separate bins but this does not have resolution for INT64 nanos
+// NOTE: Uses double to separate bins but this does not have resolution for int64_t nanos
 template<typename OUT_TYPE>
-void SearchSortedLeftString(void* pDataIn1, void* pOut1, const INT64 start, const INT64 length, char* pBin1T, INT64 maxbin1, INT64 itemSizeValue, INT64 itemSizeBin) {
+void SearchSortedLeftString(void* pDataIn1, void* pOut1, const int64_t start, const int64_t length, char* pBin1T, int64_t maxbin1, int64_t itemSizeValue, int64_t itemSizeBin) {
    const char* pData = (const char*)pDataIn1;
    pData = &pData[start];
 
@@ -1122,7 +1132,7 @@ void SearchSortedLeftString(void* pDataIn1, void* pOut1, const INT64 start, cons
    LOGGING("SearchSortedLeftString Array length %lld   bin length %lld\n", length, (long long)maxbin);
 
    // Now assign a valid bin to the good data in the middle
-   for (INT64 i = 0; i < length; i++) {
+   for (int64_t i = 0; i < length; i++) {
 
       const char* value = &pData[i*itemSizeValue];
 
@@ -1184,9 +1194,9 @@ void SearchSortedLeftString(void* pDataIn1, void* pOut1, const INT64 start, cons
 // OUT_TYPE is the output index type
 // Returns pOut1 wihch can be INT8,INT16,INT32,INT64
 //
-// NOTE: Uses double to separate bins but this does not have resolution for INT64 nanos
+// NOTE: Uses double to separate bins but this does not have resolution for int64_t nanos
 template<typename OUT_TYPE>
-void MakeBinsBSearchString(void* pDataIn1, void* pOut1, const INT64 start, const INT64 length, char* pBin1T, INT64 maxbin1, INT64 itemSizeValue, INT64 itemSizeBin) {
+void MakeBinsBSearchString(void* pDataIn1, void* pOut1, const int64_t start, const int64_t length, char* pBin1T, int64_t maxbin1, int64_t itemSizeValue, int64_t itemSizeBin) {
    const char* pData = (const char*)pDataIn1;
    pData = &pData[start];
 
@@ -1204,7 +1214,7 @@ void MakeBinsBSearchString(void* pDataIn1, void* pOut1, const INT64 start, const
    LOGGING("MakeBinsBSearchString Array length %lld   bin length %lld    itemsizebin:%lld  itemsizevalue:%lld\n", length, maxbin1, itemSizeBin, itemSizeValue);
 
    // Now assign a valid bin to the good data in the middle
-   for (INT64 i = 0; i < length; i++) {
+   for (int64_t i = 0; i < length; i++) {
 
       const char* value = &pData[i * itemSizeValue];
 
@@ -1269,9 +1279,9 @@ void MakeBinsBSearchString(void* pDataIn1, void* pOut1, const INT64 start, const
 // OUT_TYPE is the output index type
 // Returns pOut1 wihch can be INT8,INT16,INT32,INT64
 //
-// NOTE: Uses double to separate bins but this does not have resolution for INT64 nanos
+// NOTE: Uses double to separate bins but this does not have resolution for int64_t nanos
 template<typename T, typename OUT_TYPE, typename BINTYPE>
-void MakeBinsBSearchFloat(void* pDataIn1, void* pOut1, const INT64 start, const INT64 length, void* pBin1T, INT64 maxbin1, int numpyInType) {
+void MakeBinsBSearchFloat(void* pDataIn1, void* pOut1, const int64_t start, const int64_t length, void* pBin1T, int64_t maxbin1, int numpyInType) {
    const T* pData = (const T*)pDataIn1;
    pData = &pData[start];
 
@@ -1289,7 +1299,7 @@ void MakeBinsBSearchFloat(void* pDataIn1, void* pOut1, const INT64 start, const 
    LOGGING("MakeBinsBSearchFloat Array length %lld   bin length %lld    bintype %d\n", length, maxbin1, numpyInType);
 
    // Now assign a valid bin to the good data in the middle
-   for (INT64 i = 0; i < length; i++) {
+   for (int64_t i = 0; i < length; i++) {
 
       const T value = pData[i];
       if (std::isfinite(value) && value >= veryfirst && value <= verylast) {
@@ -1350,11 +1360,11 @@ void MakeBinsBSearchFloat(void* pDataIn1, void* pOut1, const INT64 start, const 
 // T is the value type
 // OUT_TYPE is the bin index type: INT8, INT16, INT32, INT64
 // U is the index type (often INT32)
-// Returns pOut1 wihch can be INT8,INT16,INT32,INT64 (the OUT_TYPE)
+// Returns pOut1 wihch can be INT8,INT16,INT32,int64_t (the OUT_TYPE)
 //
-// NOTE: Uses double to separate bins but this does not have resolution for INT64 nanos
+// NOTE: Uses double to separate bins but this does not have resolution for int64_t nanos
 template<typename T, typename OUT_TYPE, typename BINTYPE>
-void MakeBinsBSearch(void* pDataIn1, void* pOut1, const INT64 start, const INT64 length, void* pBin1T, INT64 maxbin1, int numpyInType) {
+void MakeBinsBSearch(void* pDataIn1, void* pOut1, const int64_t start, const int64_t length, void* pBin1T, int64_t maxbin1, int numpyInType) {
    const T* pData = (const T*)pDataIn1;
    pData = &pData[start];
 
@@ -1374,7 +1384,7 @@ void MakeBinsBSearch(void* pDataIn1, void* pOut1, const INT64 start, const INT64
    LOGGING("MakeBinsBSearch Array length %lld   bin length %lld\n", length, (long long)maxbin);
 
    // Now assign a valid bin to the good data in the middle
-   for (INT64 i = 0; i < length; i++) {
+   for (int64_t i = 0; i < length; i++) {
 
       const T value = pData[i];
 
@@ -1430,7 +1440,7 @@ void MakeBinsBSearch(void* pDataIn1, void* pOut1, const INT64 start, const INT64
 }
 
 //------------------------------------------------------------------------------
-// BINTYPE is the value index type: INT32 or INT64
+// BINTYPE is the value index type: int32_t or INT64
 // OUT_TYPE is the bin index type: INT8, INT16, INT32, INT64
 // Returns NULL if no routine
 template<typename OUT_TYPE, typename BINTYPE> MAKE_BINS_BSEARCH
@@ -1441,28 +1451,30 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       switch (numpyInType) {
       case NPY_BOOL:
       case NPY_INT8:
-         result = MakeBinsBSearch<INT8, OUT_TYPE, BINTYPE>;
+         result = MakeBinsBSearch<int8_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_INT16:
-         result = MakeBinsBSearch<INT16, OUT_TYPE, BINTYPE>;
+         result = MakeBinsBSearch<int16_t, OUT_TYPE, BINTYPE>;
          break;
-      CASE_NPY_INT32:
-         result = MakeBinsBSearch<INT32, OUT_TYPE, BINTYPE>;
+      case NPY_INT32:
+         result = MakeBinsBSearch<int32_t, OUT_TYPE, BINTYPE>;
          break;
-      CASE_NPY_INT64:
-         result = MakeBinsBSearch<INT64, OUT_TYPE, BINTYPE>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         result = MakeBinsBSearch<int64_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT8:
-         result = MakeBinsBSearch<UINT8, OUT_TYPE, BINTYPE>;
+         result = MakeBinsBSearch<uint8_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT16:
-         result = MakeBinsBSearch<UINT16, OUT_TYPE, BINTYPE>;
+         result = MakeBinsBSearch<uint16_t, OUT_TYPE, BINTYPE>;
          break;
-      CASE_NPY_UINT32:
-         result = MakeBinsBSearch<UINT32, OUT_TYPE, BINTYPE>;
+      case NPY_UINT32:
+         result = MakeBinsBSearch<uint32_t, OUT_TYPE, BINTYPE>;
          break;
-      CASE_NPY_UINT64:
-         result = MakeBinsBSearch<UINT64, OUT_TYPE, BINTYPE>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         result = MakeBinsBSearch<uint64_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_FLOAT:
          result = MakeBinsBSearchFloat<float, OUT_TYPE, BINTYPE>;
@@ -1483,28 +1495,30 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       switch (numpyInType) {
       case NPY_BOOL:
       case NPY_INT8:
-         result = SearchSortedLeft<INT8, OUT_TYPE, BINTYPE>;
+         result = SearchSortedLeft<int8_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_INT16:
-         result = SearchSortedLeft<INT16, OUT_TYPE, BINTYPE>;
+         result = SearchSortedLeft<int16_t, OUT_TYPE, BINTYPE>;
          break;
-      CASE_NPY_INT32:
-         result = SearchSortedLeft<INT32, OUT_TYPE, BINTYPE>;
+      case NPY_INT32:
+         result = SearchSortedLeft<int32_t, OUT_TYPE, BINTYPE>;
          break;
-      CASE_NPY_INT64:
-         result = SearchSortedLeft<INT64, OUT_TYPE, BINTYPE>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         result = SearchSortedLeft<int64_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT8:
-         result = SearchSortedLeft<UINT8, OUT_TYPE, BINTYPE>;
+         result = SearchSortedLeft<uint8_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT16:
-         result = SearchSortedLeft<UINT16, OUT_TYPE, BINTYPE>;
+         result = SearchSortedLeft<uint16_t, OUT_TYPE, BINTYPE>;
          break;
-      CASE_NPY_UINT32:
-         result = SearchSortedLeft<UINT32, OUT_TYPE, BINTYPE>;
+      case NPY_UINT32:
+         result = SearchSortedLeft<uint32_t, OUT_TYPE, BINTYPE>;
          break;
-      CASE_NPY_UINT64:
-         result = SearchSortedLeft<UINT64, OUT_TYPE, BINTYPE>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         result = SearchSortedLeft<uint64_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_FLOAT:
          result = SearchSortedLeft<float, OUT_TYPE, BINTYPE>;
@@ -1525,28 +1539,30 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       switch (numpyInType) {
       case NPY_BOOL:
       case NPY_INT8:
-         result = SearchSortedRight<INT8, OUT_TYPE, BINTYPE>;
+         result = SearchSortedRight<int8_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_INT16:
-         result = SearchSortedRight<INT16, OUT_TYPE, BINTYPE>;
+         result = SearchSortedRight<int16_t, OUT_TYPE, BINTYPE>;
          break;
-      CASE_NPY_INT32:
-         result = SearchSortedRight<INT32, OUT_TYPE, BINTYPE>;
+      case NPY_INT32:
+         result = SearchSortedRight<int32_t, OUT_TYPE, BINTYPE>;
          break;
-      CASE_NPY_INT64:
-         result = SearchSortedRight<INT64, OUT_TYPE, BINTYPE>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         result = SearchSortedRight<int64_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT8:
-         result = SearchSortedRight<UINT8, OUT_TYPE, BINTYPE>;
+         result = SearchSortedRight<uint8_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT16:
-         result = SearchSortedRight<UINT16, OUT_TYPE, BINTYPE>;
+         result = SearchSortedRight<uint16_t, OUT_TYPE, BINTYPE>;
          break;
-      CASE_NPY_UINT32:
-         result = SearchSortedRight<UINT32, OUT_TYPE, BINTYPE>;
+      case NPY_UINT32:
+         result = SearchSortedRight<uint32_t, OUT_TYPE, BINTYPE>;
          break;
-      CASE_NPY_UINT64:
-         result = SearchSortedRight<UINT64, OUT_TYPE, BINTYPE>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         result = SearchSortedRight<uint64_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_FLOAT:
          result = SearchSortedRight<float, OUT_TYPE, BINTYPE>;
@@ -1573,19 +1589,22 @@ GetMakeBinsBSearch(int numpyInType, int binType, int searchMode) {
       
    switch (binType) {
    case NPY_INT8:
-      result = GetMakeBinsBSearchPart2<OUT_TYPE, INT8>(numpyInType, searchMode);
+      result = GetMakeBinsBSearchPart2<OUT_TYPE, int8_t>(numpyInType, searchMode);
       break;
    case NPY_INT16:
-      result = GetMakeBinsBSearchPart2<OUT_TYPE, INT16>(numpyInType, searchMode);
+      result = GetMakeBinsBSearchPart2<OUT_TYPE, int16_t>(numpyInType, searchMode);
       break;
-   CASE_NPY_INT32:
-      result = GetMakeBinsBSearchPart2<OUT_TYPE, INT32>(numpyInType, searchMode);
+   case NPY_INT32:
+      result = GetMakeBinsBSearchPart2<OUT_TYPE, int32_t>(numpyInType, searchMode);
       break;
-   CASE_NPY_INT64:
-      result = GetMakeBinsBSearchPart2<OUT_TYPE, INT64>(numpyInType, searchMode);
+      // NO UINT8/16/32?
+   case NPY_INT64:
+   case NPY_LONGLONG:
+      result = GetMakeBinsBSearchPart2<OUT_TYPE, int64_t>(numpyInType, searchMode);
       break;
-   CASE_NPY_UINT64:
-      result = GetMakeBinsBSearchPart2<OUT_TYPE, UINT64>(numpyInType, searchMode);
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+      result = GetMakeBinsBSearchPart2<OUT_TYPE, uint64_t>(numpyInType, searchMode);
       break;
    case NPY_FLOAT:
       result = GetMakeBinsBSearchPart2<OUT_TYPE, float>(numpyInType, searchMode);
@@ -1629,9 +1648,9 @@ PyObject* BinsToCutsBSearch(PyObject *self, PyObject *args) {
    int binType = PyArray_TYPE(binArr1);
 
    int numpyInType = PyArray_TYPE(inArr1);
-   INT64 binSize = ArrayLength(binArr1);
+   int64_t binSize = ArrayLength(binArr1);
 
-   // Choose INT8,INT16,INT32 for bin mode
+   // Choose INT8,INT16,int32_t for bin mode
    int binmode = 0;
    if (binSize > 100) {
       binmode = 1;
@@ -1643,12 +1662,12 @@ PyObject* BinsToCutsBSearch(PyObject *self, PyObject *args) {
       }
    }
 
-   BOOL isString = FALSE;
+   bool isString = false;
 
    if (numpyInType == binType) {
       // string or unicode comparison
       if (numpyInType == NPY_STRING || numpyInType == NPY_UNICODE) {
-         isString = TRUE;
+         isString = true;
       }
    }
 
@@ -1656,16 +1675,16 @@ PyObject* BinsToCutsBSearch(PyObject *self, PyObject *args) {
 
    switch (binmode) {
    case 0:
-      func = GetMakeBinsBSearch<INT8>(numpyInType, binType, searchMode);
+      func = GetMakeBinsBSearch<int8_t>(numpyInType, binType, searchMode);
       break;
    case 1:
-      func = GetMakeBinsBSearch<INT16>(numpyInType, binType, searchMode);
+      func = GetMakeBinsBSearch<int16_t>(numpyInType, binType, searchMode);
       break;
    case 2:
-      func = GetMakeBinsBSearch<INT32>(numpyInType, binType, searchMode);
+      func = GetMakeBinsBSearch<int32_t>(numpyInType, binType, searchMode);
       break;
    case 3:
-      func = GetMakeBinsBSearch<INT64>(numpyInType, binType, searchMode);
+      func = GetMakeBinsBSearch<int64_t>(numpyInType, binType, searchMode);
       break;
    }
 
@@ -1694,17 +1713,17 @@ PyObject* BinsToCutsBSearch(PyObject *self, PyObject *args) {
                void* pDataOut;
                void* pDataIn1;
                void* pBin1;
-               INT64 binSize;
+               int64_t binSize;
                int   numpyInType;
                int   binmode;
-               INT64 inputItemSize;
-               INT64 searchItemSize;
+               int64_t inputItemSize;
+               int64_t searchItemSize;
             };
 
             BSearchCallbackStruct stBSearchCallback;
 
             // This is the routine that will be called back from multiple threads
-            auto lambdaBSearchCallback = [](void* callbackArgT, int core, INT64 start, INT64 length) -> BOOL {
+            auto lambdaBSearchCallback = [](void* callbackArgT, int core, int64_t start, int64_t length) -> bool {
                BSearchCallbackStruct* callbackArg = (BSearchCallbackStruct*)callbackArgT;
 
                //printf("[%d] Bsearch string %lld %lld\n", core, start, length);
@@ -1712,16 +1731,16 @@ PyObject* BinsToCutsBSearch(PyObject *self, PyObject *args) {
 
                   switch (callbackArg->binmode) {
                   case 0:
-                     MakeBinsBSearchString<INT8>(callbackArg->pDataIn1, callbackArg->pDataOut, start, length, (char*)callbackArg->pBin1, callbackArg->binSize, callbackArg->inputItemSize, callbackArg->searchItemSize);
+                     MakeBinsBSearchString<int8_t>(callbackArg->pDataIn1, callbackArg->pDataOut, start, length, (char*)callbackArg->pBin1, callbackArg->binSize, callbackArg->inputItemSize, callbackArg->searchItemSize);
                      break;
                   case 1:
-                     MakeBinsBSearchString<INT16>(callbackArg->pDataIn1, callbackArg->pDataOut, start, length, (char*)callbackArg->pBin1, callbackArg->binSize, callbackArg->inputItemSize, callbackArg->searchItemSize);
+                     MakeBinsBSearchString<int16_t>(callbackArg->pDataIn1, callbackArg->pDataOut, start, length, (char*)callbackArg->pBin1, callbackArg->binSize, callbackArg->inputItemSize, callbackArg->searchItemSize);
                      break;
                   case 2:
-                     MakeBinsBSearchString<INT32>(callbackArg->pDataIn1, callbackArg->pDataOut, start, length, (char*)callbackArg->pBin1, callbackArg->binSize, callbackArg->inputItemSize, callbackArg->searchItemSize);
+                     MakeBinsBSearchString<int32_t>(callbackArg->pDataIn1, callbackArg->pDataOut, start, length, (char*)callbackArg->pBin1, callbackArg->binSize, callbackArg->inputItemSize, callbackArg->searchItemSize);
                      break;
                   case 3:
-                     MakeBinsBSearchString<INT64>(callbackArg->pDataIn1, callbackArg->pDataOut, start, length, (char*)callbackArg->pBin1, callbackArg->binSize, callbackArg->inputItemSize, callbackArg->searchItemSize);
+                     MakeBinsBSearchString<int64_t>(callbackArg->pDataIn1, callbackArg->pDataOut, start, length, (char*)callbackArg->pBin1, callbackArg->binSize, callbackArg->inputItemSize, callbackArg->searchItemSize);
                      break;
                   }
                }
@@ -1743,7 +1762,7 @@ PyObject* BinsToCutsBSearch(PyObject *self, PyObject *args) {
 
                }
                //callbackArg->func(callbackArg->pDataIn1, callbackArg->pDataOut, start, length, callbackArg->pBin1, callbackArg->binSize, callbackArg->numpyInType);
-               return TRUE;
+               return true;
             };
 
             stBSearchCallback.pDataOut = PyArray_BYTES(result);
@@ -1755,7 +1774,7 @@ PyObject* BinsToCutsBSearch(PyObject *self, PyObject *args) {
             stBSearchCallback.inputItemSize = PyArray_ITEMSIZE(inArr1);
             stBSearchCallback.searchItemSize = PyArray_ITEMSIZE(binArr1);
 
-            INT64 lengthData = ArrayLength(inArr1);
+            int64_t lengthData = ArrayLength(inArr1);
             g_cMathWorker->DoMultiThreadedChunkWork(lengthData, lambdaBSearchCallback, &stBSearchCallback);
 
          }
@@ -1766,20 +1785,20 @@ PyObject* BinsToCutsBSearch(PyObject *self, PyObject *args) {
                void* pDataOut;
                void* pDataIn1;
                void* pBin1;
-               INT64 binSize;
+               int64_t binSize;
                int   numpyInType;
             };
 
             BSearchCallbackStruct stBSearchCallback;
 
             // This is the routine that will be called back from multiple threads
-            auto lambdaBSearchCallback = [](void* callbackArgT, int core, INT64 start, INT64 length) -> BOOL {
+            auto lambdaBSearchCallback = [](void* callbackArgT, int core, int64_t start, int64_t length) -> bool {
                BSearchCallbackStruct* callbackArg = (BSearchCallbackStruct*)callbackArgT;
 
                //printf("[%d] Bsearch %lld %lld\n", core, start, length);
 
                callbackArg->func(callbackArg->pDataIn1, callbackArg->pDataOut, start, length, callbackArg->pBin1, callbackArg->binSize, callbackArg->numpyInType);
-               return TRUE;
+               return true;
             };
 
             stBSearchCallback.pDataOut = PyArray_BYTES(result);
@@ -1789,7 +1808,7 @@ PyObject* BinsToCutsBSearch(PyObject *self, PyObject *args) {
             stBSearchCallback.numpyInType = numpyInType;
             stBSearchCallback.func = func;
 
-            INT64 lengthData = ArrayLength(inArr1);
+            int64_t lengthData = ArrayLength(inArr1);
             g_cMathWorker->DoMultiThreadedChunkWork(lengthData, lambdaBSearchCallback, &stBSearchCallback);
          }
 

--- a/src/Bins.cpp
+++ b/src/Bins.cpp
@@ -82,13 +82,13 @@ REINDEXCALLBACK ReIndexer(int64_t itemSize, int dtypeIndex) {
    // Get the dtype for the INDEXER (should be int32_t or INT64)
    switch (dtypeIndex) {
 
-   case NPY_INT32:
-   case NPY_UINT32:
+   CASE_NPY_INT32:
+   CASE_NPY_UINT32:
       return ReIndexDataStep1<int32_t>(itemSize);
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_UINT64:
+   
+   CASE_NPY_INT64:
+   
       return ReIndexDataStep1<int64_t>(itemSize);
    case NPY_FLOAT:
       // allow matlab style float indexing?
@@ -247,11 +247,11 @@ REMAP_INDEX ReMapIndexStep1(int numpyOutputType) {
    case NPY_INT16:
       return ReMapIndex<T, int16_t>;
       break;
-   case NPY_INT32:
+   CASE_NPY_INT32:
       return ReMapIndex<T, int32_t>;
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       return ReMapIndex<T, int64_t>;
       break;
    default:
@@ -303,11 +303,11 @@ PyObject* ReMapIndex(PyObject *self, PyObject *args) {
       case NPY_INT16:
          func = ReMapIndexStep1<int16_t>(numpyOutType);
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          func = ReMapIndexStep1<int32_t>(numpyOutType);
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          func = ReMapIndexStep1<int64_t>(numpyOutType);
          break;
       default:
@@ -425,11 +425,11 @@ GetNanInfCount(int numpyInType) {
    case NPY_INT16:
       result = NanInfCount<int16_t, U>;
       break;
-   case NPY_INT32:
+   CASE_NPY_INT32:
       result = NanInfCount<int32_t, U>;
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       result = NanInfCount<int64_t, U>;
       break;
    case NPY_UINT8:
@@ -438,11 +438,11 @@ GetNanInfCount(int numpyInType) {
    case NPY_UINT16:
       result = NanInfCount<uint16_t, U>;
       break;
-   case NPY_UINT32:
+   CASE_NPY_UINT32:
       result = NanInfCount<uint32_t, U>;
       break;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT64:
+   
       result = NanInfCount<uint64_t, U>;
       break;
    case NPY_FLOAT:
@@ -481,11 +481,11 @@ PyObject* NanInfCountFromSort(PyObject *self, PyObject *args) {
          NAN_INF_COUNT func = nullptr;
 
          switch (numpyIndexType) {
-         case NPY_INT32:
+         CASE_NPY_INT32:
             func = GetNanInfCount<int32_t>(numpyInType);
             break;
-         case NPY_INT64:
-         case NPY_LONGLONG:
+         CASE_NPY_INT64:
+         
             func = GetNanInfCount<int64_t>(numpyInType);
             break;
          }
@@ -628,11 +628,11 @@ GetMakeBinsSorted(int numpyInType) {
    case NPY_INT16:
       result = MakeBinsSorted<int16_t, U, V>;
       break;
-   case NPY_INT32:
+   CASE_NPY_INT32:
       result = MakeBinsSorted<int32_t, U, V>;
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       result = MakeBinsSorted<int64_t, U, V>;
       break;
    case NPY_UINT8:
@@ -641,11 +641,11 @@ GetMakeBinsSorted(int numpyInType) {
    case NPY_UINT16:
       result = MakeBinsSorted<uint16_t, U, V>;
       break;
-   case NPY_UINT32:
+   CASE_NPY_UINT32:
       result = MakeBinsSorted<uint32_t, U, V>;
       break;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT64:
+   
       result = MakeBinsSorted<uint64_t, U, V>;
       break;
    case NPY_FLOAT:
@@ -721,7 +721,7 @@ PyObject* BinsToCutsSorted(PyObject *self, PyObject *args) {
       MAKE_BINS_SORTED func = NULL;
 
       switch (numpyIndexType) {
-      case NPY_INT32:
+      CASE_NPY_INT32:
          switch (binmode) {
          case 0:
             func = GetMakeBinsSorted<int32_t, int8_t>(numpyInType);
@@ -738,8 +738,8 @@ PyObject* BinsToCutsSorted(PyObject *self, PyObject *args) {
          }
          break;
 
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          switch (binmode) {
          case 0:
             func = GetMakeBinsSorted<int64_t, int8_t>(numpyInType);
@@ -1456,11 +1456,11 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_INT16:
          result = MakeBinsBSearch<int16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          result = MakeBinsBSearch<int32_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          result = MakeBinsBSearch<int64_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT8:
@@ -1469,11 +1469,11 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_UINT16:
          result = MakeBinsBSearch<uint16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_UINT32:
+      CASE_NPY_UINT32:
          result = MakeBinsBSearch<uint32_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT64:
+      
          result = MakeBinsBSearch<uint64_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_FLOAT:
@@ -1500,11 +1500,11 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_INT16:
          result = SearchSortedLeft<int16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          result = SearchSortedLeft<int32_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          result = SearchSortedLeft<int64_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT8:
@@ -1513,11 +1513,11 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_UINT16:
          result = SearchSortedLeft<uint16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_UINT32:
+      CASE_NPY_UINT32:
          result = SearchSortedLeft<uint32_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT64:
+      
          result = SearchSortedLeft<uint64_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_FLOAT:
@@ -1544,11 +1544,11 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_INT16:
          result = SearchSortedRight<int16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          result = SearchSortedRight<int32_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          result = SearchSortedRight<int64_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_UINT8:
@@ -1557,11 +1557,11 @@ GetMakeBinsBSearchPart2(int numpyInType, int searchMode) {
       case NPY_UINT16:
          result = SearchSortedRight<uint16_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_UINT32:
+      CASE_NPY_UINT32:
          result = SearchSortedRight<uint32_t, OUT_TYPE, BINTYPE>;
          break;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT64:
+      
          result = SearchSortedRight<uint64_t, OUT_TYPE, BINTYPE>;
          break;
       case NPY_FLOAT:
@@ -1594,16 +1594,16 @@ GetMakeBinsBSearch(int numpyInType, int binType, int searchMode) {
    case NPY_INT16:
       result = GetMakeBinsBSearchPart2<OUT_TYPE, int16_t>(numpyInType, searchMode);
       break;
-   case NPY_INT32:
+   CASE_NPY_INT32:
       result = GetMakeBinsBSearchPart2<OUT_TYPE, int32_t>(numpyInType, searchMode);
       break;
       // NO UINT8/16/32?
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       result = GetMakeBinsBSearchPart2<OUT_TYPE, int64_t>(numpyInType, searchMode);
       break;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT64:
+   
       result = GetMakeBinsBSearchPart2<OUT_TYPE, uint64_t>(numpyInType, searchMode);
       break;
    case NPY_FLOAT:

--- a/src/BitCount.cpp
+++ b/src/BitCount.cpp
@@ -5,7 +5,7 @@
 #include <nmmintrin.h>
 
 PyObject * BitCount(PyObject *self, PyObject *args) {
-   static constexpr INT8 nibble_bitcount[] = {0,  // 0b0000
+   static constexpr int8_t nibble_bitcount[] = {0,  // 0b0000
                                               1,  // 0b0001
                                               1,  // 0b0010
                                               2,  // 0b0011
@@ -29,11 +29,11 @@ PyObject * BitCount(PyObject *self, PyObject *args) {
    npy_intp* dims = PyArray_DIMS(inArr);
    PyArrayObject* returnObject = AllocateNumpyArray(ndim, dims, NPY_INT8);
    if (returnObject == NULL) return NULL;
-   INT8* pDataOut = (INT8*)PyArray_BYTES(returnObject);
+   int8_t* pDataOut = (int8_t*)PyArray_BYTES(returnObject);
 
    const npy_intp length = CalcArrayLength(ndim, dims);
    if (PyArray_TYPE(inArr) == NPY_BOOL) {
-      auto pDataIn = (UINT8*)PyArray_BYTES(inArr);
+      auto pDataIn = (uint8_t*)PyArray_BYTES(inArr);
       for (npy_intp i(0); i < length; ++i, ++pDataIn, ++pDataOut)
          *pDataOut = *pDataIn == 0 ? 0 : 1;
    } else {
@@ -41,7 +41,7 @@ PyObject * BitCount(PyObject *self, PyObject *args) {
       switch (itemsize) {
          case 1:
             {
-               auto pDataIn = (UINT8*)PyArray_BYTES(inArr);
+               auto pDataIn = (uint8_t*)PyArray_BYTES(inArr);
                for (npy_intp i(0); i < length; ++i, ++pDataIn, ++pDataOut) {
                   const auto n(*pDataIn);
                   *pDataOut = nibble_bitcount[n >> 4] + nibble_bitcount[n & 0xf];
@@ -51,7 +51,7 @@ PyObject * BitCount(PyObject *self, PyObject *args) {
          case 2:
             // N.B. __builtin_popcount from GCC works for only unsigned int, can't use for short.
             {
-               auto pDataIn = (UINT16*)PyArray_BYTES(inArr);
+               auto pDataIn = (uint16_t*)PyArray_BYTES(inArr);
                for (npy_intp i(0); i < length; ++i, ++pDataIn, ++pDataOut) {
                   const auto n(*pDataIn);
                   *pDataOut = nibble_bitcount[n >> 12] + nibble_bitcount[(n >> 8) & 0xf] +
@@ -61,16 +61,16 @@ PyObject * BitCount(PyObject *self, PyObject *args) {
             }
          case 4:
             {
-               auto pDataIn = (UINT32*)PyArray_BYTES(inArr);
+               auto pDataIn = (uint32_t*)PyArray_BYTES(inArr);
                for (npy_intp i(0); i < length; ++i, ++pDataIn, ++pDataOut)
                   *pDataOut = _mm_popcnt_u32(*pDataIn);
                break;
             }
          case 8:
             {
-               auto pDataIn = (UINT64*)PyArray_BYTES(inArr);
+               auto pDataIn = (uint64_t*)PyArray_BYTES(inArr);
                for (npy_intp i(0); i < length; ++i, ++pDataIn, ++pDataOut)
-                  *pDataOut = (INT8)_mm_popcnt_u64(*pDataIn);
+                  *pDataOut = (int8_t)_mm_popcnt_u64(*pDataIn);
                break;
             }
          default:

--- a/src/CommonInc.h
+++ b/src/CommonInc.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <cstdlib>
-
+#include <cstdint>
 #include <iostream>
 #include <limits>
 
@@ -432,7 +432,7 @@ struct FUNCTION_LIST {
       GROUPBY_FUNC      GroupByCall;
    };
 
-   const CHAR*       FunctionName;
+   const char*       FunctionName;
 };
 
 

--- a/src/CommonInc.h
+++ b/src/CommonInc.h
@@ -71,6 +71,7 @@ using HANDLE = void*;
 #define CASE_NPY_FLOAT64    case NPY_DOUBLE
 
 using INT_PTR = ptrdiff_t;
+using DWORD = uint32_t;
 
 #define WINAPI
 #include <pthread.h>

--- a/src/CommonInc.h
+++ b/src/CommonInc.h
@@ -70,6 +70,8 @@ using HANDLE = void*;
 #define CASE_NPY_UINT64     case NPY_UINT64:   case NPY_ULONGLONG
 #define CASE_NPY_FLOAT64    case NPY_DOUBLE
 
+using INT_PTR = ptrdiff_t;
+
 #define WINAPI
 #include <pthread.h>
 

--- a/src/CommonInc.h
+++ b/src/CommonInc.h
@@ -20,102 +20,13 @@
 
 #endif
 
-#ifndef CONST
-#define CONST               const
-#endif
-typedef char               CHAR;
-typedef short              SHORT;
-typedef long               LONG;
-#define VOID void
-typedef void *PVOID;
-
-//Type             LP64   Windows
-//char              8       8
-//short             16      16
-//int               32      32
-//long              64      32
-//long long         64      64
-//pointer           64      64
-
-
-typedef unsigned long       DWORD;
-typedef int                 BOOL;
-typedef unsigned char       BYTE;
-typedef BYTE                BOOLEAN;
-typedef unsigned short      WORD;
-typedef float               FLOAT;
-typedef FLOAT               *PFLOAT;
-typedef BOOL                *PBOOL;
-typedef BOOL                *LPBOOL;
-typedef BYTE                *PBYTE;
-typedef BYTE                *LPBYTE;
-typedef int                 *PINT;
-typedef int                 *LPINT;
-typedef WORD                *PWORD;
-typedef WORD                *LPWORD;
-//typedef long                *LPLONG;  // dangerous
-typedef DWORD               *PDWORD;
-typedef DWORD               *LPDWORD;
-typedef void                *LPVOID;
-typedef CONST void          *LPCVOID;
-
-typedef int                 INT;
-typedef unsigned int        UINT;
-typedef unsigned int       *PUINT;
-
-typedef signed char         INT8, *PINT8;
-typedef signed short        INT16, *PINT16;
-typedef signed int          INT32, *PINT32;
-typedef unsigned char       UINT8, *PUINT8;
-typedef unsigned short      UINT16, *PUINT16;
-typedef unsigned int        UINT32, *PUINT32;
-
-typedef long long           INT64, *PINT64;
-typedef unsigned long long  UINT64, *PUINT64;
-
-typedef long long           LONGLONG;
-typedef unsigned long long  ULONGLONG;
-
-typedef double    DOUBLE;
-typedef float     FLOAT;
-//
-// The following types are guaranteed to be signed and 32 bits wide.
-//
-
-typedef int      LONG32, *PLONG32;
-
-//
-// The following types are guaranteed to be unsigned and 32 bits wide.
-//
-
-typedef unsigned int  ULONG32, *PULONG32;
-typedef unsigned int  DWORD32, *PDWORD32;
-
-typedef long long           INT_PTR, *PINT_PTR;
-typedef unsigned long long  UINT_PTR, *PUINT_PTR;
-
-typedef long long           LONG_PTR, *PLONG_PTR;
-typedef unsigned long long  ULONG_PTR, *PULONG_PTR;
-
-typedef ULONG_PTR SIZE_T, *PSIZE_T;
-typedef LONG_PTR  SSIZE_T, *PSSIZE_T;
-
-typedef void *HANDLE;
-
-#define TRUE 1
-#define FALSE 0
-
-
-
-
+using HANDLE = void*;
 
 #define RtlEqualMemory(Destination,Source,Length) (!memcmp((Destination),(Source),(Length)))
 #define RtlMoveMemory(Destination,Source,Length) memmove((Destination),(Source),(Length))
 #define RtlCopyMemory(Destination,Source,Length) memcpy((Destination),(Source),(Length))
 #define RtlFillMemory(Destination,Length,Fill) memset((Destination),(Fill),(Length))
 #define RtlZeroMemory(Destination,Length) memset((Destination),0,(Length))
-
-
 
 #if defined(_WIN32) && !defined(__GNUC__)
 #define WINAPI      __stdcall
@@ -144,21 +55,24 @@ typedef void *HANDLE;
 
 #define lzcnt_64 _lzcnt_u64
 
+#if 0
 #define CASE_NPY_INT32      case NPY_INT32:       case NPY_INT
 #define CASE_NPY_UINT32     case NPY_UINT32:      case NPY_UINT
 #define CASE_NPY_INT64      case NPY_INT64
 #define CASE_NPY_UINT64     case NPY_UINT64
 #define CASE_NPY_FLOAT64    case NPY_DOUBLE:     case NPY_LONGDOUBLE
+#endif
 
 #endif
 #else
 
+#if 0
 #define CASE_NPY_INT32      case NPY_INT32
 #define CASE_NPY_UINT32     case NPY_UINT32
 #define CASE_NPY_INT64      case NPY_INT64:    case NPY_LONGLONG
 #define CASE_NPY_UINT64     case NPY_UINT64:   case NPY_ULONGLONG
 #define CASE_NPY_FLOAT64    case NPY_DOUBLE
-
+#endif
 
 #define WINAPI
 #include <pthread.h>

--- a/src/CommonInc.h
+++ b/src/CommonInc.h
@@ -55,24 +55,20 @@ using HANDLE = void*;
 
 #define lzcnt_64 _lzcnt_u64
 
-#if 0
 #define CASE_NPY_INT32      case NPY_INT32:       case NPY_INT
 #define CASE_NPY_UINT32     case NPY_UINT32:      case NPY_UINT
 #define CASE_NPY_INT64      case NPY_INT64
 #define CASE_NPY_UINT64     case NPY_UINT64
 #define CASE_NPY_FLOAT64    case NPY_DOUBLE:     case NPY_LONGDOUBLE
-#endif
 
 #endif
 #else
 
-#if 0
 #define CASE_NPY_INT32      case NPY_INT32
 #define CASE_NPY_UINT32     case NPY_UINT32
 #define CASE_NPY_INT64      case NPY_INT64:    case NPY_LONGLONG
 #define CASE_NPY_UINT64     case NPY_UINT64:   case NPY_ULONGLONG
 #define CASE_NPY_FLOAT64    case NPY_DOUBLE
-#endif
 
 #define WINAPI
 #include <pthread.h>

--- a/src/CommonInc.h
+++ b/src/CommonInc.h
@@ -129,7 +129,7 @@ typedef void *HANDLE;
 #define YieldProcessor _mm_pause
 #define InterlockedIncrement _InterlockedIncrement
 
-#define FMInterlockedOr(X,Y) _InterlockedOr64((INT64*)X,Y)
+#define FMInterlockedOr(X,Y) _InterlockedOr64((int64_t*)X,Y)
 
 #include <intrin.h>
 #ifndef SFW_ALIGN
@@ -386,13 +386,13 @@ enum MATH_OPERATION {
 
 struct stScatterGatherFunc {
    // numpy intput ttype
-   INT32 inputType;
+   int32_t inputType;
 
    // the core (if any) making this calculation
-   INT32 core;
+   int32_t core;
 
    // used for nans, how many non nan values
-   INT64 lenOut;
+   int64_t lenOut;
 
    // !!must be set when used by var and std
    double meanCalculation;
@@ -400,24 +400,24 @@ struct stScatterGatherFunc {
    double resultOut;
 
    // Separate output for min/max
-   INT64  resultOutInt64;
+   int64_t  resultOutInt64;
 
 };
 
 // Generic function declarations
 // The first one passes in a vector and returns a vector
 // Used for operations like B = MIN(A)
-typedef double(*ANY_SCATTER_GATHER_FUNC)(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc);
+typedef double(*ANY_SCATTER_GATHER_FUNC)(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc);
 
-//typedef void(*UNARY_FUNC)(void* pDataIn, void* pDataOut, INT64 len);
-typedef void(*UNARY_FUNC)(void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut);
-typedef void(*UNARY_FUNC_STRIDED)(void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut);
+//typedef void(*UNARY_FUNC)(void* pDataIn, void* pDataOut, int64_t len);
+typedef void(*UNARY_FUNC)(void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut);
+typedef void(*UNARY_FUNC_STRIDED)(void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut);
 
 // Pass in two vectors and return one vector
 // Used for operations like C = A + B
-typedef void(*ANY_TWO_FUNC)(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode);
+typedef void(*ANY_TWO_FUNC)(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode);
 
-//typedef void(*MERGE_TWO_FUNC)(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 valSize, INT64 start, INT64 len, void* pDefault);
+//typedef void(*MERGE_TWO_FUNC)(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t valSize, int64_t start, int64_t len, void* pDefault);
 
 // Fast path sum
 // Arg1 data such as TradeSize
@@ -426,17 +426,17 @@ typedef void(*ANY_TWO_FUNC)(void* pDataIn, void* pDataIn2, void* pDataOut, INT64
 // Arg4 optional - count out
 
 // Used for Groupby Sum/Mean/Min/Max/etc
-typedef void(*GROUPBY_TWO_FUNC)(void* pDataIn, void* pIndex, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass);
+typedef void(*GROUPBY_TWO_FUNC)(void* pDataIn, void* pIndex, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass);
 
 // Used for Groupby Mode/Median/etc
-typedef void(*GROUPBY_X_FUNC32)(void* pColumn, void* pGroup, INT32* pFirst, INT32* pCount, void* pAccumBin,  INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam);
-typedef void(*GROUPBY_X_FUNC64)(void* pColumn, void* pGroup, INT64* pFirst, INT64* pCount, void* pAccumBin,  INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam);
+typedef void(*GROUPBY_X_FUNC32)(void* pColumn, void* pGroup, int32_t* pFirst, int32_t* pCount, void* pAccumBin,  int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam);
+typedef void(*GROUPBY_X_FUNC64)(void* pColumn, void* pGroup, int64_t* pFirst, int64_t* pCount, void* pAccumBin,  int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam);
 
 // Pass in three vectors and return one vector
 // Used for operations like D = A*B + C
-typedef void(*ANY_THREE_FUNC)(void* pDataIn, void* pDataIn2, void* pDataIn3, void* pDataOut, INT64 len, INT32 scalarMode);
+typedef void(*ANY_THREE_FUNC)(void* pDataIn, void* pDataIn2, void* pDataIn3, void* pDataOut, int64_t len, int32_t scalarMode);
 
-typedef void(*GROUPBY_FUNC)(void* pstGroupBy, INT64 index);
+typedef void(*GROUPBY_FUNC)(void* pstGroupBy, int64_t index);
 
 
 // On TSEBAL650
@@ -445,10 +445,10 @@ typedef void(*GROUPBY_FUNC)(void* pstGroupBy, INT64 index);
 // Adding two numbers and then writing the results is 2xREAD and 1xWRITE ==> 300MB total in 0.05 seconds
 // 300MB * 20 = 6GB/sec bandwidth
 // Bit count stuff
-// Output is INT8
-typedef void(*I16_I8_FUNC)(INT16* pDataIn, INT8* pDataOut, INT64 len);
-typedef void(*I32_I8_FUNC)(INT32* pDataIn, INT8* pDataOut, INT64 len);
-typedef void(*I64_I8_FUNC)(INT64* pDataIn, INT8* pDataOut, INT64 len);
+// Output is int8_t
+typedef void(*I16_I8_FUNC)(int16_t* pDataIn, int8_t* pDataOut, int64_t len);
+typedef void(*I32_I8_FUNC)(int32_t* pDataIn, int8_t* pDataOut, int64_t len);
+typedef void(*I64_I8_FUNC)(int64_t* pDataIn, int8_t* pDataOut, int64_t len);
 
 //----------------------------------------------------
 // returns pointer to a data type (of same size in memory) that holds the invalid value for the type
@@ -458,14 +458,14 @@ void* GetDefaultForType(int numpyInType);
 
 // Overloads to handle invalids
 static inline  bool   GET_INVALID(bool x) { return   false; }
-static inline  INT8   GET_INVALID(INT8 X) { return   -128; }
-static inline  UINT8  GET_INVALID(UINT8 X) { return  0xFF; }
-static inline  INT16  GET_INVALID(INT16 X) { return  -32768; }
-static inline  UINT16 GET_INVALID(UINT16 X) { return 0xFFFF; }
-static inline  INT32  GET_INVALID(INT32 X) { return  0x80000000; }
-static inline  UINT32 GET_INVALID(UINT32 X) { return 0xFFFFFFFF; }
-static inline  INT64  GET_INVALID(INT64 X) { return  0x8000000000000000; }
-static inline  UINT64 GET_INVALID(UINT64 X) { return 0xFFFFFFFFFFFFFFFF; }
+static inline  int8_t   GET_INVALID(int8_t X) { return   -128; }
+static inline  uint8_t  GET_INVALID(uint8_t X) { return  0xFF; }
+static inline  int16_t  GET_INVALID(int16_t X) { return  -32768; }
+static inline  uint16_t GET_INVALID(uint16_t X) { return 0xFFFF; }
+static inline  int32_t  GET_INVALID(int32_t X) { return  0x80000000; }
+static inline  uint32_t GET_INVALID(uint32_t X) { return 0xFFFFFFFF; }
+static inline  int64_t  GET_INVALID(int64_t X) { return  0x8000000000000000; }
+static inline  uint64_t GET_INVALID(uint64_t X) { return 0xFFFFFFFFFFFFFFFF; }
 static inline  float  GET_INVALID(float X) { return  std::numeric_limits<float>::quiet_NaN(); }
 static inline  double GET_INVALID(double X) { return std::numeric_limits<double>::quiet_NaN(); }
 static inline  long double GET_INVALID(long double X) { return std::numeric_limits<long double>::quiet_NaN(); }
@@ -495,17 +495,17 @@ enum SCALAR_MODE {
 //-----------------------------------------------------------
 // List of function calls
 struct FUNCTION_LIST {
-   INT16             TypeOfFunctionCall; // See enum
-   INT16             NumpyType;         // For the array and constants
-   INT16             NumpyOutputType;
+   int16_t             TypeOfFunctionCall; // See enum
+   int16_t             NumpyType;         // For the array and constants
+   int16_t             NumpyOutputType;
 
    // The item size for two input arrays assumed to be the same
-   INT64             InputItemSize;
-   INT64             OutputItemSize;
+   int64_t             InputItemSize;
+   int64_t             OutputItemSize;
 
    // Strides may be 0 if it is a scalar or length 1
-   INT64             Input1Strides;
-   INT64             Input2Strides;
+   int64_t             Input1Strides;
+   int64_t             Input2Strides;
 
    // TODO: Why not make this void and recast?
    // Only one of these can be set

--- a/src/CommonInc.h
+++ b/src/CommonInc.h
@@ -72,6 +72,7 @@ using HANDLE = void*;
 
 using INT_PTR = ptrdiff_t;
 using DWORD = uint32_t;
+using LPVOID = void*;
 
 #define WINAPI
 #include <pthread.h>

--- a/src/Compare.cpp
+++ b/src/Compare.cpp
@@ -782,7 +782,7 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       case MATH_OPERATION::CMP_LTE:     return CompareDouble<_CMP_LE_OS, COMP_LE>;
       }
       break;
-   case NPY_INT:
+   case NPY_INT32:
       switch (func) {
       case MATH_OPERATION::CMP_EQ:      return CompareInt32S<COMP32i_EQS<__m256i>, COMP_EQ>;
       case MATH_OPERATION::CMP_NE:      return CompareInt32<COMP32i_NE<__m256i>, COMP_NE>;
@@ -792,7 +792,7 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       case MATH_OPERATION::CMP_LTE:     return CompareInt32<COMP32i_LE<__m256i>, COMP_LE>;
       }
       break;
-   case NPY_UINT:
+   case NPY_UINT32:
       switch (func) {
       // NOTE: if this needs to get sped up, upcast from uint32_t to int64_t  using _mm256_cvtepu32_epi64 and cmpint64
       // For equal, not equal the sign does not matter

--- a/src/Compare.cpp
+++ b/src/Compare.cpp
@@ -47,7 +47,7 @@ inline __m256i LOADU(const __m256i* x) { return _mm256_loadu_si256((__m256i cons
 
 // Debug routine to dump 8 int32 values
 //void printm256(__m256i m0) {
-//   INT32* pData = (INT32*)&m0;
+//   int32_t* pData = (int32_t*)&m0;
 //   printf("Value is 0x%.8x 0x%.8x 0x%.8x 0x%.8x 0x%.8x 0x%.8x 0x%.8x 0x%.8x\n", pData[0], pData[1], pData[2], pData[3], pData[4], pData[5], pData[6], pData[7]);
 //}
 
@@ -124,24 +124,24 @@ template<typename T> FORCE_INLINE const __m256i COMP32i_LTS(T y1, T x1, T y2, T 
 }
 
 // This series of functions processes 8 int32 and returns 8 bools
-template<typename T> FORCE_INLINE const INT64 COMP32i_EQ(T x, T y) { return gBooleanLUT64[_mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpeq_epi32(x, y))) & 255];}
-template<typename T> FORCE_INLINE const INT64 COMP32i_NE(T x, T y) { return gBooleanLUT64Inverse[_mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpeq_epi32(x, y))) & 255]; }
-template<typename T> FORCE_INLINE const INT64 COMP32i_GT(T x, T y) { return gBooleanLUT64[_mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpgt_epi32(x, y))) & 255]; }
-template<typename T> FORCE_INLINE const INT64 COMP32i_LT(T x, T y) { return gBooleanLUT64[_mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpgt_epi32(y, x))) & 255]; }
-template<typename T> FORCE_INLINE const INT64 COMP32i_GE(T x, T y) { return gBooleanLUT64Inverse[_mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpgt_epi32(y, x))) & 255]; }
-template<typename T> FORCE_INLINE const INT64 COMP32i_LE(T x, T y) { return gBooleanLUT64Inverse[_mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpgt_epi32(x, y))) & 255]; }
+template<typename T> FORCE_INLINE const int64_t COMP32i_EQ(T x, T y) { return gBooleanLUT64[_mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpeq_epi32(x, y))) & 255];}
+template<typename T> FORCE_INLINE const int64_t COMP32i_NE(T x, T y) { return gBooleanLUT64Inverse[_mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpeq_epi32(x, y))) & 255]; }
+template<typename T> FORCE_INLINE const int64_t COMP32i_GT(T x, T y) { return gBooleanLUT64[_mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpgt_epi32(x, y))) & 255]; }
+template<typename T> FORCE_INLINE const int64_t COMP32i_LT(T x, T y) { return gBooleanLUT64[_mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpgt_epi32(y, x))) & 255]; }
+template<typename T> FORCE_INLINE const int64_t COMP32i_GE(T x, T y) { return gBooleanLUT64Inverse[_mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpgt_epi32(y, x))) & 255]; }
+template<typename T> FORCE_INLINE const int64_t COMP32i_LE(T x, T y) { return gBooleanLUT64Inverse[_mm256_movemask_ps(_mm256_castsi256_ps(_mm256_cmpgt_epi32(x, y))) & 255]; }
 
 // This will compute 4 x int64 comparison at a time
-template<typename T> FORCE_INLINE const INT32 COMP64i_EQ(T x, T y) { 
+template<typename T> FORCE_INLINE const int32_t COMP64i_EQ(T x, T y) { 
    return gBooleanLUT32[_mm256_movemask_pd(_mm256_castsi256_pd(_mm256_cmpeq_epi64(x, y))) & 15];
 }
 
 // This series of functions processes 4 int64 and returns 4 bools
-template<typename T> FORCE_INLINE const INT32 COMP64i_NE(T x, T y) { return gBooleanLUT32Inverse[_mm256_movemask_pd(_mm256_castsi256_pd(_mm256_cmpeq_epi64(x, y))) & 15]; }
-template<typename T> FORCE_INLINE const INT32 COMP64i_GT(T x, T y) { return gBooleanLUT32[_mm256_movemask_pd(_mm256_castsi256_pd(_mm256_cmpgt_epi64(x, y))) & 15]; }
-template<typename T> FORCE_INLINE const INT32 COMP64i_LT(T x, T y) { return gBooleanLUT32[_mm256_movemask_pd(_mm256_castsi256_pd(_mm256_cmpgt_epi64(y, x))) & 15]; }
-template<typename T> FORCE_INLINE const INT32 COMP64i_GE(T x, T y) { return gBooleanLUT32Inverse[_mm256_movemask_pd(_mm256_castsi256_pd(_mm256_cmpgt_epi64(y, x))) & 15]; }
-template<typename T> FORCE_INLINE const INT32 COMP64i_LE(T x, T y) { return gBooleanLUT32Inverse[_mm256_movemask_pd(_mm256_castsi256_pd(_mm256_cmpgt_epi64(x, y))) & 15]; }
+template<typename T> FORCE_INLINE const int32_t COMP64i_NE(T x, T y) { return gBooleanLUT32Inverse[_mm256_movemask_pd(_mm256_castsi256_pd(_mm256_cmpeq_epi64(x, y))) & 15]; }
+template<typename T> FORCE_INLINE const int32_t COMP64i_GT(T x, T y) { return gBooleanLUT32[_mm256_movemask_pd(_mm256_castsi256_pd(_mm256_cmpgt_epi64(x, y))) & 15]; }
+template<typename T> FORCE_INLINE const int32_t COMP64i_LT(T x, T y) { return gBooleanLUT32[_mm256_movemask_pd(_mm256_castsi256_pd(_mm256_cmpgt_epi64(y, x))) & 15]; }
+template<typename T> FORCE_INLINE const int32_t COMP64i_GE(T x, T y) { return gBooleanLUT32Inverse[_mm256_movemask_pd(_mm256_castsi256_pd(_mm256_cmpgt_epi64(y, x))) & 15]; }
+template<typename T> FORCE_INLINE const int32_t COMP64i_LE(T x, T y) { return gBooleanLUT32Inverse[_mm256_movemask_pd(_mm256_castsi256_pd(_mm256_cmpgt_epi64(x, y))) & 15]; }
 
 // This will compute 32 x int8 comparison at a time
 template<typename T> FORCE_INLINE const __m256i COMP8i_EQ(T x, T y, T mask1) { return _mm256_and_si256(_mm256_cmpeq_epi8(x, y), mask1); }
@@ -198,19 +198,19 @@ template<typename T> FORCE_INLINE const bool COMP_LT(T X, T Y) { return (X <  Y)
 template<typename T> FORCE_INLINE const bool COMP_LE(T X, T Y) { return (X <= Y); }
 template<typename T> FORCE_INLINE const bool COMP_NE(T X, T Y) { return (X != Y); }
 
-// Comparing INT64 to UINT64
-template<typename T> FORCE_INLINE const bool COMP_GT_INT64(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X > Y); }
-template<typename T> FORCE_INLINE const bool COMP_GE_INT64(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X >= Y); }
-template<typename T> FORCE_INLINE const bool COMP_LT_INT64(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X < Y); }
-template<typename T> FORCE_INLINE const bool COMP_LE_INT64(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X <= Y); }
+// Comparing int64_t to uint64_t
+template<typename T> FORCE_INLINE const bool COMP_GT_int64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X > Y); }
+template<typename T> FORCE_INLINE const bool COMP_GE_int64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X >= Y); }
+template<typename T> FORCE_INLINE const bool COMP_LT_int64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X < Y); }
+template<typename T> FORCE_INLINE const bool COMP_LE_int64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X <= Y); }
 
-// Comparing UINT64 to INT64
-template<typename T> FORCE_INLINE const bool COMP_EQ_UINT64(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X == Y); }
-template<typename T> FORCE_INLINE const bool COMP_NE_UINT64(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X != Y); }
-template<typename T> FORCE_INLINE const bool COMP_GT_UINT64(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X > Y); }
-template<typename T> FORCE_INLINE const bool COMP_GE_UINT64(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X >= Y); }
-template<typename T> FORCE_INLINE const bool COMP_LT_UINT64(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X < Y); }
-template<typename T> FORCE_INLINE const bool COMP_LE_UINT64(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X <= Y); }
+// Comparing uint64_t to int64_t
+template<typename T> FORCE_INLINE const bool COMP_EQ_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X == Y); }
+template<typename T> FORCE_INLINE const bool COMP_NE_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X != Y); }
+template<typename T> FORCE_INLINE const bool COMP_GT_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X > Y); }
+template<typename T> FORCE_INLINE const bool COMP_GE_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X >= Y); }
+template<typename T> FORCE_INLINE const bool COMP_LT_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X < Y); }
+template<typename T> FORCE_INLINE const bool COMP_LE_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X <= Y); }
 
 
 
@@ -219,30 +219,30 @@ template<typename T> FORCE_INLINE const bool COMP_LE_UINT64(T X, T Y) { if ((X |
 // It can handle scalars
 // Used by comparison of integers
 template<typename T, const bool COMPARE(T,T)>
-static void CompareAny(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
-   INT8* pDataOutX = (INT8*)pDataOut;    
+static void CompareAny(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
+   int8_t* pDataOutX = (int8_t*)pDataOut;    
    T* pDataInX = (T*)pDataIn;      
    T* pDataIn2X = (T*)pDataIn2;      
 
    LOGGING("compare any sizeof(T) %lld  len: %lld  scalarmode: %d\n", sizeof(T), len, scalarMode);
 
    if (scalarMode == SCALAR_MODE::NO_SCALARS) {
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[i]);
       } 
    }
    else 
    if (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR) {
       T arg1 = *pDataInX;  
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(arg1, pDataIn2X[i]);
       } 
 }
    else 
    if (scalarMode == SCALAR_MODE::SECOND_ARG_SCALAR) {
       T arg2 = *pDataIn2X;
-      LOGGING("arg2 is %lld or %llu\n", (INT64)arg2, (UINT64)arg2);
-      for (INT64 i = 0; i < len; i++) {
+      LOGGING("arg2 is %lld or %llu\n", (int64_t)arg2, (uint64_t)arg2);
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(pDataInX[i], arg2);
       } 
    }
@@ -250,7 +250,7 @@ static void CompareAny(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len,
       // probably cannot happen         
       T arg1 = *pDataInX;  
       T arg2 = *pDataIn2X;  
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(arg1, arg2);
       } 
    }
@@ -260,51 +260,51 @@ static void CompareAny(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len,
 //----------------------------------------------------------------------------------
 // Lookup to go from 1 byte to 8 byte boolean values
 template<const int COMP_OPCODE, const bool COMPARE(float, float)>
-static void CompareFloat(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) {
+static void CompareFloat(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) {
    const __m256* pSrc1Fast = (const __m256*)pDataIn;                             
    const __m256* pSrc2Fast = (const __m256*)pDataIn2;                            
-   INT64 fastCount = len / 8;                                                    
-   INT64* pDestFast = (INT64*)pDataOut;          
+   int64_t fastCount = len / 8;                                                    
+   int64_t* pDestFast = (int64_t*)pDataOut;          
 
    if (scalarMode == SCALAR_MODE::NO_SCALARS) {                                 
-      for (INT64 i = 0; i < fastCount; i++) {                                       
+      for (int64_t i = 0; i < fastCount; i++) {                                       
          // Alternate way
-         INT32 bitmask = _mm256_movemask_ps(_mm256_cmp_ps(LOADU(pSrc1Fast+i), LOADU(pSrc2Fast+ i), COMP_OPCODE));
+         int32_t bitmask = _mm256_movemask_ps(_mm256_cmp_ps(LOADU(pSrc1Fast+i), LOADU(pSrc2Fast+ i), COMP_OPCODE));
          pDestFast[i] = gBooleanLUT64[bitmask & 255];                               
       }                                                                             
       len = len - (fastCount * 8);                               
       const float* pDataInX = &((float*)pDataIn)[fastCount * 8];
       const float* pDataIn2X = &((float*)pDataIn2)[fastCount * 8];
-      INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 8];
-      for (INT64 i = 0; i < len; i++) {
+      int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 8];
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[i]);
       }
    } else 
    if (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR) { 
       __m256 m0 = LOADU(pSrc1Fast);
-      for (INT64 i = 0; i < fastCount; i++) {                                       
-         INT32 bitmask = _mm256_movemask_ps(_mm256_cmp_ps(m0, LOADU(pSrc2Fast+i), COMP_OPCODE));
+      for (int64_t i = 0; i < fastCount; i++) {                                       
+         int32_t bitmask = _mm256_movemask_ps(_mm256_cmp_ps(m0, LOADU(pSrc2Fast+i), COMP_OPCODE));
          pDestFast[i] = gBooleanLUT64[bitmask & 255];                               
       }                                                                             
       len = len - (fastCount * 8);
       const float* pDataInX = (float*)pDataIn;
       const float* pDataIn2X = &((float*)pDataIn2)[fastCount * 8];
-      INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 8];
-      for (INT64 i = 0; i < len; i++) {
+      int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 8];
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(pDataInX[0], pDataIn2X[i]);
       }
    } else 
    if (scalarMode == SCALAR_MODE::SECOND_ARG_SCALAR) { 
       __m256 m0 = LOADU(pSrc2Fast);
-      for (INT64 i = 0; i < fastCount; i++) {
-         INT32 bitmask = _mm256_movemask_ps(_mm256_cmp_ps(LOADU(pSrc1Fast+i), m0, COMP_OPCODE));
+      for (int64_t i = 0; i < fastCount; i++) {
+         int32_t bitmask = _mm256_movemask_ps(_mm256_cmp_ps(LOADU(pSrc1Fast+i), m0, COMP_OPCODE));
          pDestFast[i] = gBooleanLUT64[bitmask & 255];                               
       }                                                                             
       len = len - (fastCount * 8);
       const float* pDataInX = &((float*)pDataIn)[fastCount * 8];
       const float* pDataIn2X = (float*)pDataIn2;
-      INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 8];
-      for (INT64 i = 0; i < len; i++) {
+      int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 8];
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[0]);
       }
    } else { 
@@ -315,19 +315,19 @@ static void CompareFloat(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 le
 //=======================================================================================================
 //
 template<const int COMP_OPCODE, const bool COMPARE(double, double)>
-static void CompareDouble(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode)
+static void CompareDouble(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode)
 {
    
    const __m256d* pSrc1Fast = (const __m256d*)pDataIn;                             
    const __m256d* pSrc2Fast = (const __m256d*)pDataIn2;                            
-   INT64 fastCount = len / 4;                                                    
-   INT32* pDestFast = (INT32*)pDataOut;       
+   int64_t fastCount = len / 4;                                                    
+   int32_t* pDestFast = (int32_t*)pDataOut;       
 
    if (scalarMode == SCALAR_MODE::NO_SCALARS) 
    {
-      for (INT64 i = 0; i < fastCount; i++)          
+      for (int64_t i = 0; i < fastCount; i++)          
       {
-         INT32 bitmask = _mm256_movemask_pd(_mm256_cmp_pd(LOADU(pSrc1Fast+i), LOADU(pSrc2Fast+ i), COMP_OPCODE));
+         int32_t bitmask = _mm256_movemask_pd(_mm256_cmp_pd(LOADU(pSrc1Fast+i), LOADU(pSrc2Fast+ i), COMP_OPCODE));
          //printf("bitmask is %d\n", bitmask);
          //printf("bitmask & 15 is %d\n", bitmask & 15);
          pDestFast[i] = gBooleanLUT32[bitmask & 15];
@@ -335,8 +335,8 @@ static void CompareDouble(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 l
       len = len - (fastCount * 4);
       const double* pDataInX = &((double*)pDataIn)[fastCount * 4];
       const double* pDataIn2X = &((double*)pDataIn2)[fastCount * 4];
-      INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 4];
-      for (INT64 i = 0; i < len; i++) {
+      int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 4];
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[i]);
       }
    } 
@@ -344,16 +344,16 @@ static void CompareDouble(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 l
    if (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR) 
    {
       __m256d m0 = LOADU(pSrc1Fast);
-      for (INT64 i = 0; i < fastCount; i++)
+      for (int64_t i = 0; i < fastCount; i++)
       {   
-         INT32 bitmask = _mm256_movemask_pd( _mm256_cmp_pd(m0, LOADU(pSrc2Fast+i), COMP_OPCODE));
+         int32_t bitmask = _mm256_movemask_pd( _mm256_cmp_pd(m0, LOADU(pSrc2Fast+i), COMP_OPCODE));
          pDestFast[i] = gBooleanLUT32[bitmask & 15];                               
       }                                                                             
       len = len - (fastCount * 4);
       const double* pDataInX = (double*)pDataIn;
       const double* pDataIn2X = &((double*)pDataIn2)[fastCount * 4];
-      INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 4];
-      for (INT64 i = 0; i < len; i++) {
+      int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 4];
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(pDataInX[0], pDataIn2X[i]);
       }
    } 
@@ -361,16 +361,16 @@ static void CompareDouble(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 l
    if (scalarMode == SCALAR_MODE::SECOND_ARG_SCALAR) 
    {   
       __m256d m0 = LOADU(pSrc2Fast);
-      for (INT64 i = 0; i < fastCount; i++)
+      for (int64_t i = 0; i < fastCount; i++)
       {         
-         INT32 bitmask = _mm256_movemask_pd( _mm256_cmp_pd(LOADU(pSrc1Fast+i), m0, COMP_OPCODE));
+         int32_t bitmask = _mm256_movemask_pd( _mm256_cmp_pd(LOADU(pSrc1Fast+i), m0, COMP_OPCODE));
          pDestFast[i] = gBooleanLUT32[bitmask & 15];                               
       }                                                                             
       len = len - (fastCount * 4);
       const double* pDataInX = &((double*)pDataIn)[fastCount * 4];
       const double* pDataIn2X = (double*)pDataIn2;
-      INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 4];
-      for (INT64 i = 0; i < len; i++) {
+      int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 4];
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[0]);
       }
    } 
@@ -380,27 +380,27 @@ static void CompareDouble(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 l
 
 //=======================================================================================================
 //
-template<const INT32 COMP_256(__m256i, __m256i), const bool COMPARE(INT64, INT64)>
-static void CompareInt64(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode)
+template<const int32_t COMP_256(__m256i, __m256i), const bool COMPARE(int64_t, int64_t)>
+static void CompareInt64(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode)
 {
 
    const __m256i* pSrc1Fast = (const __m256i*)pDataIn;
    const __m256i* pSrc2Fast = (const __m256i*)pDataIn2;
-   INT64 fastCount = len / 4;
-   INT32* pDestFast = (INT32*)pDataOut;
+   int64_t fastCount = len / 4;
+   int32_t* pDestFast = (int32_t*)pDataOut;
 
    if (scalarMode == SCALAR_MODE::NO_SCALARS)
    {
-      for (INT64 i = 0; i < fastCount; i++)
+      for (int64_t i = 0; i < fastCount; i++)
       {
          pDestFast[i] = COMP_256(LOADU(pSrc1Fast + i), LOADU(pSrc2Fast + i));
 
       }
       len = len - (fastCount * 4);
-      const INT64* pDataInX = &((INT64*)pDataIn)[fastCount * 4];
-      const INT64* pDataIn2X = &((INT64*)pDataIn2)[fastCount * 4];
-      INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 4];
-      for (INT64 i = 0; i < len; i++) {
+      const int64_t* pDataInX = &((int64_t*)pDataIn)[fastCount * 4];
+      const int64_t* pDataIn2X = &((int64_t*)pDataIn2)[fastCount * 4];
+      int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 4];
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[i]);
       }
    }
@@ -408,15 +408,15 @@ static void CompareInt64(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 le
       if (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR)
       {
          __m256i m0 = LOADU(pSrc1Fast);
-         for (INT64 i = 0; i < fastCount; i++)
+         for (int64_t i = 0; i < fastCount; i++)
          {
             pDestFast[i] = COMP_256(m0, LOADU(pSrc2Fast +i));
          }
          len = len - (fastCount * 4);
-         const INT64* pDataInX = (INT64*)pDataIn;
-         const INT64* pDataIn2X = &((INT64*)pDataIn2)[fastCount * 4];
-         INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 4];
-         for (INT64 i = 0; i < len; i++) {
+         const int64_t* pDataInX = (int64_t*)pDataIn;
+         const int64_t* pDataIn2X = &((int64_t*)pDataIn2)[fastCount * 4];
+         int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 4];
+         for (int64_t i = 0; i < len; i++) {
             pDataOutX[i] = COMPARE(pDataInX[0], pDataIn2X[i]);
          }
       }
@@ -424,15 +424,15 @@ static void CompareInt64(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 le
          if (scalarMode == SCALAR_MODE::SECOND_ARG_SCALAR)
          {
             __m256i m0 = LOADU(pSrc2Fast);
-            for (INT64 i = 0; i < fastCount; i++)
+            for (int64_t i = 0; i < fastCount; i++)
             {
                pDestFast[i] = COMP_256(LOADU(pSrc1Fast+i), m0);
             }
             len = len - (fastCount * 4);
-            const INT64* pDataInX = &((INT64*)pDataIn)[fastCount * 4];
-            const INT64* pDataIn2X = (INT64*)pDataIn2;
-            INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 4];
-            for (INT64 i = 0; i < len; i++) {
+            const int64_t* pDataInX = &((int64_t*)pDataIn)[fastCount * 4];
+            const int64_t* pDataIn2X = (int64_t*)pDataIn2;
+            int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 4];
+            for (int64_t i = 0; i < len; i++) {
                pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[0]);
             }
          }
@@ -444,13 +444,13 @@ static void CompareInt64(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 le
 // Compare 4x8xint32 using 256bit vector intrinsics
 // This routine is currently disabled and runs at slightly faster speed as CompareInt32
 // Leave the code because as is a good example on how to compute 32 bools
-template<const __m256i COMP_256(__m256i, __m256i, __m256i, __m256i, __m256i, __m256i, __m256i, __m256i), const bool COMPARE(INT32, INT32)>
-static void CompareInt32S(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode)
+template<const __m256i COMP_256(__m256i, __m256i, __m256i, __m256i, __m256i, __m256i, __m256i, __m256i), const bool COMPARE(int32_t, int32_t)>
+static void CompareInt32S(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode)
 {
    const __m256i* pSrc1Fast = (const __m256i*)pDataIn;
    const __m256i* pSrc2Fast = (const __m256i*)pDataIn2;
    // compute 32 bools at once
-   INT64 fastCount = len / 32;
+   int64_t fastCount = len / 32;
    __m256i* pDestFast = (__m256i*)pDataOut;
    __m256i* pDestFastEnd = pDestFast + fastCount;
 
@@ -470,10 +470,10 @@ static void CompareInt32S(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 l
          pDestFast++;
       }
       len = len - (fastCount * 32);
-      const INT32* pDataInX = (INT32*)pSrc1Fast;
-      const INT32* pDataIn2X =(INT32*)pSrc2Fast;
-      INT8* pDataOutX = (INT8*)pDestFast;
-      for (INT64 i = 0; i < len; i++) {
+      const int32_t* pDataInX = (int32_t*)pSrc1Fast;
+      const int32_t* pDataIn2X =(int32_t*)pSrc2Fast;
+      int8_t* pDataOutX = (int8_t*)pDestFast;
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[i]);
       }
    }
@@ -493,10 +493,10 @@ static void CompareInt32S(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 l
             pDestFast++;
          }
          len = len - (fastCount * 32);
-         const INT32* pDataInX = (INT32*)pDataIn;
-         const INT32* pDataIn2X = (INT32*)pSrc2Fast;
-         INT8* pDataOutX = (INT8*)pDestFast;
-         for (INT64 i = 0; i < len; i++) {
+         const int32_t* pDataInX = (int32_t*)pDataIn;
+         const int32_t* pDataIn2X = (int32_t*)pSrc2Fast;
+         int8_t* pDataOutX = (int8_t*)pDestFast;
+         for (int64_t i = 0; i < len; i++) {
             pDataOutX[i] = COMPARE(pDataInX[0], pDataIn2X[i]);
          }
       }
@@ -517,10 +517,10 @@ static void CompareInt32S(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 l
                pDestFast++;
             }
             len = len - (fastCount * 32);
-            const INT32* pDataInX = (INT32*)pSrc1Fast;
-            const INT32* pDataIn2X = (INT32*)pDataIn2;
-            INT8* pDataOutX = (INT8*)pDestFast;
-            for (INT64 i = 0; i < len; i++) {
+            const int32_t* pDataInX = (int32_t*)pSrc1Fast;
+            const int32_t* pDataIn2X = (int32_t*)pDataIn2;
+            int8_t* pDataOutX = (int8_t*)pDestFast;
+            for (int64_t i = 0; i < len; i++) {
                pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[0]);
             }
          }
@@ -529,27 +529,27 @@ static void CompareInt32S(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 l
 
 //=======================================================================================================
 // Compare 8xint32 using 256bit vector intrinsics
-template<const INT64 COMP_256(__m256i, __m256i), const bool COMPARE(INT32, INT32)>
-static void CompareInt32(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode)
+template<const int64_t COMP_256(__m256i, __m256i), const bool COMPARE(int32_t, int32_t)>
+static void CompareInt32(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode)
 {
 
    const __m256i* pSrc1Fast = (const __m256i*)pDataIn;
    const __m256i* pSrc2Fast = (const __m256i*)pDataIn2;
    // compute 8 bools at once
-   INT64 fastCount = len / 8;
-   INT64* pDestFast = (INT64*)pDataOut;
+   int64_t fastCount = len / 8;
+   int64_t* pDestFast = (int64_t*)pDataOut;
 
    if (scalarMode == SCALAR_MODE::NO_SCALARS)
    {
-      for (INT64 i = 0; i < fastCount; i++)
+      for (int64_t i = 0; i < fastCount; i++)
       {
          pDestFast[i] = COMP_256(LOADU(pSrc1Fast + i), LOADU(pSrc2Fast + i));
       }
       len = len - (fastCount * 8);
-      const INT32* pDataInX = &((INT32*)pDataIn)[fastCount * 8];
-      const INT32* pDataIn2X = &((INT32*)pDataIn2)[fastCount * 8];
-      INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 8];
-      for (INT64 i = 0; i < len; i++) {
+      const int32_t* pDataInX = &((int32_t*)pDataIn)[fastCount * 8];
+      const int32_t* pDataIn2X = &((int32_t*)pDataIn2)[fastCount * 8];
+      int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 8];
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[i]);
       }
    }
@@ -557,15 +557,15 @@ static void CompareInt32(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 le
       if (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR)
       {
          __m256i m0 = LOADU(pSrc1Fast);
-         for (INT64 i = 0; i < fastCount; i++)
+         for (int64_t i = 0; i < fastCount; i++)
          {
             pDestFast[i] = COMP_256(m0, LOADU(pSrc2Fast + i));
          }
          len = len - (fastCount * 8);
-         const INT32* pDataInX = (INT32*)pDataIn;
-         const INT32* pDataIn2X = &((INT32*)pDataIn2)[fastCount * 8];
-         INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 8];
-         for (INT64 i = 0; i < len; i++) {
+         const int32_t* pDataInX = (int32_t*)pDataIn;
+         const int32_t* pDataIn2X = &((int32_t*)pDataIn2)[fastCount * 8];
+         int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 8];
+         for (int64_t i = 0; i < len; i++) {
             pDataOutX[i] = COMPARE(pDataInX[0], pDataIn2X[i]);
          }
       }
@@ -573,15 +573,15 @@ static void CompareInt32(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 le
          if (scalarMode == SCALAR_MODE::SECOND_ARG_SCALAR)
          {
             __m256i m0 = LOADU(pSrc2Fast);
-            for (INT64 i = 0; i < fastCount; i++)
+            for (int64_t i = 0; i < fastCount; i++)
             {
                pDestFast[i] = COMP_256(LOADU(pSrc1Fast + i), m0);
             }
             len = len - (fastCount * 8);
-            const INT32* pDataInX = &((INT32*)pDataIn)[fastCount * 8];
-            const INT32* pDataIn2X = (INT32*)pDataIn2;
-            INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 8];
-            for (INT64 i = 0; i < len; i++) {
+            const int32_t* pDataInX = &((int32_t*)pDataIn)[fastCount * 8];
+            const int32_t* pDataIn2X = (int32_t*)pDataIn2;
+            int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 8];
+            for (int64_t i = 0; i < len; i++) {
                pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[0]);
             }
          }
@@ -591,28 +591,28 @@ static void CompareInt32(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 le
 
 //=======================================================================================================
 // Compare 8xint8 using 256bit vector intrinsics
-template<const __m256i COMP_256(__m256i, __m256i, __m256i), const bool COMPARE(INT8, INT8)>
-static void CompareInt8(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode)
+template<const __m256i COMP_256(__m256i, __m256i, __m256i), const bool COMPARE(int8_t, int8_t)>
+static void CompareInt8(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode)
 {
 
    const __m256i* pSrc1Fast = (const __m256i*)pDataIn;
    const __m256i* pSrc2Fast = (const __m256i*)pDataIn2;
    // compute 32 bools at once
-   INT64 fastCount = len / 32;
+   int64_t fastCount = len / 32;
    __m256i* pDestFast = (__m256i*)pDataOut;
    __m256i mask1 = _mm256_set1_epi8(1);
 
    if (scalarMode == SCALAR_MODE::NO_SCALARS)
    {
-      for (INT64 i = 0; i < fastCount; i++)
+      for (int64_t i = 0; i < fastCount; i++)
       {
          STOREU(pDestFast + i, COMP_256(LOADU(pSrc1Fast + i), LOADU(pSrc2Fast + i), mask1));
       }
       len = len - (fastCount * 32);
-      const INT8* pDataInX = &((INT8*)pDataIn)[fastCount * 32];
-      const INT8* pDataIn2X = &((INT8*)pDataIn2)[fastCount * 32];
-      INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 32];
-      for (INT64 i = 0; i < len; i++) {
+      const int8_t* pDataInX = &((int8_t*)pDataIn)[fastCount * 32];
+      const int8_t* pDataIn2X = &((int8_t*)pDataIn2)[fastCount * 32];
+      int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 32];
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[i]);
       }
    }
@@ -620,15 +620,15 @@ static void CompareInt8(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len
       if (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR)
       {
          __m256i m0 = LOADU(pSrc1Fast);
-         for (INT64 i = 0; i < fastCount; i++)
+         for (int64_t i = 0; i < fastCount; i++)
          {
             STOREU(pDestFast +i, COMP_256(m0, LOADU(pSrc2Fast + i), mask1));
          }
          len = len - (fastCount * 32);
-         const INT8* pDataInX = (INT8*)pDataIn;
-         const INT8* pDataIn2X = &((INT8*)pDataIn2)[fastCount * 32];
-         INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 32];
-         for (INT64 i = 0; i < len; i++) {
+         const int8_t* pDataInX = (int8_t*)pDataIn;
+         const int8_t* pDataIn2X = &((int8_t*)pDataIn2)[fastCount * 32];
+         int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 32];
+         for (int64_t i = 0; i < len; i++) {
             pDataOutX[i] = COMPARE(pDataInX[0], pDataIn2X[i]);
          }
       }
@@ -636,15 +636,15 @@ static void CompareInt8(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len
          if (scalarMode == SCALAR_MODE::SECOND_ARG_SCALAR)
          {
             __m256i m0 = LOADU(pSrc2Fast);
-            for (INT64 i = 0; i < fastCount; i++)
+            for (int64_t i = 0; i < fastCount; i++)
             {
                STOREU(pDestFast + i, COMP_256(LOADU(pSrc1Fast + i), m0, mask1));
             }
             len = len - (fastCount * 32);
-            const INT8* pDataInX = &((INT8*)pDataIn)[fastCount * 32];
-            const INT8* pDataIn2X = (INT8*)pDataIn2;
-            INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 32];
-            for (INT64 i = 0; i < len; i++) {
+            const int8_t* pDataInX = &((int8_t*)pDataIn)[fastCount * 32];
+            const int8_t* pDataIn2X = (int8_t*)pDataIn2;
+            int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 32];
+            for (int64_t i = 0; i < len; i++) {
                pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[0]);
             }
          }
@@ -654,28 +654,28 @@ static void CompareInt8(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len
 
 //=======================================================================================================
 // Compare 8xint16 using 256bit vector intrinsics
-template<const __m128i COMP_256(__m256i, __m256i, __m256i), const bool COMPARE(INT16, INT16)>
-static void CompareInt16(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode)
+template<const __m128i COMP_256(__m256i, __m256i, __m256i), const bool COMPARE(int16_t, int16_t)>
+static void CompareInt16(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode)
 {
 
    const __m256i* pSrc1Fast = (const __m256i*)pDataIn;
    const __m256i* pSrc2Fast = (const __m256i*)pDataIn2;
    // compute 16 bools at once
-   INT64 fastCount = len / 16;
+   int64_t fastCount = len / 16;
    __m128i* pDestFast = (__m128i*)pDataOut;
    __m256i mask1 = _mm256_set1_epi16(1);
 
    if (scalarMode == SCALAR_MODE::NO_SCALARS)
    {
-      for (INT64 i = 0; i < fastCount; i++)
+      for (int64_t i = 0; i < fastCount; i++)
       {
          STOREU128(pDestFast + i, COMP_256(LOADU(pSrc1Fast + i), LOADU(pSrc2Fast + i), mask1));
       }
       len = len - (fastCount * 16);
-      const INT16* pDataInX = &((INT16*)pDataIn)[fastCount * 16];
-      const INT16* pDataIn2X = &((INT16*)pDataIn2)[fastCount * 16];
-      INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 16];
-      for (INT64 i = 0; i < len; i++) {
+      const int16_t* pDataInX = &((int16_t*)pDataIn)[fastCount * 16];
+      const int16_t* pDataIn2X = &((int16_t*)pDataIn2)[fastCount * 16];
+      int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 16];
+      for (int64_t i = 0; i < len; i++) {
          pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[i]);
       }
    }
@@ -683,15 +683,15 @@ static void CompareInt16(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 le
       if (scalarMode == SCALAR_MODE::FIRST_ARG_SCALAR)
       {
          __m256i m0 = LOADU(pSrc1Fast);
-         for (INT64 i = 0; i < fastCount; i++)
+         for (int64_t i = 0; i < fastCount; i++)
          {
             STOREU128(pDestFast + i, COMP_256(m0, LOADU(pSrc2Fast + i), mask1));
          }
          len = len - (fastCount * 16);
-         const INT16* pDataInX = (INT16*)pDataIn;
-         const INT16* pDataIn2X = &((INT16*)pDataIn2)[fastCount * 16];
-         INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 16];
-         for (INT64 i = 0; i < len; i++) {
+         const int16_t* pDataInX = (int16_t*)pDataIn;
+         const int16_t* pDataIn2X = &((int16_t*)pDataIn2)[fastCount * 16];
+         int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 16];
+         for (int64_t i = 0; i < len; i++) {
             pDataOutX[i] = COMPARE(pDataInX[0], pDataIn2X[i]);
          }
       }
@@ -699,15 +699,15 @@ static void CompareInt16(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 le
          if (scalarMode == SCALAR_MODE::SECOND_ARG_SCALAR)
          {
             __m256i m0 = LOADU(pSrc2Fast);
-            for (INT64 i = 0; i < fastCount; i++)
+            for (int64_t i = 0; i < fastCount; i++)
             {
                STOREU128(pDestFast + i, COMP_256(LOADU(pSrc1Fast + i), m0, mask1));
             }
             len = len - (fastCount * 16);
-            const INT16* pDataInX = &((INT16*)pDataIn)[fastCount * 16];
-            const INT16* pDataIn2X = (INT16*)pDataIn2;
-            INT8* pDataOutX = &((INT8*)pDataOut)[fastCount * 16];
-            for (INT64 i = 0; i < len; i++) {
+            const int16_t* pDataInX = &((int16_t*)pDataIn)[fastCount * 16];
+            const int16_t* pDataIn2X = (int16_t*)pDataIn2;
+            int8_t* pDataOutX = &((int8_t*)pDataOut)[fastCount * 16];
+            for (int64_t i = 0; i < len; i++) {
                pDataOutX[i] = COMPARE(pDataInX[i], pDataIn2X[0]);
             }
          }
@@ -717,17 +717,17 @@ static void CompareInt16(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 le
 
 
 // example of stub
-//static void Compare32(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode) { return CompareFloat<_CMP_EQ_OS>(pDataIn, pDataIn2, pDataOut, len, scalarMode); }
+//static void Compare32(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode) { return CompareFloat<_CMP_EQ_OS>(pDataIn, pDataIn2, pDataOut, len, scalarMode); }
 //const int CMP_LUT[6] = { _CMP_EQ_OS, _CMP_NEQ_OS, _CMP_LT_OS, _CMP_GT_OS, _CMP_LE_OS, _CMP_GE_OS };
 
 //==========================================================
 // May return NULL if it cannot handle type or function
 ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int numpyInType2, int numpyOutType, int* wantedOutType) {
 
-   BOOL bSpecialComparison = FALSE;
+   bool bSpecialComparison = FALSE;
 
    if (scalarMode == SCALAR_MODE::NO_SCALARS && numpyInType1 != numpyInType2) {
-      // Because upcasting an INT64 to a float64 results in precision loss, we try comparisons
+      // Because upcasting an int64_t to a float64 results in precision loss, we try comparisons
       if (sizeof(long) == 8) {
          if (numpyInType1 >= NPY_LONG && numpyInType1 <= NPY_ULONGLONG && numpyInType2 >= NPY_LONG && numpyInType2 <= NPY_ULONGLONG) {
             bSpecialComparison = TRUE;
@@ -794,26 +794,26 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       break;
    CASE_NPY_UINT32:
       switch (func) {
-      // NOTE: if this needs to get sped up, upcast from UINT32 to INT64  using _mm256_cvtepu32_epi64 and cmpint64
+      // NOTE: if this needs to get sped up, upcast from uint32_t to int64_t  using _mm256_cvtepu32_epi64 and cmpint64
       // For equal, not equal the sign does not matter
       case MATH_OPERATION::CMP_EQ:      return CompareInt32<COMP32i_EQ<__m256i>, COMP_EQ>;
       case MATH_OPERATION::CMP_NE:      return CompareInt32<COMP32i_NE<__m256i>, COMP_NE>;
-      case MATH_OPERATION::CMP_GT:      return CompareAny<UINT32, COMP_GT>;
-      case MATH_OPERATION::CMP_GTE:     return CompareAny<UINT32, COMP_GE>;
-      case MATH_OPERATION::CMP_LT:      return CompareAny<UINT32, COMP_LT>;
-      case MATH_OPERATION::CMP_LTE:     return CompareAny<UINT32, COMP_LE>;
+      case MATH_OPERATION::CMP_GT:      return CompareAny<uint32_t, COMP_GT>;
+      case MATH_OPERATION::CMP_GTE:     return CompareAny<uint32_t, COMP_GE>;
+      case MATH_OPERATION::CMP_LT:      return CompareAny<uint32_t, COMP_LT>;
+      case MATH_OPERATION::CMP_LTE:     return CompareAny<uint32_t, COMP_LE>;
       }
       break;
    CASE_NPY_INT64:
       // signed ints in numpy will have last bit set
       if (numpyInType1 != numpyInType2 && !(numpyInType2 & 1)) {
          switch (func) {
-         case MATH_OPERATION::CMP_EQ:      return CompareAny<INT64, COMP_EQ_UINT64>;
-         case MATH_OPERATION::CMP_NE:      return CompareAny<INT64, COMP_NE_UINT64>;
-         case MATH_OPERATION::CMP_GT:      return CompareAny<INT64, COMP_GT_INT64>;
-         case MATH_OPERATION::CMP_GTE:     return CompareAny<INT64, COMP_GE_INT64>;
-         case MATH_OPERATION::CMP_LT:      return CompareAny<INT64, COMP_LT_INT64>;
-         case MATH_OPERATION::CMP_LTE:     return CompareAny<INT64, COMP_LE_INT64>;
+         case MATH_OPERATION::CMP_EQ:      return CompareAny<int64_t, COMP_EQ_uint64_t>;
+         case MATH_OPERATION::CMP_NE:      return CompareAny<int64_t, COMP_NE_uint64_t>;
+         case MATH_OPERATION::CMP_GT:      return CompareAny<int64_t, COMP_GT_int64_t>;
+         case MATH_OPERATION::CMP_GTE:     return CompareAny<int64_t, COMP_GE_int64_t>;
+         case MATH_OPERATION::CMP_LT:      return CompareAny<int64_t, COMP_LT_int64_t>;
+         case MATH_OPERATION::CMP_LTE:     return CompareAny<int64_t, COMP_LE_int64_t>;
          }
       }
       else {
@@ -832,12 +832,12 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       if (numpyInType1 != numpyInType2 && (numpyInType2 & 1)) {
          switch (func) {
             // For equal, not equal the sign does not matter
-         case MATH_OPERATION::CMP_EQ:      return CompareAny<INT64, COMP_EQ>;
-         case MATH_OPERATION::CMP_NE:      return CompareAny<INT64, COMP_NE>;
-         case MATH_OPERATION::CMP_GT:      return CompareAny<UINT64, COMP_GT_UINT64>;
-         case MATH_OPERATION::CMP_GTE:     return CompareAny<UINT64, COMP_GE_UINT64>;
-         case MATH_OPERATION::CMP_LT:      return CompareAny<UINT64, COMP_LT_UINT64>;
-         case MATH_OPERATION::CMP_LTE:     return CompareAny<UINT64, COMP_LE_UINT64>;
+         case MATH_OPERATION::CMP_EQ:      return CompareAny<int64_t, COMP_EQ>;
+         case MATH_OPERATION::CMP_NE:      return CompareAny<int64_t, COMP_NE>;
+         case MATH_OPERATION::CMP_GT:      return CompareAny<uint64_t, COMP_GT_uint64_t>;
+         case MATH_OPERATION::CMP_GTE:     return CompareAny<uint64_t, COMP_GE_uint64_t>;
+         case MATH_OPERATION::CMP_LT:      return CompareAny<uint64_t, COMP_LT_uint64_t>;
+         case MATH_OPERATION::CMP_LTE:     return CompareAny<uint64_t, COMP_LE_uint64_t>;
          }
       }
       else {
@@ -845,10 +845,10 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
             // For equal, not equal the sign does not matter
          case MATH_OPERATION::CMP_EQ:      return CompareInt64<COMP64i_EQ<__m256i>, COMP_EQ>;
          case MATH_OPERATION::CMP_NE:      return CompareInt64<COMP64i_NE<__m256i>, COMP_NE>;
-         case MATH_OPERATION::CMP_GT:      return CompareAny<UINT64, COMP_GT>;
-         case MATH_OPERATION::CMP_GTE:     return CompareAny<UINT64, COMP_GE>;
-         case MATH_OPERATION::CMP_LT:      return CompareAny<UINT64, COMP_LT>;
-         case MATH_OPERATION::CMP_LTE:     return CompareAny<UINT64, COMP_LE>;
+         case MATH_OPERATION::CMP_GT:      return CompareAny<uint64_t, COMP_GT>;
+         case MATH_OPERATION::CMP_GTE:     return CompareAny<uint64_t, COMP_GE>;
+         case MATH_OPERATION::CMP_LT:      return CompareAny<uint64_t, COMP_LT>;
+         case MATH_OPERATION::CMP_LTE:     return CompareAny<uint64_t, COMP_LE>;
          }
 
       }
@@ -868,10 +868,10 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       switch (func) {
       case MATH_OPERATION::CMP_EQ:      return CompareInt8<COMP8i_EQ<__m256i>, COMP_EQ>;
       case MATH_OPERATION::CMP_NE:      return CompareInt8<COMP8i_NE<__m256i>, COMP_NE>;
-      case MATH_OPERATION::CMP_GT:      return CompareAny<UINT8, COMP_GT>;
-      case MATH_OPERATION::CMP_GTE:     return CompareAny<UINT8, COMP_GE>;
-      case MATH_OPERATION::CMP_LT:      return CompareAny<UINT8, COMP_LT>;
-      case MATH_OPERATION::CMP_LTE:     return CompareAny<UINT8, COMP_LE>;
+      case MATH_OPERATION::CMP_GT:      return CompareAny<uint8_t, COMP_GT>;
+      case MATH_OPERATION::CMP_GTE:     return CompareAny<uint8_t, COMP_GE>;
+      case MATH_OPERATION::CMP_LT:      return CompareAny<uint8_t, COMP_LT>;
+      case MATH_OPERATION::CMP_LTE:     return CompareAny<uint8_t, COMP_LE>;
       }
    case NPY_INT16:
       switch (func) {
@@ -885,13 +885,13 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       break;
    case NPY_UINT16:
       switch (func) {
-         // NOTE: if this needs to get sped up, upcast from UINT16 to INT32  using _mm256_cvtepu16_epi32 and cmpint32
+         // NOTE: if this needs to get sped up, upcast from uint16_t to int32_t  using _mm256_cvtepu16_epi32 and cmpint32
       case MATH_OPERATION::CMP_EQ:      return CompareInt16<COMP16i_EQ<__m256i>, COMP_EQ>;
       case MATH_OPERATION::CMP_NE:      return CompareInt16<COMP16i_NE<__m256i>, COMP_NE>;
-      case MATH_OPERATION::CMP_GT:      return CompareAny<UINT16, COMP_GT>;
-      case MATH_OPERATION::CMP_GTE:     return CompareAny<UINT16, COMP_GE>;
-      case MATH_OPERATION::CMP_LT:      return CompareAny<UINT16, COMP_LT>;
-      case MATH_OPERATION::CMP_LTE:     return CompareAny<UINT16, COMP_LE>;
+      case MATH_OPERATION::CMP_GT:      return CompareAny<uint16_t, COMP_GT>;
+      case MATH_OPERATION::CMP_GTE:     return CompareAny<uint16_t, COMP_GE>;
+      case MATH_OPERATION::CMP_LT:      return CompareAny<uint16_t, COMP_LT>;
+      case MATH_OPERATION::CMP_LTE:     return CompareAny<uint16_t, COMP_LE>;
       }
       break;
    }

--- a/src/Compare.cpp
+++ b/src/Compare.cpp
@@ -782,7 +782,7 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       case MATH_OPERATION::CMP_LTE:     return CompareDouble<_CMP_LE_OS, COMP_LE>;
       }
       break;
-   case NPY_INT32:
+   CASE_NPY_INT32:
       switch (func) {
       case MATH_OPERATION::CMP_EQ:      return CompareInt32S<COMP32i_EQS<__m256i>, COMP_EQ>;
       case MATH_OPERATION::CMP_NE:      return CompareInt32<COMP32i_NE<__m256i>, COMP_NE>;
@@ -792,7 +792,7 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       case MATH_OPERATION::CMP_LTE:     return CompareInt32<COMP32i_LE<__m256i>, COMP_LE>;
       }
       break;
-   case NPY_UINT32:
+   CASE_NPY_UINT32:
       switch (func) {
       // NOTE: if this needs to get sped up, upcast from uint32_t to int64_t  using _mm256_cvtepu32_epi64 and cmpint64
       // For equal, not equal the sign does not matter
@@ -804,8 +804,8 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       case MATH_OPERATION::CMP_LTE:     return CompareAny<uint32_t, COMP_LE>;
       }
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       // signed ints in numpy will have last bit set
       if (numpyInType1 != numpyInType2 && !(numpyInType2 & 1)) {
          switch (func) {
@@ -828,8 +828,8 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
          }
       }
       break;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT64:
+   
       // signed ints in numpy will have last bit set
       if (numpyInType1 != numpyInType2 && (numpyInType2 & 1)) {
          switch (func) {

--- a/src/Compare.cpp
+++ b/src/Compare.cpp
@@ -782,7 +782,7 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       case MATH_OPERATION::CMP_LTE:     return CompareDouble<_CMP_LE_OS, COMP_LE>;
       }
       break;
-   case NPY_INT32:
+   case NPY_INT:
       switch (func) {
       case MATH_OPERATION::CMP_EQ:      return CompareInt32S<COMP32i_EQS<__m256i>, COMP_EQ>;
       case MATH_OPERATION::CMP_NE:      return CompareInt32<COMP32i_NE<__m256i>, COMP_NE>;
@@ -792,7 +792,7 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       case MATH_OPERATION::CMP_LTE:     return CompareInt32<COMP32i_LE<__m256i>, COMP_LE>;
       }
       break;
-   case NPY_UINT32:
+   case NPY_UINT:
       switch (func) {
       // NOTE: if this needs to get sped up, upcast from uint32_t to int64_t  using _mm256_cvtepu32_epi64 and cmpint64
       // For equal, not equal the sign does not matter

--- a/src/Compare.cpp
+++ b/src/Compare.cpp
@@ -199,18 +199,18 @@ template<typename T> FORCE_INLINE const bool COMP_LE(T X, T Y) { return (X <= Y)
 template<typename T> FORCE_INLINE const bool COMP_NE(T X, T Y) { return (X != Y); }
 
 // Comparing int64_t to uint64_t
-template<typename T> FORCE_INLINE const bool COMP_GT_int64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X > Y); }
-template<typename T> FORCE_INLINE const bool COMP_GE_int64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X >= Y); }
-template<typename T> FORCE_INLINE const bool COMP_LT_int64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X < Y); }
-template<typename T> FORCE_INLINE const bool COMP_LE_int64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X <= Y); }
+template<typename T> FORCE_INLINE const bool COMP_GT_int64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return false; return (X > Y); }
+template<typename T> FORCE_INLINE const bool COMP_GE_int64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return false; return (X >= Y); }
+template<typename T> FORCE_INLINE const bool COMP_LT_int64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return true; return (X < Y); }
+template<typename T> FORCE_INLINE const bool COMP_LE_int64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return true; return (X <= Y); }
 
 // Comparing uint64_t to int64_t
-template<typename T> FORCE_INLINE const bool COMP_EQ_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X == Y); }
-template<typename T> FORCE_INLINE const bool COMP_NE_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X != Y); }
-template<typename T> FORCE_INLINE const bool COMP_GT_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X > Y); }
-template<typename T> FORCE_INLINE const bool COMP_GE_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return TRUE; return (X >= Y); }
-template<typename T> FORCE_INLINE const bool COMP_LT_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X < Y); }
-template<typename T> FORCE_INLINE const bool COMP_LE_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return FALSE; return (X <= Y); }
+template<typename T> FORCE_INLINE const bool COMP_EQ_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return false; return (X == Y); }
+template<typename T> FORCE_INLINE const bool COMP_NE_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return true; return (X != Y); }
+template<typename T> FORCE_INLINE const bool COMP_GT_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return true; return (X > Y); }
+template<typename T> FORCE_INLINE const bool COMP_GE_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return true; return (X >= Y); }
+template<typename T> FORCE_INLINE const bool COMP_LT_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return false; return (X < Y); }
+template<typename T> FORCE_INLINE const bool COMP_LE_uint64_t(T X, T Y) { if ((X | Y) & 0x8000000000000000) return false; return (X <= Y); }
 
 
 
@@ -724,18 +724,18 @@ static void CompareInt16(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t 
 // May return NULL if it cannot handle type or function
 ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int numpyInType2, int numpyOutType, int* wantedOutType) {
 
-   bool bSpecialComparison = FALSE;
+   bool bSpecialComparison = false;
 
    if (scalarMode == SCALAR_MODE::NO_SCALARS && numpyInType1 != numpyInType2) {
       // Because upcasting an int64_t to a float64 results in precision loss, we try comparisons
       if (sizeof(long) == 8) {
          if (numpyInType1 >= NPY_LONG && numpyInType1 <= NPY_ULONGLONG && numpyInType2 >= NPY_LONG && numpyInType2 <= NPY_ULONGLONG) {
-            bSpecialComparison = TRUE;
+            bSpecialComparison = true;
          }
       }
       else {
          if (numpyInType1 >= NPY_LONGLONG && numpyInType1 <= NPY_ULONGLONG && numpyInType2 >= NPY_LONGLONG && numpyInType2 <= NPY_ULONGLONG) {
-            bSpecialComparison = TRUE;
+            bSpecialComparison = true;
          }
       }
 
@@ -782,7 +782,7 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       case MATH_OPERATION::CMP_LTE:     return CompareDouble<_CMP_LE_OS, COMP_LE>;
       }
       break;
-   CASE_NPY_INT32:
+   case NPY_INT32:
       switch (func) {
       case MATH_OPERATION::CMP_EQ:      return CompareInt32S<COMP32i_EQS<__m256i>, COMP_EQ>;
       case MATH_OPERATION::CMP_NE:      return CompareInt32<COMP32i_NE<__m256i>, COMP_NE>;
@@ -792,7 +792,7 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       case MATH_OPERATION::CMP_LTE:     return CompareInt32<COMP32i_LE<__m256i>, COMP_LE>;
       }
       break;
-   CASE_NPY_UINT32:
+   case NPY_UINT32:
       switch (func) {
       // NOTE: if this needs to get sped up, upcast from uint32_t to int64_t  using _mm256_cvtepu32_epi64 and cmpint64
       // For equal, not equal the sign does not matter
@@ -804,7 +804,8 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
       case MATH_OPERATION::CMP_LTE:     return CompareAny<uint32_t, COMP_LE>;
       }
       break;
-   CASE_NPY_INT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       // signed ints in numpy will have last bit set
       if (numpyInType1 != numpyInType2 && !(numpyInType2 & 1)) {
          switch (func) {
@@ -827,7 +828,8 @@ ANY_TWO_FUNC GetComparisonOpFast(int func, int scalarMode, int numpyInType1, int
          }
       }
       break;
-   CASE_NPY_UINT64:
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
       // signed ints in numpy will have last bit set
       if (numpyInType1 != numpyInType2 && (numpyInType2 & 1)) {
          switch (func) {

--- a/src/Compress.h
+++ b/src/Compress.h
@@ -36,22 +36,22 @@ PyObject *CompressDecompressArrays(PyObject* self, PyObject *args);
 #define HEADER_TAG_ARRAY 1
 
 struct NUMPY_HEADERSIZE {
-   UINT8    magic;
-   INT8     compressiontype;
-   INT8     dtype;
-   INT8     ndim;
+   uint8_t    magic;
+   int8_t     compressiontype;
+   int8_t     dtype;
+   int8_t     ndim;
 
-   INT32    itemsize;
-   INT32    flags;
+   int32_t    itemsize;
+   int32_t    flags;
 
    // no more than 3 dims
-   INT64    dimensions[3];
+   int64_t    dimensions[3];
    size_t   compressedSize;
 
    void*    pCompressedArray;
 
-   INT64    get_arraylength() {
-      INT64 arraylength = dimensions[0];
+   int64_t    get_arraylength() {
+      int64_t arraylength = dimensions[0];
 
       for (int i = 1; i < ndim; i++) {
          arraylength *= dimensions[0];
@@ -68,11 +68,11 @@ struct NUMPY_HEADERSIZE {
 struct COMPRESS_NUMPY_TO_NUMPY {
    struct ArrayInfo*   aInfo;
 
-   INT64               totalHeaders;
+   int64_t               totalHeaders;
 
-   INT16               compMode;
-   INT16               compType;
-   INT32               compLevel;
+   int16_t               compMode;
+   int16_t               compType;
+   int32_t               compLevel;
 
    // Per core allocations
    void*                pCoreMemory[64];

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -36,11 +36,11 @@
 //extern __m256i __cdecl _mm256_cvtepu16_epi32(__m128i);
 //extern __m256i __cdecl _mm256_cvtepu16_epi64(__m128i);
 //extern __m256i __cdecl _mm256_cvtepu32_epi64(__m128i);
-typedef void(*CONVERT_SAFE)(void* pDataIn, void* pDataOut, INT64 len, void* pBadInput1, void* pBadOutput1, INT64 strideIn, INT64 strideOut);
-typedef void(*MASK_CONVERT_SAFE)(void* pDataIn, void* pDataOut, INT8* pMask, INT64 len, void* pBadInput1, void* pBadOutput1);
-typedef void(*CONVERT_SAFE_STRING)(void* pDataIn, void* pDataOut, INT64 len, INT64 inputItemSize, INT64 outputItemSize);
+typedef void(*CONVERT_SAFE)(void* pDataIn, void* pDataOut, int64_t len, void* pBadInput1, void* pBadOutput1, int64_t strideIn, int64_t strideOut);
+typedef void(*MASK_CONVERT_SAFE)(void* pDataIn, void* pDataOut, int8_t* pMask, int64_t len, void* pBadInput1, void* pBadOutput1);
+typedef void(*CONVERT_SAFE_STRING)(void* pDataIn, void* pDataOut, int64_t len, int64_t inputItemSize, int64_t outputItemSize);
 
-static void ConvertSafeStringCopy(void* pDataIn, void* pDataOut, INT64 len, INT64 inputItemSize, INT64 outputItemSize) {
+static void ConvertSafeStringCopy(void* pDataIn, void* pDataOut, int64_t len, int64_t inputItemSize, int64_t outputItemSize) {
    LOGGING("String convert %lld %lld\n", inputItemSize, outputItemSize);
    if (inputItemSize == outputItemSize) {
       // straight memcpy
@@ -50,13 +50,13 @@ static void ConvertSafeStringCopy(void* pDataIn, void* pDataOut, INT64 len, INT6
       if (inputItemSize < outputItemSize) {
          char* pOut = (char*)pDataOut;
          char* pIn = (char*)pDataIn;
-         INT64 remain = outputItemSize - inputItemSize;
+         int64_t remain = outputItemSize - inputItemSize;
 
          if (inputItemSize >= 8) {
-            for (INT64 i = 0; i < len; i++) {
+            for (int64_t i = 0; i < len; i++) {
                memcpy(pOut, pIn, inputItemSize);
                pOut += inputItemSize;
-               for (INT64 j = 0; j < remain; j++) {
+               for (int64_t j = 0; j < remain; j++) {
                   pOut[j] = 0;
                }
 
@@ -66,14 +66,14 @@ static void ConvertSafeStringCopy(void* pDataIn, void* pDataOut, INT64 len, INT6
 
          }
          else {
-            for (INT64 i = 0; i < len; i++) {
-               for (INT64 j = 0; j < inputItemSize; j++) {
+            for (int64_t i = 0; i < len; i++) {
+               for (int64_t j = 0; j < inputItemSize; j++) {
                   pOut[j] = pIn[j];
                }
                pOut += inputItemSize;
 
                // consider memset
-               for (INT64 j = 0; j < remain; j++) {
+               for (int64_t j = 0; j < remain; j++) {
                   pOut[j] = 0;
                }
 
@@ -88,7 +88,7 @@ static void ConvertSafeStringCopy(void* pDataIn, void* pDataOut, INT64 len, INT6
          char* pOut = (char*)pDataOut;
          char* pIn = (char*)pDataIn;
 
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             memcpy(pOut, pIn, outputItemSize);
             pOut += outputItemSize;
             pIn += inputItemSize;
@@ -108,7 +108,7 @@ public:
    ConvertBase() {};
    ~ConvertBase() {};
 
-   static void PutMaskFast(void* pDataIn, void* pDataOut, INT8* pMask, INT64 len, void* pBadInput1, void* pBadOutput1) {
+   static void PutMaskFast(void* pDataIn, void* pDataOut, int8_t* pMask, int64_t len, void* pBadInput1, void* pBadOutput1) {
       T* pIn = (T*)pDataIn;
       T* pOut = (T*)pDataOut;
 
@@ -120,7 +120,7 @@ public:
       }
    }
 
-   static void PutMaskCopy(void* pDataIn, void* pDataOut, INT8* pMask, INT64 len, void* pBadInput1, void* pBadOutput1) {
+   static void PutMaskCopy(void* pDataIn, void* pDataOut, int8_t* pMask, int64_t len, void* pBadInput1, void* pBadOutput1) {
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
       T pBadValueIn = *(T*)pBadInput1;
@@ -138,7 +138,7 @@ public:
       }
    }
 
-   static void PutMaskCopyBool(void* pDataIn, void* pDataOut, INT8* pMask, INT64 len, void* pBadInput1, void* pBadOutput1) {
+   static void PutMaskCopyBool(void* pDataIn, void* pDataOut, int8_t* pMask, int64_t len, void* pBadInput1, void* pBadOutput1) {
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
       T pBadValueIn = *(T*)pBadInput1;
@@ -152,7 +152,7 @@ public:
    }
 
 
-   static void PutMaskCopyFloat(void* pDataIn, void* pDataOut, INT8* pMask, INT64 len, void* pBadInput1, void* pBadOutput1) {
+   static void PutMaskCopyFloat(void* pDataIn, void* pDataOut, int8_t* pMask, int64_t len, void* pBadInput1, void* pBadOutput1) {
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
       U pBadValueOut = *(U*)pBadOutput1;
@@ -171,9 +171,9 @@ public:
 
    // Pass in one vector and returns converted vector
    // Used for operations like C = A + B
-   //typedef void(*ANY_TWO_FUNC)(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode);
-   //typedef void(*ANY_ONE_FUNC)(void* pDataIn, void* pDataOut, INT64 len);
-   static void OneStubConvert(void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+   //typedef void(*ANY_TWO_FUNC)(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode);
+   //typedef void(*ANY_ONE_FUNC)(void* pDataIn, void* pDataOut, int64_t len);
+   static void OneStubConvert(void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -184,8 +184,8 @@ public:
          // NAN converts to MININT (for float --> int conversion)
          // then the reverse, MIININT converts to NAN (for int --> float conversion)
          // convert from int --> float
-         // check for NPY_MIN_INT64
-         for (INT64 i = 0; i < len; i++) {
+         // check for NPY_MIN_INT64_t
+         for (int64_t i = 0; i < len; i++) {
             pOut[i] = (U)pIn[i];
          }
       }
@@ -201,7 +201,7 @@ public:
    }
 
 
-   static void OneStubConvertSafeCopy(void* pDataIn, void* pDataOut, INT64 len, void* pBadInput1, void* pBadOutput1, INT64 strideIn, INT64 strideOut) {
+   static void OneStubConvertSafeCopy(void* pDataIn, void* pDataOut, int64_t len, void* pBadInput1, void* pBadOutput1, int64_t strideIn, int64_t strideOut) {
       // include memcpy with stride
       if (strideIn == sizeof(T) && strideOut == sizeof(U)) {
          memcpy(pDataOut, pDataIn, len * sizeof(U));
@@ -222,13 +222,13 @@ public:
 
    //------------------------------------------------------------------------
    // Designed NOT to preserve sentinels
-   static void OneStubConvertUnsafe(void* pDataIn, void* pDataOut, INT64 len, void* pBadInput1, void* pBadOutput1, INT64 strideIn, INT64 strideOut) {
+   static void OneStubConvertUnsafe(void* pDataIn, void* pDataOut, int64_t len, void* pBadInput1, void* pBadOutput1, int64_t strideIn, int64_t strideOut) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
 
       if (strideIn == sizeof(T) && strideOut == sizeof(U)) {
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             pOut[i] = (U)pIn[i];
          }
       }
@@ -246,8 +246,8 @@ public:
 
    //------------------------------------------------------------------------
    // Designed to preserve sentinels
-   // NOTE: discussion on on what happens with UINT8 conversion (may or may not ignore 0xFF on conversion since so common)
-   static void OneStubConvertSafe(void* pDataIn, void* pDataOut, INT64 len, void* pBadInput1, void* pBadOutput1, INT64 strideIn, INT64 strideOut) {
+   // NOTE: discussion on on what happens with uint8_t conversion (may or may not ignore 0xFF on conversion since so common)
+   static void OneStubConvertSafe(void* pDataIn, void* pDataOut, int64_t len, void* pBadInput1, void* pBadOutput1, int64_t strideIn, int64_t strideOut) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -258,9 +258,9 @@ public:
       // NAN converts to MININT (for float --> int conversion)
       // then the reverse, MIININT converts to NAN (for int --> float conversion)
       // convert from int --> float
-      // check for NPY_MIN_INT64
+      // check for NPY_MIN_INT64_t
       if (strideIn == sizeof(T) && strideOut == sizeof(U)) {
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             if (pIn[i] != pBadValueIn) {
                pOut[i] = (U)pIn[i];
             }
@@ -286,7 +286,7 @@ public:
    }
 
 
-   static void OneStubConvertSafeFloatToDouble(void* pDataIn, void* pDataOut, INT64 len, void* pBadInput1, void* pBadOutput1, INT64 strideIn, INT64 strideOut) {
+   static void OneStubConvertSafeFloatToDouble(void* pDataIn, void* pDataOut, int64_t len, void* pBadInput1, void* pBadOutput1, int64_t strideIn, int64_t strideOut) {
 
       float* pIn = (float*)pDataIn;
       double* pOut = (double*)pDataOut;
@@ -317,13 +317,13 @@ public:
    }
 
 
-   static void OneStubConvertSafeDoubleToFloat(void* pDataIn, void* pDataOut, INT64 len, void* pBadInput1, void* pBadOutput1, INT64 strideIn, INT64 strideOut) {
+   static void OneStubConvertSafeDoubleToFloat(void* pDataIn, void* pDataOut, int64_t len, void* pBadInput1, void* pBadOutput1, int64_t strideIn, int64_t strideOut) {
 
       double* pIn = (double*)pDataIn;
       float* pOut = (float*)pDataOut;
 
       if (strideIn == sizeof(double) && strideOut == sizeof(float)) {
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             pOut[i] = (float)pIn[i];
          }
       }
@@ -339,7 +339,7 @@ public:
    }
 
 
-   static void OneStubConvertSafeFloat(void* pDataIn, void* pDataOut, INT64 len, void* pBadInput1, void* pBadOutput1, INT64 strideIn, INT64 strideOut) {
+   static void OneStubConvertSafeFloat(void* pDataIn, void* pDataOut, int64_t len, void* pBadInput1, void* pBadOutput1, int64_t strideIn, int64_t strideOut) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -350,9 +350,9 @@ public:
       // NAN converts to MININT (for float --> int conversion)
       // then the reverse, MIININT converts to NAN (for int --> float conversion)
       // convert from int --> float
-      // check for NPY_MIN_INT64
+      // check for NPY_MIN_INT64_t
       if (strideIn == sizeof(T) && strideOut == sizeof(U)) {
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
 
             if (std::isfinite(pIn[i]) && (pIn[i] != pBadValueIn)) {
                pOut[i] = (U)pIn[i];
@@ -379,7 +379,7 @@ public:
    }
 
 
-   static void OneStubConvertSafeBool(void* pDataIn, void* pDataOut, INT64 len, void* pBadInput1, void* pBadOutput1, INT64 strideIn, INT64 strideOut) {
+   static void OneStubConvertSafeBool(void* pDataIn, void* pDataOut, int64_t len, void* pBadInput1, void* pBadOutput1, int64_t strideIn, int64_t strideOut) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -389,7 +389,7 @@ public:
       // then the reverse, MIININT converts to NAN (for int --> float conversion)
       // convet from float --> int
       if (strideIn == sizeof(T) && strideOut == sizeof(U)) {
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             pOut[i] = (U)(pIn[i] != 0);
          }
       }
@@ -405,7 +405,7 @@ public:
    }
 
 
-   static void OneStubConvertBool(void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+   static void OneStubConvertBool(void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -415,7 +415,7 @@ public:
          // NAN converts to MININT (for float --> int conversion)
          // then the reverse, MIININT converts to NAN (for int --> float conversion)
          // convet from float --> int
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             pOut[i] = (U)(pIn[i] != 0);
          }
       }
@@ -440,14 +440,14 @@ static UNARY_FUNC GetConversionStep2(int outputType) {
    case NPY_FLOAT:  return ConvertBase<T, float>::OneStubConvert;
    case NPY_DOUBLE: return ConvertBase<T, double>::OneStubConvert;
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvert;
-   case NPY_BYTE:   return ConvertBase<T, INT8>::OneStubConvert;
-   case NPY_INT16:  return ConvertBase<T, INT16>::OneStubConvert;
-   CASE_NPY_INT32:  return ConvertBase<T, INT32>::OneStubConvert;
-   CASE_NPY_INT64:  return ConvertBase<T, INT64>::OneStubConvert;
-   case NPY_UBYTE:  return ConvertBase<T, UINT8>::OneStubConvert;
-   case NPY_UINT16: return ConvertBase<T, UINT16>::OneStubConvert;
-   CASE_NPY_UINT32: return ConvertBase<T, UINT32>::OneStubConvert;
-   CASE_NPY_UINT64: return ConvertBase<T, UINT64>::OneStubConvert;
+   case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvert;
+   case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvert;
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvert;
+   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::OneStubConvert;
+   case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvert;
+   case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvert;
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvert;
+   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::OneStubConvert;
    }
    return NULL;
 
@@ -460,21 +460,21 @@ static CONVERT_SAFE GetConversionStep2Safe(int outputType) {
    case NPY_FLOAT:  return ConvertBase<T, float>::OneStubConvertSafe;
    case NPY_DOUBLE: return ConvertBase<T, double>::OneStubConvertSafe;
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafe;
-   case NPY_BYTE:   return ConvertBase<T, INT8>::OneStubConvertSafe;
-   case NPY_INT16:  return ConvertBase<T, INT16>::OneStubConvertSafe;
-   CASE_NPY_INT32:  return ConvertBase<T, INT32>::OneStubConvertSafe;
-   CASE_NPY_INT64:  return ConvertBase<T, INT64>::OneStubConvertSafe;
-   case NPY_UBYTE:  return ConvertBase<T, UINT8>::OneStubConvertSafe;
-   case NPY_UINT16: return ConvertBase<T, UINT16>::OneStubConvertSafe;
-   CASE_NPY_UINT32: return ConvertBase<T, UINT32>::OneStubConvertSafe;
-   CASE_NPY_UINT64: return ConvertBase<T, UINT64>::OneStubConvertSafe;
+   case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafe;
+   case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafe;
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafe;
+   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::OneStubConvertSafe;
+   case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafe;
+   case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafe;
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafe;
+   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::OneStubConvertSafe;
    }
    return NULL;
 
 }
 
 //-----------------------------------------------------------
-// Used when converting from a UINT8 which has no sentinel (discussion point)
+// Used when converting from a uint8_t which has no sentinel (discussion point)
 template<typename T>
 static CONVERT_SAFE GetConversionStep2Unsafe(int outputType) {
    switch (outputType) {
@@ -482,14 +482,14 @@ static CONVERT_SAFE GetConversionStep2Unsafe(int outputType) {
    case NPY_FLOAT:  return ConvertBase<T, float>::OneStubConvertUnsafe;
    case NPY_DOUBLE: return ConvertBase<T, double>::OneStubConvertUnsafe;
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertUnsafe;
-   case NPY_BYTE:   return ConvertBase<T, INT8>::OneStubConvertUnsafe;
-   case NPY_INT16:  return ConvertBase<T, INT16>::OneStubConvertUnsafe;
-   CASE_NPY_INT32:  return ConvertBase<T, INT32>::OneStubConvertUnsafe;
-   CASE_NPY_INT64:  return ConvertBase<T, INT64>::OneStubConvertUnsafe;
-   case NPY_UBYTE:  return ConvertBase<T, UINT8>::OneStubConvertUnsafe;
-   case NPY_UINT16: return ConvertBase<T, UINT16>::OneStubConvertUnsafe;
-   CASE_NPY_UINT32: return ConvertBase<T, UINT32>::OneStubConvertUnsafe;
-   CASE_NPY_UINT64: return ConvertBase<T, UINT64>::OneStubConvertUnsafe;
+   case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertUnsafe;
+   case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertUnsafe;
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertUnsafe;
+   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::OneStubConvertUnsafe;
+   case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertUnsafe;
+   case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertUnsafe;
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertUnsafe;
+   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::OneStubConvertUnsafe;
    }
    return NULL;
 
@@ -503,14 +503,14 @@ static CONVERT_SAFE GetConversionStep2SafeFromFloat(int outputType) {
    case NPY_FLOAT:  return ConvertBase<T, float>::OneStubConvertSafeFloat;
    case NPY_DOUBLE: return ConvertBase<T, double>::OneStubConvertSafeFloatToDouble;  // very common
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
-   case NPY_BYTE:   return ConvertBase<T, INT8>::OneStubConvertSafeFloat;
-   case NPY_INT16:  return ConvertBase<T, INT16>::OneStubConvertSafeFloat;
-   CASE_NPY_INT32:  return ConvertBase<T, INT32>::OneStubConvertSafeFloat;
-   CASE_NPY_INT64:  return ConvertBase<T, INT64>::OneStubConvertSafeFloat;
-   case NPY_UBYTE:  return ConvertBase<T, UINT8>::OneStubConvertSafeFloat;
-   case NPY_UINT16: return ConvertBase<T, UINT16>::OneStubConvertSafeFloat;
-   CASE_NPY_UINT32: return ConvertBase<T, UINT32>::OneStubConvertSafeFloat;
-   CASE_NPY_UINT64: return ConvertBase<T, UINT64>::OneStubConvertSafeFloat;
+   case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
+   case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
+   case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
+   case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
    }
    return NULL;
 
@@ -523,14 +523,14 @@ static CONVERT_SAFE GetConversionStep2SafeFromDouble(int outputType) {
    case NPY_FLOAT:  return ConvertBase<T, float>::OneStubConvertSafeDoubleToFloat;   // very common
    case NPY_DOUBLE: return ConvertBase<T, double>::OneStubConvertSafeFloat;
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
-   case NPY_BYTE:   return ConvertBase<T, INT8>::OneStubConvertSafeFloat;
-   case NPY_INT16:  return ConvertBase<T, INT16>::OneStubConvertSafeFloat;
-   CASE_NPY_INT32:  return ConvertBase<T, INT32>::OneStubConvertSafeFloat;
-   CASE_NPY_INT64:  return ConvertBase<T, INT64>::OneStubConvertSafeFloat;
-   case NPY_UBYTE:  return ConvertBase<T, UINT8>::OneStubConvertSafeFloat;
-   case NPY_UINT16: return ConvertBase<T, UINT16>::OneStubConvertSafeFloat;
-   CASE_NPY_UINT32: return ConvertBase<T, UINT32>::OneStubConvertSafeFloat;
-   CASE_NPY_UINT64: return ConvertBase<T, UINT64>::OneStubConvertSafeFloat;
+   case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
+   case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
+   case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
+   case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
    }
    return NULL;
 
@@ -544,14 +544,14 @@ static CONVERT_SAFE GetConversionStep2SafeFloat(int outputType) {
    case NPY_FLOAT:  return ConvertBase<T, float>::OneStubConvertSafeFloat;
    case NPY_DOUBLE: return ConvertBase<T, double>::OneStubConvertSafeFloat;
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
-   case NPY_BYTE:   return ConvertBase<T, INT8>::OneStubConvertSafeFloat;
-   case NPY_INT16:  return ConvertBase<T, INT16>::OneStubConvertSafeFloat;
-   CASE_NPY_INT32:  return ConvertBase<T, INT32>::OneStubConvertSafeFloat;
-   CASE_NPY_INT64:  return ConvertBase<T, INT64>::OneStubConvertSafeFloat;
-   case NPY_UBYTE:  return ConvertBase<T, UINT8>::OneStubConvertSafeFloat;
-   case NPY_UINT16: return ConvertBase<T, UINT16>::OneStubConvertSafeFloat;
-   CASE_NPY_UINT32: return ConvertBase<T, UINT32>::OneStubConvertSafeFloat;
-   CASE_NPY_UINT64: return ConvertBase<T, UINT64>::OneStubConvertSafeFloat;
+   case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
+   case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
+   case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
+   case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
    }
    return NULL;
 
@@ -563,18 +563,18 @@ static CONVERT_SAFE GetConversionFunctionSafeCopy(int inputType) {
    switch (inputType) {
    case NPY_BYTE:
    case NPY_UBYTE:
-   case NPY_BOOL:   return ConvertBase<INT8, INT8>::OneStubConvertSafeCopy;
+   case NPY_BOOL:   return ConvertBase<int8_t, int8_t>::OneStubConvertSafeCopy;
 
    case NPY_INT16:
-   case NPY_UINT16:  return ConvertBase<INT16, INT16>::OneStubConvertSafeCopy;
+   case NPY_UINT16:  return ConvertBase<int16_t, int16_t>::OneStubConvertSafeCopy;
 
    CASE_NPY_INT32:
    CASE_NPY_UINT32:
-   case NPY_FLOAT:  return ConvertBase<INT32, INT32>::OneStubConvertSafeCopy;
+   case NPY_FLOAT:  return ConvertBase<int32_t, int32_t>::OneStubConvertSafeCopy;
 
    CASE_NPY_INT64:
    CASE_NPY_UINT64:
-   case NPY_DOUBLE: return ConvertBase<INT64, INT64>::OneStubConvertSafeCopy;
+   case NPY_DOUBLE: return ConvertBase<int64_t, int64_t>::OneStubConvertSafeCopy;
 
    case NPY_LONGDOUBLE: return ConvertBase<long double, long double>::OneStubConvertSafeCopy;
 
@@ -592,22 +592,22 @@ static CONVERT_SAFE GetConversionFunctionSafe(int inputType, int outputType) {
 
    switch (inputType) {
    //case NPY_BOOL:   return GetConversionStep2Safe<bool>(outputType);
-   case NPY_BOOL:   return GetConversionStep2Safe<INT8>(outputType);
+   case NPY_BOOL:   return GetConversionStep2Safe<int8_t>(outputType);
    case NPY_FLOAT:  return GetConversionStep2SafeFromFloat<float>(outputType);
    case NPY_DOUBLE: return GetConversionStep2SafeFromDouble<double>(outputType);
    case NPY_LONGDOUBLE: return GetConversionStep2SafeFloat<long double>(outputType);
-   case NPY_BYTE:   return GetConversionStep2Safe<INT8>(outputType);
-   case NPY_INT16:  return GetConversionStep2Safe<INT16>(outputType);
-   CASE_NPY_INT32:  return GetConversionStep2Safe<INT32>(outputType);
-   CASE_NPY_INT64:  return GetConversionStep2Safe<INT64>(outputType);
+   case NPY_BYTE:   return GetConversionStep2Safe<int8_t>(outputType);
+   case NPY_INT16:  return GetConversionStep2Safe<int16_t>(outputType);
+   CASE_NPY_INT32:  return GetConversionStep2Safe<int32_t>(outputType);
+   CASE_NPY_INT64:  return GetConversionStep2Safe<int64_t>(outputType);
 
-   // DISCUSSION -- UINT8 and the value 255 or 0xFF will not be a sentinel
-   //case NPY_UBYTE:  return GetConversionStep2Unsafe<UINT8>(outputType);
-   case NPY_UBYTE:  return GetConversionStep2Safe<UINT8>(outputType);
+   // DISCUSSION -- uint8_t and the value 255 or 0xFF will not be a sentinel
+   //case NPY_UBYTE:  return GetConversionStep2Unsafe<uint8_t>(outputType);
+   case NPY_UBYTE:  return GetConversionStep2Safe<uint8_t>(outputType);
 
-   case NPY_UINT16: return GetConversionStep2Safe<UINT16>(outputType);
-   CASE_NPY_UINT32: return GetConversionStep2Safe<UINT32>(outputType);
-   CASE_NPY_UINT64: return GetConversionStep2Safe<UINT64>(outputType);
+   case NPY_UINT16: return GetConversionStep2Safe<uint16_t>(outputType);
+   CASE_NPY_UINT32: return GetConversionStep2Safe<uint32_t>(outputType);
+   CASE_NPY_UINT64: return GetConversionStep2Safe<uint64_t>(outputType);
 
    }
    return NULL;
@@ -623,18 +623,18 @@ static CONVERT_SAFE GetConversionFunctionUnsafe(int inputType, int outputType) {
 
    switch (inputType) {
       //case NPY_BOOL:   return GetConversionStep2Safe<bool>(outputType);
-   case NPY_BOOL:   return GetConversionStep2Unsafe<INT8>(outputType);
+   case NPY_BOOL:   return GetConversionStep2Unsafe<int8_t>(outputType);
    case NPY_FLOAT:  return GetConversionStep2Unsafe<float>(outputType);
    case NPY_DOUBLE: return GetConversionStep2Unsafe<double>(outputType);
    case NPY_LONGDOUBLE: return GetConversionStep2Unsafe<long double>(outputType);
-   case NPY_BYTE:   return GetConversionStep2Unsafe<INT8>(outputType);
-   case NPY_INT16:  return GetConversionStep2Unsafe<INT16>(outputType);
-   CASE_NPY_INT32:  return GetConversionStep2Unsafe<INT32>(outputType);
-   CASE_NPY_INT64:  return GetConversionStep2Unsafe<INT64>(outputType);
-   case NPY_UBYTE:  return GetConversionStep2Unsafe<UINT8>(outputType);
-   case NPY_UINT16: return GetConversionStep2Unsafe<UINT16>(outputType);
-   CASE_NPY_UINT32: return GetConversionStep2Unsafe<UINT32>(outputType);
-   CASE_NPY_UINT64: return GetConversionStep2Unsafe<UINT64>(outputType);
+   case NPY_BYTE:   return GetConversionStep2Unsafe<int8_t>(outputType);
+   case NPY_INT16:  return GetConversionStep2Unsafe<int16_t>(outputType);
+   CASE_NPY_INT32:  return GetConversionStep2Unsafe<int32_t>(outputType);
+   CASE_NPY_INT64:  return GetConversionStep2Unsafe<int64_t>(outputType);
+   case NPY_UBYTE:  return GetConversionStep2Unsafe<uint8_t>(outputType);
+   case NPY_UINT16: return GetConversionStep2Unsafe<uint16_t>(outputType);
+   CASE_NPY_UINT32: return GetConversionStep2Unsafe<uint32_t>(outputType);
+   CASE_NPY_UINT64: return GetConversionStep2Unsafe<uint64_t>(outputType);
 
    }
    return NULL;
@@ -649,14 +649,14 @@ static MASK_CONVERT_SAFE GetConversionPutMask2Float(int outputType) {
    case NPY_FLOAT:  return ConvertBase<T, float>::PutMaskCopyFloat;
    case NPY_DOUBLE: return ConvertBase<T, double>::PutMaskCopyFloat;
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::PutMaskCopyFloat;
-   case NPY_BYTE:   return ConvertBase<T, INT8>::PutMaskCopyFloat;
-   case NPY_INT16:  return ConvertBase<T, INT16>::PutMaskCopyFloat;
-   CASE_NPY_INT32:  return ConvertBase<T, INT32>::PutMaskCopyFloat;
-   CASE_NPY_INT64:  return ConvertBase<T, INT64>::PutMaskCopyFloat;
-   case NPY_UBYTE:  return ConvertBase<T, UINT8>::PutMaskCopyFloat;
-   case NPY_UINT16: return ConvertBase<T, UINT16>::PutMaskCopyFloat;
-   CASE_NPY_UINT32: return ConvertBase<T, UINT32>::PutMaskCopyFloat;
-   CASE_NPY_UINT64: return ConvertBase<T, UINT64>::PutMaskCopyFloat;
+   case NPY_BYTE:   return ConvertBase<T, int8_t>::PutMaskCopyFloat;
+   case NPY_INT16:  return ConvertBase<T, int16_t>::PutMaskCopyFloat;
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopyFloat;
+   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::PutMaskCopyFloat;
+   case NPY_UBYTE:  return ConvertBase<T, uint8_t>::PutMaskCopyFloat;
+   case NPY_UINT16: return ConvertBase<T, uint16_t>::PutMaskCopyFloat;
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopyFloat;
+   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::PutMaskCopyFloat;
    }
    return NULL;
 
@@ -670,14 +670,14 @@ static MASK_CONVERT_SAFE GetConversionPutMask2(int outputType) {
    case NPY_FLOAT:  return ConvertBase<T, float>::PutMaskCopy;
    case NPY_DOUBLE: return ConvertBase<T, double>::PutMaskCopy;
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::PutMaskCopy;
-   case NPY_BYTE:   return ConvertBase<T, INT8>::PutMaskCopy;
-   case NPY_INT16:  return ConvertBase<T, INT16>::PutMaskCopy;
-   CASE_NPY_INT32:  return ConvertBase<T, INT32>::PutMaskCopy;
-   CASE_NPY_INT64:  return ConvertBase<T, INT64>::PutMaskCopy;
-   case NPY_UBYTE:  return ConvertBase<T, UINT8>::PutMaskCopy;
-   case NPY_UINT16: return ConvertBase<T, UINT16>::PutMaskCopy;
-   CASE_NPY_UINT32: return ConvertBase<T, UINT32>::PutMaskCopy;
-   CASE_NPY_UINT64: return ConvertBase<T, UINT64>::PutMaskCopy;
+   case NPY_BYTE:   return ConvertBase<T, int8_t>::PutMaskCopy;
+   case NPY_INT16:  return ConvertBase<T, int16_t>::PutMaskCopy;
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopy;
+   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::PutMaskCopy;
+   case NPY_UBYTE:  return ConvertBase<T, uint8_t>::PutMaskCopy;
+   case NPY_UINT16: return ConvertBase<T, uint16_t>::PutMaskCopy;
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopy;
+   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::PutMaskCopy;
    }
    return NULL;
 
@@ -690,18 +690,18 @@ static MASK_CONVERT_SAFE GetConversionPutMask(int inputType, int outputType) {
       switch (inputType) {
       case NPY_BYTE:
       case NPY_UBYTE:
-      case NPY_BOOL:   return ConvertBase<INT8, INT8>::PutMaskFast;
+      case NPY_BOOL:   return ConvertBase<int8_t, int8_t>::PutMaskFast;
 
       case NPY_INT16:
-      case NPY_UINT16:  return ConvertBase<INT16, INT16>::PutMaskFast;
+      case NPY_UINT16:  return ConvertBase<int16_t, int16_t>::PutMaskFast;
 
       CASE_NPY_INT32:
       CASE_NPY_UINT32:
-      case NPY_FLOAT:  return ConvertBase<INT32, INT32>::PutMaskFast;
+      case NPY_FLOAT:  return ConvertBase<int32_t, int32_t>::PutMaskFast;
 
       CASE_NPY_INT64:
       CASE_NPY_UINT64:
-      case NPY_DOUBLE: return ConvertBase<INT64, INT64>::PutMaskFast;
+      case NPY_DOUBLE: return ConvertBase<int64_t, int64_t>::PutMaskFast;
 
       case NPY_LONGDOUBLE: return ConvertBase<long double, long double>::PutMaskFast;
 
@@ -710,22 +710,22 @@ static MASK_CONVERT_SAFE GetConversionPutMask(int inputType, int outputType) {
 
    switch (inputType) {
       //case NPY_BOOL:   return GetConversionStep2Safe<bool>(outputType);
-   case NPY_BOOL:   return GetConversionPutMask2<INT8>(outputType);
+   case NPY_BOOL:   return GetConversionPutMask2<int8_t>(outputType);
    case NPY_FLOAT:  return GetConversionPutMask2Float<float>(outputType);
    case NPY_DOUBLE: return GetConversionPutMask2Float<double>(outputType);
    case NPY_LONGDOUBLE: return GetConversionPutMask2Float<long double>(outputType);
-   case NPY_BYTE:   return GetConversionPutMask2<INT8>(outputType);
-   case NPY_INT16:  return GetConversionPutMask2<INT16>(outputType);
-   CASE_NPY_INT32:  return GetConversionPutMask2<INT32>(outputType);
-   CASE_NPY_INT64:  return GetConversionPutMask2<INT64>(outputType);
+   case NPY_BYTE:   return GetConversionPutMask2<int8_t>(outputType);
+   case NPY_INT16:  return GetConversionPutMask2<int16_t>(outputType);
+   CASE_NPY_INT32:  return GetConversionPutMask2<int32_t>(outputType);
+   CASE_NPY_INT64:  return GetConversionPutMask2<int64_t>(outputType);
 
-      // DISCUSSION -- UINT8 and the value 255 or 0xFF will not be a sentinel
-      //case NPY_UBYTE:  return GetConversionStep2Unsafe<UINT8>(outputType);
-   case NPY_UBYTE:  return GetConversionPutMask2<UINT8>(outputType);
+      // DISCUSSION -- uint8_t and the value 255 or 0xFF will not be a sentinel
+      //case NPY_UBYTE:  return GetConversionStep2Unsafe<uint8_t>(outputType);
+   case NPY_UBYTE:  return GetConversionPutMask2<uint8_t>(outputType);
 
-   case NPY_UINT16: return GetConversionPutMask2<UINT16>(outputType);
-   CASE_NPY_UINT32: return GetConversionPutMask2<UINT32>(outputType);
-   CASE_NPY_UINT64: return GetConversionPutMask2<UINT64>(outputType);
+   case NPY_UINT16: return GetConversionPutMask2<uint16_t>(outputType);
+   CASE_NPY_UINT32: return GetConversionPutMask2<uint32_t>(outputType);
+   CASE_NPY_UINT64: return GetConversionPutMask2<uint64_t>(outputType);
 
    }
    return NULL;
@@ -741,27 +741,27 @@ struct CONVERT_CALLBACK {
    void* pBadInput1;
    void* pBadOutput1;
 
-   INT64 typeSizeIn;
-   INT64 typeSizeOut;
+   int64_t typeSizeIn;
+   int64_t typeSizeOut;
 
 } stConvertCallback;
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL ConvertThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
+static BOOL ConvertThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
    BOOL didSomeWork = FALSE;
    CONVERT_CALLBACK* Callback = (CONVERT_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    char* pDataIn = (char *)Callback->pDataIn;
    char* pDataOut = (char*)Callback->pDataOut;
-   INT64 lenX;
-   INT64 workBlock;
+   int64_t lenX;
+   int64_t workBlock;
 
    // As long as there is work to do
    while ((lenX = pstWorkerItem->GetNextWorkBlock(&workBlock)) > 0) {
 
-      INT64 inputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeIn;
-      INT64 outputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeOut;
+      int64_t inputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeIn;
+      int64_t outputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeOut;
 
       Callback->anyConvertCallback(pDataIn + inputAdj, pDataOut + outputAdj, lenX, Callback->pBadInput1, Callback->pBadOutput1, Callback->typeSizeIn, Callback->typeSizeOut);
 
@@ -802,10 +802,10 @@ void* GetInvalid(int dtype) {
 PyObject *
 ConvertSafeInternal(
    PyArrayObject* const inArr1,
-   const INT64 out_dtype) {
+   const int64_t out_dtype) {
 
-   const INT32 numpyOutType = (INT32)out_dtype;
-   const INT32 numpyInType = PyArray_TYPE(inArr1);
+   const int32_t numpyOutType = (int32_t)out_dtype;
+   const int32_t numpyInType = PyArray_TYPE(inArr1);
 
    if (numpyOutType < 0 || numpyInType > NPY_LONGDOUBLE || numpyOutType > NPY_LONGDOUBLE) {
       return PyErr_Format(PyExc_ValueError, "ConvertSafe: Don't know how to convert these types %d %d", numpyInType, numpyOutType);
@@ -825,8 +825,8 @@ ConvertSafeInternal(
    npy_intp* const dims = PyArray_DIMS(inArr1);
 
    // Make sure array lengths match
-   const INT64 arraySize1 = CalcArrayLength(ndim, dims);
-   const INT64 len = arraySize1;
+   const int64_t arraySize1 = CalcArrayLength(ndim, dims);
+   const int64_t len = arraySize1;
 
    // Allocate the output array.
    // TODO: Consider using AllocateLikeNumpyArray here instead for simplicity.
@@ -846,11 +846,11 @@ ConvertSafeInternal(
    void* pBadOutput1 = GetDefaultForType(numpyOutType);
 
    // Check the strides of both the input and output to make sure we can handle
-   INT64 strideIn;
+   int64_t strideIn;
    int directionIn = GetStridesAndContig(inArr1, ndim, strideIn);
 
    int ndimOut;
-   INT64 strideOut;
+   int64_t strideOut;
    int directionOut = GetStridesAndContig(outArray, ndimOut, strideOut);
 
    // If the input is C and/or F-contiguous, the output should have
@@ -862,35 +862,35 @@ ConvertSafeInternal(
       // Check if we can process, else punt to numpy
       if (directionIn == 1 && directionOut == 0) {
          // Row Major 2dim like array with output being fully contiguous
-         INT64 innerLen = 1;
+         int64_t innerLen = 1;
          for (int i = directionIn; i < ndim; i++) {
             innerLen *= PyArray_DIM(inArr1, i);
          }
          // TODO: consider dividing the work over multiple threads if innerLen is large enough
-         const INT64 outerLen = PyArray_DIM(inArr1, 0);
-         const INT64 outerStride = PyArray_STRIDE(inArr1, 0);
+         const int64_t outerLen = PyArray_DIM(inArr1, 0);
+         const int64_t outerStride = PyArray_STRIDE(inArr1, 0);
 
          LOGGING("Row Major  innerLen:%lld  outerLen:%lld  outerStride:%lld\n", innerLen, outerLen, outerStride);
 
-         for (INT64 j = 0; j < outerLen; j++) {
+         for (int64_t j = 0; j < outerLen; j++) {
             pFunction((char*)pDataIn + (j * outerStride), (char*)pDataOut + (j * innerLen * strideOut), innerLen, pBadInput1, pBadOutput1, strideIn, strideOut);
          }
 
       }
       else if (directionIn == -1 && directionOut == 0) {
          // Col Major 2dim like array with output being fully contiguous
-         INT64 innerLen = 1;
+         int64_t innerLen = 1;
          directionIn = -directionIn;
          for (int i = 0; i < directionIn; i++) {
             innerLen *= PyArray_DIM(inArr1, i);
          }
          // TODO: consider dividing the work over multiple threads if innerLen is large enough
-         const INT64 outerLen = PyArray_DIM(inArr1, (ndim - 1));
-         const INT64 outerStride = PyArray_STRIDE(inArr1, (ndim - 1));
+         const int64_t outerLen = PyArray_DIM(inArr1, (ndim - 1));
+         const int64_t outerStride = PyArray_STRIDE(inArr1, (ndim - 1));
 
          LOGGING("Col Major  innerLen:%lld  outerLen:%lld  outerStride:%lld\n", innerLen, outerLen, outerStride);
 
-         for (INT64 j = 0; j < outerLen; j++) {
+         for (int64_t j = 0; j < outerLen; j++) {
             pFunction((char*)pDataIn + (j * outerStride), (char*)pDataOut + (j * innerLen * strideOut), innerLen, pBadInput1, pBadOutput1, strideIn, strideOut);
          }
       }
@@ -939,13 +939,13 @@ PyObject *
 ConvertSafe(PyObject *self, PyObject *args)
 {
    PyArrayObject *inArr1 = NULL;
-   INT64 out_dtype = 0;
+   int64_t out_dtype = 0;
 
    if (Py_SIZE(args) > 1) {
       PyArrayObject* inObject = (PyArrayObject*)PyTuple_GET_ITEM(args, 0);
       PyObject* inNumber = PyTuple_GET_ITEM(args, 1);
       if (PyLong_CheckExact(inNumber)) {
-         INT64 dtypeNum = PyLong_AsLongLong(inNumber);
+         int64_t dtypeNum = PyLong_AsLongLong(inNumber);
 
          if (IsFastArrayOrNumpy(inObject)) {
             PyObject* result =
@@ -982,10 +982,10 @@ ConvertSafe(PyObject *self, PyObject *args)
 PyObject *
 ConvertUnsafeInternal(
    PyArrayObject *inArr1,
-   INT64 out_dtype) {
+   int64_t out_dtype) {
 
-   const INT32 numpyOutType = (INT32)out_dtype;
-   const INT32 numpyInType = ObjectToDtype(inArr1);
+   const int32_t numpyOutType = (int32_t)out_dtype;
+   const int32_t numpyInType = ObjectToDtype(inArr1);
 
    if (numpyOutType < 0 || numpyInType < 0 || numpyInType > NPY_LONGDOUBLE || numpyOutType > NPY_LONGDOUBLE) {
       return PyErr_Format(PyExc_ValueError, "ConvertUnsafe: Don't know how to convert these types %d %d", numpyInType, numpyOutType);
@@ -1006,8 +1006,8 @@ ConvertUnsafeInternal(
    npy_intp* const dims = PyArray_DIMS(inArr1);
    //auto* const inArr1_strides = PyArray_STRIDES(inArr1);
    // TODO: CalcArrayLength probably needs to be fixed to account for any non-default striding
-   const INT64 arraySize1 = CalcArrayLength(ndim, dims);
-   const INT64 len = arraySize1;
+   const int64_t arraySize1 = CalcArrayLength(ndim, dims);
+   const int64_t len = arraySize1;
 
    // Allocate the output array.
    // TODO: Consider using AllocateLikeNumpyArray here instead for simplicity.
@@ -1065,7 +1065,7 @@ PyObject *
 ConvertUnsafe(PyObject *self, PyObject *args)
 {
    PyArrayObject *inArr1 = NULL;
-   INT64 out_dtype = 0;
+   int64_t out_dtype = 0;
 
    if (!PyArg_ParseTuple(
       args, "O!L:ConvertUnsafe",
@@ -1081,14 +1081,14 @@ ConvertUnsafe(PyObject *self, PyObject *args)
 //=====================================================================================
 // COMBINE MASK------------------------------------------------------------------------
 //=====================================================================================
-typedef void(*COMBINE_MASK)(void* pDataIn, void* pDataOut, INT64 len, INT8* pFilter);
+typedef void(*COMBINE_MASK)(void* pDataIn, void* pDataOut, int64_t len, int8_t* pFilter);
 
 template<typename T>
-static void CombineMask(void* pDataInT, void* pDataOutT, INT64 len, INT8* pFilter) {
+static void CombineMask(void* pDataInT, void* pDataOutT, int64_t len, int8_t* pFilter) {
    T*    pDataIn = (T*)pDataInT;
    T*    pDataOut = (T*)pDataOutT;
 
-   for (INT64 i = 0; i < len; i++) {
+   for (int64_t i = 0; i < len; i++) {
       pDataOut[i] = pDataIn[i] * (T)pFilter[i];
    }
 
@@ -1097,10 +1097,10 @@ static void CombineMask(void* pDataInT, void* pDataOutT, INT64 len, INT8* pFilte
 
 static COMBINE_MASK GetCombineFunction(int outputType) {
    switch (outputType) {
-   case NPY_INT8:   return CombineMask<INT8>;
-   case NPY_INT16:  return CombineMask<INT16>;
-   CASE_NPY_INT32:  return CombineMask<INT32>;
-   CASE_NPY_INT64:  return CombineMask<INT64>;
+   case NPY_INT8:   return CombineMask<int8_t>;
+   case NPY_INT16:  return CombineMask<int16_t>;
+   CASE_NPY_INT32:  return CombineMask<int32_t>;
+   CASE_NPY_INT64:  return CombineMask<int64_t>;
    }
    return NULL;
 
@@ -1114,28 +1114,28 @@ struct COMBINE_CALLBACK {
    COMBINE_MASK anyCombineCallback;
    char* pDataIn;
    char* pDataOut;
-   INT8* pFilter;
+   int8_t* pFilter;
 
-   INT64 typeSizeOut;
+   int64_t typeSizeOut;
 
 } stCombineCallback;
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL CombineThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
+static BOOL CombineThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
    BOOL didSomeWork = FALSE;
    COMBINE_CALLBACK* Callback = (COMBINE_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    char* pDataIn = (char *)Callback->pDataIn;
    char* pDataOut = (char*)Callback->pDataOut;
-   INT64 lenX;
-   INT64 workBlock;
+   int64_t lenX;
+   int64_t workBlock;
 
    // As long as there is work to do
    while ((lenX = pstWorkerItem->GetNextWorkBlock(&workBlock)) > 0) {
 
-      INT64 inputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeOut;
-      INT64 filterAdj = pstWorkerItem->BlockSize * workBlock;
+      int64_t inputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeOut;
+      int64_t filterAdj = pstWorkerItem->BlockSize * workBlock;
 
       Callback->anyCombineCallback(pDataIn + inputAdj, pDataOut + inputAdj, lenX, Callback->pFilter + filterAdj);
 
@@ -1165,7 +1165,7 @@ CombineFilter(PyObject *self, PyObject *args)
    PyArrayObject *inArr1 = NULL;
    PyArrayObject *inFilter = NULL;
 
-   INT64 out_dtype = 0;
+   int64_t out_dtype = 0;
 
    if (!PyArg_ParseTuple(
       args, "O!O!:CombineFilter",
@@ -1175,12 +1175,12 @@ CombineFilter(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   INT32 numpyOutType = PyArray_TYPE(inArr1);
+   int32_t numpyOutType = PyArray_TYPE(inArr1);
    void* pDataIn = PyArray_BYTES(inArr1);
    int ndim = PyArray_NDIM(inArr1);
    npy_intp* dims = PyArray_DIMS(inArr1);
-   INT64 arraySize1 = CalcArrayLength(ndim, dims);
-   INT64 len = arraySize1;
+   int64_t arraySize1 = CalcArrayLength(ndim, dims);
+   int64_t len = arraySize1;
 
    if (arraySize1 != ArrayLength(inFilter)) {
       PyErr_Format(PyExc_ValueError, "CombineFilter: Filter size not the same %lld", arraySize1);
@@ -1220,7 +1220,7 @@ CombineFilter(PyObject *self, PyObject *args)
 
       if (outArray) {
          void* pDataOut = PyArray_BYTES(outArray);
-         INT8* pFilter = (INT8*)PyArray_BYTES(inFilter);
+         int8_t* pFilter = (int8_t*)PyArray_BYTES(inFilter);
 
          stMATH_WORKER_ITEM* pWorkItem = g_cMathWorker->GetWorkItem(len);
 
@@ -1259,10 +1259,10 @@ CombineFilter(PyObject *self, PyObject *args)
 //=====================================================================================
 // COMBINE ACCUM 2 MASK----------------------------------------------------------------
 //=====================================================================================
-typedef void(*COMBINE_ACCUM2_MASK)(void* pDataIn1, void* pDataIn2, void* pDataOut, const INT64 multiplier, const INT64 maxbin, INT64 len, void* pCountOut2, INT8* pFilter);
+typedef void(*COMBINE_ACCUM2_MASK)(void* pDataIn1, void* pDataIn2, void* pDataOut, const int64_t multiplier, const int64_t maxbin, int64_t len, void* pCountOut2, int8_t* pFilter);
 
 template<typename T, typename U, typename V>
-static void CombineAccum2Mask(void* pDataIn1T, void* pDataIn2T, void* pDataOutT, const INT64 multiplier, const INT64 maxbinT, INT64 len, void* pCountOut2, INT8* pFilter) {
+static void CombineAccum2Mask(void* pDataIn1T, void* pDataIn2T, void* pDataOutT, const int64_t multiplier, const int64_t maxbinT, int64_t len, void* pCountOut2, int8_t* pFilter) {
    T*    pDataIn1 = (T*)pDataIn1T;
    U*    pDataIn2 = (U*)pDataIn2T;
    V*    pDataOut = (V*)pDataOutT;
@@ -1270,11 +1270,11 @@ static void CombineAccum2Mask(void* pDataIn1T, void* pDataIn2T, void* pDataOutT,
    const V maxbin = (V)maxbinT;
 
    if (pCountOut2) {
-      // TODO: handle INT64 also
-      INT32* pCountOut = (INT32*)pCountOut2;
+      // TODO: handle int64_t also
+      int32_t* pCountOut = (int32_t*)pCountOut2;
 
       if (pFilter) {
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             if (pFilter[i]) {
                V bin = (V)(pDataIn2[i] * multiplier + pDataIn1[i]);
                if (bin >= 0 && bin < maxbin) {
@@ -1293,7 +1293,7 @@ static void CombineAccum2Mask(void* pDataIn1T, void* pDataIn2T, void* pDataOutT,
          }
       }
       else {
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             V bin = (V)(pDataIn2[i] * multiplier + pDataIn1[i]);
             if (bin >= 0 && bin < maxbin) {
                pCountOut[bin]++;
@@ -1310,7 +1310,7 @@ static void CombineAccum2Mask(void* pDataIn1T, void* pDataIn2T, void* pDataOutT,
    else {
       // NO COUNT
       if (pFilter) {
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             if (pFilter[i]) {
                V bin = (V)(pDataIn2[i] * multiplier + pDataIn1[i]);
                if (bin >= 0 && bin < maxbin) {
@@ -1326,7 +1326,7 @@ static void CombineAccum2Mask(void* pDataIn1T, void* pDataIn2T, void* pDataOutT,
          }
       }
       else {
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             V bin = (V)(pDataIn2[i] * multiplier + pDataIn1[i]);
             pDataOut[i] = bin;
             //if (bin >= 0 && bin < maxbin) {
@@ -1349,10 +1349,10 @@ static COMBINE_ACCUM2_MASK GetCombineAccum2Function(int outputType) {
    //printf("GetCombine -- %lld %lld\n", sizeof(T), sizeof(U));
 
    switch (outputType) {
-   case NPY_INT8:   return CombineAccum2Mask<T,U,INT8>;
-   case NPY_INT16:  return CombineAccum2Mask<T,U,INT16>;
-   CASE_NPY_INT32:  return CombineAccum2Mask<T,U,INT32>;
-   CASE_NPY_INT64:  return CombineAccum2Mask<T,U,INT64>;
+   case NPY_INT8:   return CombineAccum2Mask<T,U,int8_t>;
+   case NPY_INT16:  return CombineAccum2Mask<T,U,int16_t>;
+   CASE_NPY_INT32:  return CombineAccum2Mask<T,U,int32_t>;
+   CASE_NPY_INT64:  return CombineAccum2Mask<T,U,int64_t>;
    }
    return NULL;
 
@@ -1365,14 +1365,14 @@ struct COMBINE_ACCUM2_CALLBACK {
    char* pDataIn1;
    char* pDataIn2;
    char* pDataOut;
-   INT8* pFilter;
+   int8_t* pFilter;
 
    void* pCountOut; // int32 or int64
-   INT64 typeSizeIn1;
-   INT64 typeSizeIn2;
-   INT64 typeSizeOut;
-   INT64 multiplier;
-   INT64 maxbin;
+   int64_t typeSizeIn1;
+   int64_t typeSizeIn2;
+   int64_t typeSizeOut;
+   int64_t multiplier;
+   int64_t maxbin;
    void* pCountWorkSpace; //int32 or int64
 
 } stCombineAccum2Callback;
@@ -1380,24 +1380,24 @@ struct COMBINE_ACCUM2_CALLBACK {
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL CombineThreadAccum2Callback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
+static BOOL CombineThreadAccum2Callback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
    BOOL didSomeWork = FALSE;
    COMBINE_ACCUM2_CALLBACK* Callback = (COMBINE_ACCUM2_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    char* pDataIn1 = (char *)Callback->pDataIn1;
    char* pDataIn2 = (char *)Callback->pDataIn2;
    char* pDataOut = (char*)Callback->pDataOut;
-   INT64 lenX;
-   INT64 workBlock;
+   int64_t lenX;
+   int64_t workBlock;
 
 
    // As long as there is work to do
    while ((lenX = pstWorkerItem->GetNextWorkBlock(&workBlock)) > 0) {
 
-      INT64 inputAdj1 = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeIn1;
-      INT64 inputAdj2 = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeIn2;
-      INT64 outputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeOut;
-      INT64 filterAdj = pstWorkerItem->BlockSize * workBlock;
+      int64_t inputAdj1 = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeIn1;
+      int64_t inputAdj2 = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeIn2;
+      int64_t outputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeOut;
+      int64_t filterAdj = pstWorkerItem->BlockSize * workBlock;
 
       //pFunction(pDataIn1, pDataIn2, pDataOut, inArr1Max, hashSize, arraySize1, pCountArray, pFilterIn);
 
@@ -1410,7 +1410,7 @@ static BOOL CombineThreadAccum2Callback(struct stMATH_WORKER_ITEM* pstWorkerItem
          lenX,
          // based on core, pick a counter
          // TODO: 64bit code also
-         Callback->pCountWorkSpace ? & ((INT32*)(Callback->pCountWorkSpace))[(core+1) * Callback->maxbin] : NULL,
+         Callback->pCountWorkSpace ? & ((int32_t*)(Callback->pCountWorkSpace))[(core+1) * Callback->maxbin] : NULL,
          Callback->pFilter ? (Callback->pFilter + filterAdj) : NULL);
 
       // Indicate we completed a block
@@ -1442,11 +1442,11 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
 {
    PyArrayObject *inArr1 = NULL;
    PyArrayObject *inArr2 = NULL;
-   INT64 inArr1Max = 0;
-   INT64 inArr2Max = 0;
+   int64_t inArr1Max = 0;
+   int64_t inArr2Max = 0;
    PyObject *inFilter = NULL;
 
-   INT64 out_dtype = 0;
+   int64_t out_dtype = 0;
 
    if (!PyArg_ParseTuple(
       args, "O!O!LLO:CombineAccum2Filter",
@@ -1463,16 +1463,16 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
    inArr1Max++;
    inArr2Max++;
 
-   INT64 hashSize = inArr1Max * inArr2Max ;
+   int64_t hashSize = inArr1Max * inArr2Max ;
    //printf("Combine hashsize is %lld     %lld x %lld\n", hashSize, inArr1Max, inArr2Max);
 
    void* pDataIn1 = PyArray_BYTES(inArr1);
    void* pDataIn2 = PyArray_BYTES(inArr2);
-   INT8* pFilterIn = NULL;
+   int8_t* pFilterIn = NULL;
    int ndim = PyArray_NDIM(inArr1);
    npy_intp* dims = PyArray_DIMS(inArr1);
-   INT64 arraySize1 = CalcArrayLength(ndim, dims);
-   INT64 arraySize2 = ArrayLength(inArr2);
+   int64_t arraySize1 = CalcArrayLength(ndim, dims);
+   int64_t arraySize2 = ArrayLength(inArr2);
 
    if (arraySize1 != arraySize2) {
       PyErr_Format(PyExc_ValueError, "CombineAccum2Filter: array sizes not the same %lld", arraySize1);
@@ -1488,7 +1488,7 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
          PyErr_Format(PyExc_ValueError, "CombineAccum2Filter: Filter is not type NPY_BOOL");
          return NULL;
       }
-      pFilterIn = (INT8*)PyArray_BYTES((PyArrayObject*)inFilter);
+      pFilterIn = (int8_t*)PyArray_BYTES((PyArrayObject*)inFilter);
    }
 
    if (hashSize < 0) {
@@ -1496,8 +1496,8 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   INT32 numpyOutType = NPY_INT64;
-   INT64 typeSizeOut = 8;
+   int32_t numpyOutType = NPY_INT64;
+   int64_t typeSizeOut = 8;
 
    if (hashSize < 2000000000) {
       numpyOutType = NPY_INT32;
@@ -1520,37 +1520,37 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
    switch (PyArray_TYPE(inArr1)) {
    case NPY_INT8:
       switch (type2) {
-      case NPY_INT8:   pFunction = GetCombineAccum2Function<INT8, INT8>(numpyOutType);  break;
-      case NPY_INT16:  pFunction = GetCombineAccum2Function<INT8, INT16>(numpyOutType);  break;
-      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<INT8, INT32>(numpyOutType);  break;
-      CASE_NPY_INT64:  pFunction = GetCombineAccum2Function<INT8, INT64>(numpyOutType);  break;
+      case NPY_INT8:   pFunction = GetCombineAccum2Function<int8_t, int8_t>(numpyOutType);  break;
+      case NPY_INT16:  pFunction = GetCombineAccum2Function<int8_t, int16_t>(numpyOutType);  break;
+      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<int8_t, int32_t>(numpyOutType);  break;
+      CASE_NPY_INT64:  pFunction = GetCombineAccum2Function<int8_t, int64_t>(numpyOutType);  break;
       }
       break;
 
    case NPY_INT16:
       switch (type2) {
-      case NPY_INT8:   pFunction = GetCombineAccum2Function<INT16, INT8>(numpyOutType);  break;
-      case NPY_INT16:  pFunction = GetCombineAccum2Function<INT16, INT16>(numpyOutType);  break;
-      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<INT16, INT32>(numpyOutType);  break;
-      CASE_NPY_INT64:  pFunction = GetCombineAccum2Function<INT16, INT64>(numpyOutType);  break;
+      case NPY_INT8:   pFunction = GetCombineAccum2Function<int16_t, int8_t>(numpyOutType);  break;
+      case NPY_INT16:  pFunction = GetCombineAccum2Function<int16_t, int16_t>(numpyOutType);  break;
+      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<int16_t, int32_t>(numpyOutType);  break;
+      CASE_NPY_INT64:  pFunction = GetCombineAccum2Function<int16_t, int64_t>(numpyOutType);  break;
       }
       break;
 
    CASE_NPY_INT32:
       switch (type2) {
-      case NPY_INT8:   pFunction = GetCombineAccum2Function<INT32, INT8>(numpyOutType);  break;
-      case NPY_INT16:  pFunction = GetCombineAccum2Function<INT32, INT16>(numpyOutType);  break;
-      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<INT32, INT32>(numpyOutType);  break;
-      CASE_NPY_INT64:  pFunction = GetCombineAccum2Function<INT32, INT64>(numpyOutType);  break;
+      case NPY_INT8:   pFunction = GetCombineAccum2Function<int32_t, int8_t>(numpyOutType);  break;
+      case NPY_INT16:  pFunction = GetCombineAccum2Function<int32_t, int16_t>(numpyOutType);  break;
+      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<int32_t, int32_t>(numpyOutType);  break;
+      CASE_NPY_INT64:  pFunction = GetCombineAccum2Function<int32_t, int64_t>(numpyOutType);  break;
       }
       break;
 
    CASE_NPY_INT64:
       switch (type2) {
-      case NPY_INT8:   pFunction = GetCombineAccum2Function<INT64, INT8>(numpyOutType);  break;
-      case NPY_INT16:  pFunction = GetCombineAccum2Function<INT64, INT16>(numpyOutType);  break;
-      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<INT64, INT32>(numpyOutType);  break;
-      CASE_NPY_INT64:  pFunction = GetCombineAccum2Function<INT64, INT64>(numpyOutType);  break;
+      case NPY_INT8:   pFunction = GetCombineAccum2Function<int64_t, int8_t>(numpyOutType);  break;
+      case NPY_INT16:  pFunction = GetCombineAccum2Function<int64_t, int16_t>(numpyOutType);  break;
+      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<int64_t, int32_t>(numpyOutType);  break;
+      CASE_NPY_INT64:  pFunction = GetCombineAccum2Function<int64_t, int64_t>(numpyOutType);  break;
       }
       break;
    }
@@ -1564,7 +1564,7 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
       if (outArray) {
          void* pDataOut = PyArray_BYTES(outArray);
          BOOL is64bithash = FALSE;
-         INT64 sizeofhash = 4;
+         int64_t sizeofhash = 4;
 
          // 32 bit count limitation here
          PyArrayObject* countArray = NULL;
@@ -1580,7 +1580,7 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
             countArray = AllocateNumpyArray(1, (npy_intp*)&hashSize, is64bithash ? NPY_INT64 : NPY_INT32);
             CHECK_MEMORY_ERROR(countArray);
             if (countArray) {
-               pCountArray = (INT64*)PyArray_BYTES(countArray);
+               pCountArray = (int64_t*)PyArray_BYTES(countArray);
                memset(pCountArray, 0, hashSize * sizeofhash);
             }
          }
@@ -1596,7 +1596,7 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
 
             // TODO: steal from hash
             INT numCores = g_cMathWorker->WorkerThreadCount + 1;
-            INT64 sizeToAlloc = numCores * hashSize * sizeofhash;
+            int64_t sizeToAlloc = numCores * hashSize * sizeofhash;
             PVOID pWorkSpace = 0;
 
             if (bWantCount) {
@@ -1632,8 +1632,8 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
                if (is64bithash) {
 
                   // Collect the results
-                  INT64* pCoreCountArray = (INT64*)pWorkSpace;
-                  INT64* pCountArray2 = (INT64*)pCountArray;
+                  int64_t* pCoreCountArray = (int64_t*)pWorkSpace;
+                  int64_t* pCountArray2 = (int64_t*)pCountArray;
 
                   for (int j = 0; j < numCores; j++) {
 
@@ -1647,8 +1647,8 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
                }
                else {
                   // Collect the results
-                  INT32* pCoreCountArray = (INT32*)pWorkSpace;
-                  INT32* pCountArray2 = (INT32*)pCountArray;
+                  int32_t* pCoreCountArray = (int32_t*)pWorkSpace;
+                  int32_t* pCountArray2 = (int32_t*)pCountArray;
 
                   for (int j = 0; j < numCores; j++) {
 
@@ -1685,7 +1685,7 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   PyErr_Format(PyExc_ValueError, "Dont know how to combine filter these types %d.  Please make sure all bins are INT8, INT16, INT32, or INT64.", numpyOutType);
+   PyErr_Format(PyExc_ValueError, "Dont know how to combine filter these types %d.  Please make sure all bins are int8_t, int16_t, int32_t, or int64_t.", numpyOutType);
    return NULL;
 }
 
@@ -1704,47 +1704,47 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
 //         NewFirst    (the new iFirstKey)
 //
 //
-typedef INT64(*COMBINE_1_FILTER)(
+typedef int64_t(*COMBINE_1_FILTER)(
    void*    pInputIndex,
    void*    pOutputIndex,  // newly allocated
-   INT32*   pNewFirst,     // newly allocated
-   INT8*    pFilter,       // may be null
-   INT64    arrayLength,   // index array size
-   INT64    hashLength);   // max uniques + 1 (for 0 bin)
+   int32_t*   pNewFirst,     // newly allocated
+   int8_t*    pFilter,       // may be null
+   int64_t    arrayLength,   // index array size
+   int64_t    hashLength);   // max uniques + 1 (for 0 bin)
 
 template<typename INDEX>
-INT64 Combine1Filter(
+int64_t Combine1Filter(
    void*    pInputIndex,
    void*    pOutputIndex,  // newly allocated
-   INT32*   pNewFirst,     // newly allocated NOTE: for > 2e9 should be INT64
-   INT8*    pFilter,       // may be null
-   INT64    arrayLength,
-   INT64    hashLength) {
+   int32_t*   pNewFirst,     // newly allocated NOTE: for > 2e9 should be int64_t
+   int8_t*    pFilter,       // may be null
+   int64_t    arrayLength,
+   int64_t    hashLength) {
 
    INDEX*      pInput = (INDEX*)pInputIndex;
    INDEX*      pOutput = (INDEX*)pOutputIndex;
 
    //WORKSPACE_ALLOC
-   INT64 allocSize = hashLength * sizeof(INT32);
+   int64_t allocSize = hashLength * sizeof(int32_t);
 
-   INT32* pHash = (INT32*)WorkSpaceAllocLarge(allocSize);
+   int32_t* pHash = (int32_t*)WorkSpaceAllocLarge(allocSize);
    memset(pHash, 0, allocSize);
 
-   INT32       uniquecount = 0;
+   int32_t       uniquecount = 0;
    if (pFilter) {
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          if (pFilter[i]) {
             INDEX index = pInput[i];
-            //printf("[%lld] got index for %lld\n", (INT64)index, i);
+            //printf("[%lld] got index for %lld\n", (int64_t)index, i);
 
             if (index != 0) {
                // Check hash
                if (pHash[index] == 0) {
                   // First time, assign FirstKey
-                  pNewFirst[uniquecount] = (INT32)i;
+                  pNewFirst[uniquecount] = (int32_t)i;
                   uniquecount++;
 
-                  //printf("reassign index:%lld to bin:%d\n", (INT64)index, uniquecount);
+                  //printf("reassign index:%lld to bin:%d\n", (int64_t)index, uniquecount);
 
                   // ReassignKey
                   pHash[index] = uniquecount;
@@ -1752,7 +1752,7 @@ INT64 Combine1Filter(
                }
                else {
                   // Get reassigned key
-                  //printf("exiting  index:%lld to bin:%d\n", (INT64)index, (INT32)pHash[index]);
+                  //printf("exiting  index:%lld to bin:%d\n", (int64_t)index, (int32_t)pHash[index]);
                   pOutput[i] = (INDEX)pHash[index];
                }
             }
@@ -1769,15 +1769,15 @@ INT64 Combine1Filter(
    }
    else {
       // When no filter provided
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          INDEX index = pInput[i];
-         //printf("[%lld] got index\n", (INT64)index);
+         //printf("[%lld] got index\n", (int64_t)index);
 
          if (index != 0) {
             // Check hash
             if (pHash[index] == 0) {
                // First time, assign FirstKey
-               pNewFirst[uniquecount] = (INT32)i;
+               pNewFirst[uniquecount] = (int32_t)i;
                uniquecount++;
 
                // ReassignKey
@@ -1816,10 +1816,10 @@ PyObject *
 CombineAccum1Filter(PyObject *self, PyObject *args)
 {
    PyArrayObject *inArr1 = NULL;
-   INT64 inArr1Max = 0;
+   int64_t inArr1Max = 0;
    PyObject *inFilter = NULL;
 
-   INT64 out_dtype = 0;
+   int64_t out_dtype = 0;
 
    if (!PyArg_ParseTuple(
       args, "O!LO:CombineAccum1Filter",
@@ -1832,11 +1832,11 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
    }
 
    void* pDataIn1 = PyArray_BYTES(inArr1);
-   INT8* pFilterIn = NULL;
+   int8_t* pFilterIn = NULL;
 
    int ndim = PyArray_NDIM(inArr1);
    npy_intp* dims = PyArray_DIMS(inArr1);
-   INT64 arraySize1 = CalcArrayLength(ndim, dims);
+   int64_t arraySize1 = CalcArrayLength(ndim, dims);
 
    if (PyArray_Check(inFilter)) {
       if (arraySize1 != ArrayLength((PyArrayObject*)inFilter)) {
@@ -1847,11 +1847,11 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
          PyErr_Format(PyExc_ValueError, "CombineAccum1Filter: Filter is not type NPY_BOOL");
          return NULL;
       }
-      pFilterIn = (INT8*)PyArray_BYTES((PyArrayObject*)inFilter);
+      pFilterIn = (int8_t*)PyArray_BYTES((PyArrayObject*)inFilter);
    }
 
    inArr1Max++;
-   INT64 hashSize = inArr1Max;
+   int64_t hashSize = inArr1Max;
    //printf("Combine hashsize is %lld     %lld\n", hashSize, inArr1Max);
    if (hashSize < 0 || hashSize > 2000000000) {
       PyErr_Format(PyExc_ValueError, "CombineAccum1Filter: Index sizes are either 0, negative, or produce more than 2 billion results %lld", hashSize);
@@ -1863,16 +1863,16 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
    COMBINE_1_FILTER pFunction = NULL;
    switch (dtype) {
    case NPY_INT8:
-      pFunction = Combine1Filter<INT8>;
+      pFunction = Combine1Filter<int8_t>;
       break;
    case NPY_INT16:
-      pFunction = Combine1Filter<INT16>;
+      pFunction = Combine1Filter<int16_t>;
       break;
    CASE_NPY_INT32:
-      pFunction = Combine1Filter<INT32>;
+      pFunction = Combine1Filter<int32_t>;
       break;
    CASE_NPY_INT64:
-      pFunction = Combine1Filter<INT64>;
+      pFunction = Combine1Filter<int64_t>;
       break;
    }
 
@@ -1880,13 +1880,13 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
       PyArrayObject* outArray = AllocateNumpyArray(ndim, dims, dtype, 0, PyArray_IS_F_CONTIGUOUS(inArr1));
       CHECK_MEMORY_ERROR(outArray);
 
-      PyArrayObject* firstArray = AllocateNumpyArray(1, (npy_intp*)&arraySize1, NPY_INT32);  // TODO: bump up to INT64 for large arrays
+      PyArrayObject* firstArray = AllocateNumpyArray(1, (npy_intp*)&arraySize1, NPY_INT32);  // TODO: bump up to int64_t for large arrays
       CHECK_MEMORY_ERROR(firstArray);
 
       if (outArray && firstArray) {
-         INT32* pFirst = (INT32*)PyArray_BYTES(firstArray);
+         int32_t* pFirst = (int32_t*)PyArray_BYTES(firstArray);
 
-         INT64 uniqueCount =
+         int64_t uniqueCount =
             pFunction(
                pDataIn1,
                PyArray_BYTES(outArray),
@@ -1897,13 +1897,13 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
 
          if (uniqueCount < arraySize1) {
             // fixup first to hold only the uniques
-            PyArrayObject* firstArrayReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, NPY_INT32);  // TODO: bump up to INT64 for large arrays
+            PyArrayObject* firstArrayReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, NPY_INT32);  // TODO: bump up to int64_t for large arrays
             CHECK_MEMORY_ERROR(firstArrayReduced);
 
             if (firstArrayReduced) {
-               INT32* pFirstReduced = (INT32*)PyArray_BYTES(firstArrayReduced);
+               int32_t* pFirstReduced = (int32_t*)PyArray_BYTES(firstArrayReduced);
 
-               memcpy(pFirstReduced, pFirst, uniqueCount * sizeof(INT32));
+               memcpy(pFirstReduced, pFirst, uniqueCount * sizeof(int32_t));
             }
             Py_DecRef((PyObject*)firstArray);
             firstArray = firstArrayReduced;
@@ -1928,37 +1928,37 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
 
 
 
-typedef INT64(*IFIRST_FILTER)(
+typedef int64_t(*IFIRST_FILTER)(
    void*    pInputIndex,
    void*    pNewFirstIndex,     // newly allocated
-   INT8*    pFilter,       // may be null
-   INT64    arrayLength,   // index array size
-   INT64    hashLength);   // max uniques + 1 (for 0 bin)
+   int8_t*    pFilter,       // may be null
+   int64_t    arrayLength,   // index array size
+   int64_t    hashLength);   // max uniques + 1 (for 0 bin)
 
 template<typename INDEX>
-INT64 iFirstFilter(
+int64_t iFirstFilter(
    void*    pInputIndex,
-   void*    pNewFirstIndex,     // newly allocated NOTE: for > 2e9 should be INT64
-   INT8*    pFilter,       // may be null
-   INT64    arrayLength,
-   INT64    hashLength) {
+   void*    pNewFirstIndex,     // newly allocated NOTE: for > 2e9 should be int64_t
+   int8_t*    pFilter,       // may be null
+   int64_t    arrayLength,
+   int64_t    hashLength) {
 
    INDEX*      pInput = (INDEX*)pInputIndex;
-   INT64*      pNewFirst = (INT64*)pNewFirstIndex;
-   INT64       invalid = (INT64)(1LL <<  (sizeof(INT64) * 8 - 1));
+   int64_t*      pNewFirst = (int64_t*)pNewFirstIndex;
+   int64_t       invalid = (int64_t)(1LL <<  (sizeof(int64_t) * 8 - 1));
 
    // Fill with invalid
-   for (INT64 i = 0; i < hashLength; i++) {
+   for (int64_t i = 0; i < hashLength; i++) {
       pNewFirst[i] = invalid;
    }
 
    // NOTE: the uniquecount is currently not used
-   INT32       uniquecount = 0;
+   int32_t       uniquecount = 0;
    if (pFilter) {
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          if (pFilter[i]) {
             INDEX index = pInput[i];
-            //printf("[%lld] got index for %lld\n", (INT64)index, i);
+            //printf("[%lld] got index for %lld\n", (int64_t)index, i);
 
             if (index > 0 && index < hashLength) {
                // Check hash
@@ -1974,7 +1974,7 @@ INT64 iFirstFilter(
    }
    else {
       // When no filter provided
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          INDEX index = pInput[i];
 
          if (index > 0 && index < hashLength) {
@@ -1992,24 +1992,24 @@ INT64 iFirstFilter(
 }
 
 template<typename INDEX>
-INT64 iLastFilter(
+int64_t iLastFilter(
    void*    pInputIndex,
-   void*    pNewLastIndex,     // newly allocated NOTE: for > 2e9 should be INT64
-   INT8*    pFilter,           // may be null
-   INT64    arrayLength,
-   INT64    hashLength) {
+   void*    pNewLastIndex,     // newly allocated NOTE: for > 2e9 should be int64_t
+   int8_t*    pFilter,           // may be null
+   int64_t    arrayLength,
+   int64_t    hashLength) {
 
    INDEX*      pInput = (INDEX*)pInputIndex;
-   INT64*      pNewLast = (INT64*)pNewLastIndex;
-   INT64       invalid = (INT64)(1LL << (sizeof(INT64) * 8 - 1));
+   int64_t*      pNewLast = (int64_t*)pNewLastIndex;
+   int64_t       invalid = (int64_t)(1LL << (sizeof(int64_t) * 8 - 1));
 
    // Fill with invalid
-   for (INT64 i = 0; i < hashLength; i++) {
+   for (int64_t i = 0; i < hashLength; i++) {
       pNewLast[i] = invalid;
    }
 
    if (pFilter) {
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          if (pFilter[i]) {
             INDEX index = pInput[i];
             if (index > 0 && index < hashLength) {
@@ -2021,7 +2021,7 @@ INT64 iLastFilter(
    }
    else {
       // When no filter provided
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          INDEX index = pInput[i];
 
          if (index > 0 && index < hashLength) {
@@ -2048,11 +2048,11 @@ INT64 iLastFilter(
 PyObject *
 MakeiFirst(PyObject *self, PyObject *args) {
    PyArrayObject *inArr1 = NULL;
-   INT64 inArr1Max = 0;
+   int64_t inArr1Max = 0;
    PyObject *inFilter = NULL;
-   INT64 isLast = 0;
+   int64_t isLast = 0;
 
-   INT64 out_dtype = 0;
+   int64_t out_dtype = 0;
 
    if (!PyArg_ParseTuple(
       args, "O!LOL:MakeiFirst",
@@ -2066,11 +2066,11 @@ MakeiFirst(PyObject *self, PyObject *args) {
    }
 
    void* pDataIn1 = PyArray_BYTES(inArr1);
-   INT8* pFilterIn = NULL;
+   int8_t* pFilterIn = NULL;
 
    int ndim = PyArray_NDIM(inArr1);
    npy_intp* dims = PyArray_DIMS(inArr1);
-   INT64 arraySize1 = CalcArrayLength(ndim, dims);
+   int64_t arraySize1 = CalcArrayLength(ndim, dims);
 
    if (PyArray_Check(inFilter)) {
       if (arraySize1 != ArrayLength((PyArrayObject*)inFilter)) {
@@ -2081,11 +2081,11 @@ MakeiFirst(PyObject *self, PyObject *args) {
          PyErr_Format(PyExc_ValueError, "MakeiFirst: Filter is not type NPY_BOOL");
          return NULL;
       }
-      pFilterIn = (INT8*)PyArray_BYTES((PyArrayObject*)inFilter);
+      pFilterIn = (int8_t*)PyArray_BYTES((PyArrayObject*)inFilter);
    }
 
    inArr1Max++;
-   INT64 hashSize = inArr1Max;
+   int64_t hashSize = inArr1Max;
    //printf("Combine hashsize is %lld     %lld\n", hashSize, inArr1Max);
    if (hashSize < 0 || hashSize > 20000000000LL) {
       PyErr_Format(PyExc_ValueError, "MakeiFirst: Index sizes are either 0, negative, or produce more than 20 billion results %lld", hashSize);
@@ -2099,16 +2099,16 @@ MakeiFirst(PyObject *self, PyObject *args) {
    if (isLast) {
       switch (dtype) {
       case NPY_INT8:
-         pFunction = iLastFilter<INT8>;
+         pFunction = iLastFilter<int8_t>;
          break;
       case NPY_INT16:
-         pFunction = iLastFilter<INT16>;
+         pFunction = iLastFilter<int16_t>;
          break;
       case NPY_INT32:
-         pFunction = iLastFilter<INT32>;
+         pFunction = iLastFilter<int32_t>;
          break;
       case NPY_INT64:
-         pFunction = iLastFilter<INT64>;
+         pFunction = iLastFilter<int64_t>;
          break;
       }
 
@@ -2116,16 +2116,16 @@ MakeiFirst(PyObject *self, PyObject *args) {
    else {
       switch (dtype) {
       case NPY_INT8:
-         pFunction = iFirstFilter<INT8>;
+         pFunction = iFirstFilter<int8_t>;
          break;
       case NPY_INT16:
-         pFunction = iFirstFilter<INT16>;
+         pFunction = iFirstFilter<int16_t>;
          break;
       case NPY_INT32:
-         pFunction = iFirstFilter<INT32>;
+         pFunction = iFirstFilter<int32_t>;
          break;
       case NPY_INT64:
-         pFunction = iFirstFilter<INT64>;
+         pFunction = iFirstFilter<int64_t>;
          break;
       }
    }
@@ -2137,7 +2137,7 @@ MakeiFirst(PyObject *self, PyObject *args) {
       if (firstArray) {
          void* pFirst = PyArray_BYTES(firstArray);
 
-         INT64 uniqueCount =
+         int64_t uniqueCount =
             pFunction(
                pDataIn1,
                pFirst,
@@ -2160,8 +2160,8 @@ MakeiFirst(PyObject *self, PyObject *args) {
 
 //=====================================================================================
 //
-void TrailingSpaces(char* pStringArray, INT64 length, INT64 itemSize) {
-   for (INT64 i = 0; i < length; i++) {
+void TrailingSpaces(char* pStringArray, int64_t length, int64_t itemSize) {
+   for (int64_t i = 0; i < length; i++) {
       char* pStart = pStringArray + (i * itemSize);
       char* pEnd = pStart + itemSize - 1;
       while (pEnd >= pStart && (*pEnd == ' ' || *pEnd == 0)) {
@@ -2172,12 +2172,12 @@ void TrailingSpaces(char* pStringArray, INT64 length, INT64 itemSize) {
 
 //=====================================================================================
 //
-void TrailingSpacesUnicode(UINT32* pUnicodeArray, INT64 length, INT64 itemSize) {
+void TrailingSpacesUnicode(uint32_t* pUnicodeArray, int64_t length, int64_t itemSize) {
    itemSize = itemSize / 4;
 
-   for (INT64 i = 0; i < length; i++) {
-      UINT32* pStart = pUnicodeArray + (i * itemSize);
-      UINT32* pEnd = pStart + itemSize - 1;
+   for (int64_t i = 0; i < length; i++) {
+      uint32_t* pStart = pUnicodeArray + (i * itemSize);
+      uint32_t* pEnd = pStart + itemSize - 1;
       while (pEnd >= pStart && (*pEnd == 32 || *pEnd == 0)) {
          *pEnd-- = 0;
       }
@@ -2204,14 +2204,14 @@ RemoveTrailingSpaces(PyObject *self, PyObject *args)
 
    if (dtype == NPY_STRING || dtype == NPY_UNICODE) {
       void* pDataIn1 = PyArray_BYTES(inArr1);
-      INT64 arraySize1 = ArrayLength(inArr1);
-      INT64 itemSize = PyArray_ITEMSIZE(inArr1);
+      int64_t arraySize1 = ArrayLength(inArr1);
+      int64_t itemSize = PyArray_ITEMSIZE(inArr1);
 
       if (dtype == NPY_STRING) {
          TrailingSpaces((char *)pDataIn1, arraySize1, itemSize);
       }
       else {
-         TrailingSpacesUnicode((UINT32 *)pDataIn1, arraySize1, itemSize);
+         TrailingSpacesUnicode((uint32_t *)pDataIn1, arraySize1, itemSize);
       }
 
       Py_IncRef((PyObject*)inArr1);
@@ -2224,7 +2224,7 @@ RemoveTrailingSpaces(PyObject *self, PyObject *args)
 }
 
 
-int GetUpcastDtype(ArrayInfo* aInfo, INT64 tupleSize) {
+int GetUpcastDtype(ArrayInfo* aInfo, int64_t tupleSize) {
    int maxfloat = -1;
    int maxint = -1;
    int maxuint = -1;
@@ -2368,8 +2368,8 @@ PyObject *GetUpcastNum(PyObject* self, PyObject *args)
       return NULL;
    }
 
-   INT64 totalItemSize = 0;
-   INT64 tupleSize = 0;
+   int64_t totalItemSize = 0;
+   int64_t tupleSize = 0;
 
    // Allow jagged rows
    // Do not copy
@@ -2391,7 +2391,7 @@ PyObject *GetUpcastNum(PyObject* self, PyObject *args)
 PyObject *HStack(PyObject* self, PyObject *args)
 {
    PyObject *inList1 = NULL;
-   INT32 dtype = -1;
+   int32_t dtype = -1;
 
    if (!PyArg_ParseTuple(
       args, "O|i",
@@ -2408,16 +2408,16 @@ PyObject *HStack(PyObject* self, PyObject *args)
       }
    }
 
-   INT64 totalItemSize = 0;
-   INT64 tupleSize = 0;
+   int64_t totalItemSize = 0;
+   int64_t tupleSize = 0;
 
    // Allow jagged rows
    ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, FALSE);
 
    if (aInfo) {
 
-      INT64 totalLength = 0;
-      INT64 maxItemSize = 0;
+      int64_t totalLength = 0;
+      int64_t maxItemSize = 0;
       PyArrayObject* outputArray = NULL;
 
       if (dtype == -1) {
@@ -2458,8 +2458,8 @@ PyObject *HStack(PyObject* self, PyObject *args)
          // Path for strings
          //
          struct stHSTACK_STRING {
-            INT64                   Offset;
-            INT64                   ItemSize;
+            int64_t                   Offset;
+            int64_t                   ItemSize;
             CONVERT_SAFE_STRING     ConvertSafeString;
          };
 
@@ -2484,7 +2484,7 @@ PyObject *HStack(PyObject* self, PyObject *args)
 
          CHECK_MEMORY_ERROR(outputArray);
          if (outputArray) {
-            INT64 itemSize = PyArray_ITEMSIZE(outputArray);
+            int64_t itemSize = PyArray_ITEMSIZE(outputArray);
             char* pOutput = (char*)PyArray_BYTES(outputArray);
 
             if (tupleSize < 2 || totalLength <= g_cMathWorker->WORK_ITEM_CHUNK) {
@@ -2496,12 +2496,12 @@ PyObject *HStack(PyObject* self, PyObject *args)
             else {
 
                // Callback routine from multithreaded worker thread (items just count up from 0,1,2,...)
-               //typedef BOOL(*MTWORK_CALLBACK)(void* callbackArg, int core, INT64 workIndex);
+               //typedef BOOL(*MTWORK_CALLBACK)(void* callbackArg, int core, int64_t workIndex);
                struct stSHSTACK {
                   stHSTACK_STRING*  pHStack;
                   ArrayInfo*        aInfo;
                   char*             pOutput;
-                  INT64             ItemSizeOutput;
+                  int64_t             ItemSizeOutput;
                } myhstack;
 
                myhstack.pHStack = pHStack;
@@ -2511,9 +2511,9 @@ PyObject *HStack(PyObject* self, PyObject *args)
 
                LOGGING("MT string hstack work on %lld\n", tupleSize);
 
-               auto lambdaHSCallback = [](void* callbackArgT, int core, INT64 workIndex) -> BOOL {
+               auto lambdaHSCallback = [](void* callbackArgT, int core, int64_t workIndex) -> BOOL {
                   stSHSTACK* callbackArg = (stSHSTACK*)callbackArgT;
-                  INT64 t = workIndex;
+                  int64_t t = workIndex;
                   callbackArg->pHStack[t].ConvertSafeString(
                      callbackArg->aInfo[t].pData,
                      callbackArg->pOutput + (callbackArg->pHStack[t].Offset * callbackArg->ItemSizeOutput),
@@ -2535,7 +2535,7 @@ PyObject *HStack(PyObject* self, PyObject *args)
 
          // Path for non-strings
          struct stHSTACK {
-            INT64          Offset;
+            int64_t          Offset;
             void*          pBadInput1;
             CONVERT_SAFE   ConvertSafe;
          };
@@ -2566,7 +2566,7 @@ PyObject *HStack(PyObject* self, PyObject *args)
             // if output is boolean, bad means FALSE
             void* pBadOutput1 = GetDefaultForType(dtype);
 
-            INT64 strideOut = PyArray_STRIDE(outputArray, 0);
+            int64_t strideOut = PyArray_STRIDE(outputArray, 0);
             char* pOutput = (char*)PyArray_BYTES(outputArray);
 
             if (tupleSize < 2 || totalLength <= g_cMathWorker->WORK_ITEM_CHUNK) {
@@ -2584,12 +2584,12 @@ PyObject *HStack(PyObject* self, PyObject *args)
             else {
 
                // Callback routine from multithreaded worker thread (items just count up from 0,1,2,...)
-               //typedef BOOL(*MTWORK_CALLBACK)(void* callbackArg, int core, INT64 workIndex);
+               //typedef BOOL(*MTWORK_CALLBACK)(void* callbackArg, int core, int64_t workIndex);
                struct stSHSTACK {
                   stHSTACK*      pHStack;
                   ArrayInfo*     aInfo;
                   char*          pOutput;
-                  INT64          StrideOut;
+                  int64_t          StrideOut;
                   void*          pBadOutput1;
                } myhstack;
 
@@ -2601,9 +2601,9 @@ PyObject *HStack(PyObject* self, PyObject *args)
 
                LOGGING("MT hstack work on %lld\n", tupleSize);
 
-               auto lambdaHSCallback = [](void* callbackArgT, int core, INT64 workIndex) -> BOOL {
+               auto lambdaHSCallback = [](void* callbackArgT, int core, int64_t workIndex) -> BOOL {
                   stSHSTACK* callbackArg = (stSHSTACK*)callbackArgT;
-                  INT64 t = workIndex;
+                  int64_t t = workIndex;
                   callbackArg->pHStack[t].ConvertSafe(
                      callbackArg->aInfo[t].pData,
                      callbackArg->pOutput + (callbackArg->pHStack[t].Offset * callbackArg->StrideOut),
@@ -2646,7 +2646,7 @@ PyObject *HStack(PyObject* self, PyObject *args)
 PyObject *ShiftArrays(PyObject* self, PyObject *args)
 {
    PyObject *inList1 = NULL;
-   INT64 shiftAmount = 0;
+   int64_t shiftAmount = 0;
 
    if (!PyArg_ParseTuple(
       args, "OL",
@@ -2656,29 +2656,29 @@ PyObject *ShiftArrays(PyObject* self, PyObject *args)
       return NULL;
    }
 
-   INT64 totalItemSize = 0;
-   INT64 tupleSize = 0;
+   int64_t totalItemSize = 0;
+   int64_t tupleSize = 0;
 
    // Allow jagged rows
    ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, FALSE);
 
    if (aInfo) {
 
-      INT64 totalLength = 0;
+      int64_t totalLength = 0;
 
       // Callback routine from multithreaded worker thread (items just count up from 0,1,2,...)
-      //typedef BOOL(*MTWORK_CALLBACK)(void* callbackArg, int core, INT64 workIndex);
+      //typedef BOOL(*MTWORK_CALLBACK)(void* callbackArg, int core, int64_t workIndex);
       struct stSHIFT {
          ArrayInfo*     aInfo;
-         INT64          shiftAmount;
+         int64_t          shiftAmount;
       } myshift;
 
       myshift.aInfo = aInfo;
       myshift.shiftAmount = shiftAmount;
 
-      auto lambdaShiftCallback = [](void* callbackArgT, int core, INT64 workIndex) -> BOOL {
+      auto lambdaShiftCallback = [](void* callbackArgT, int core, int64_t workIndex) -> BOOL {
          stSHIFT* pShift = (stSHIFT*)callbackArgT;
-         INT64 t = workIndex;
+         int64_t t = workIndex;
 
          ArrayInfo* pArrayInfo = &pShift->aInfo[t];
 
@@ -2700,8 +2700,8 @@ PyObject *ShiftArrays(PyObject* self, PyObject *args)
                // h k n x x   5  6  7  8  9
                // i l o x x  10 11 12 13 14
                //
-               INT64 rows = pDims[0];
-               INT64 cols = pDims[1];
+               int64_t rows = pDims[0];
+               int64_t cols = pDims[1];
 
                LOGGING("!! encountered fortran array while shifting! %lld x %lld\n", rows, cols);
 
@@ -2713,7 +2713,7 @@ PyObject *ShiftArrays(PyObject* self, PyObject *args)
                   char* pDst = pArrayInfo->pData;
                   char* pSrc = pDst + (pShift->shiftAmount * pArrayInfo->ItemSize);
 
-                  INT64 rowsToMove = rows - pShift->shiftAmount;
+                  int64_t rowsToMove = rows - pShift->shiftAmount;
 
                   // Check for negative shift value
                   if (pShift->shiftAmount < 0) {
@@ -2723,11 +2723,11 @@ PyObject *ShiftArrays(PyObject* self, PyObject *args)
                   }
 
                   if (rowsToMove > 0) {
-                     INT64 rowsToMoveSize = rowsToMove * pArrayInfo->ItemSize;
-                     INT64 rowSize = rows * pArrayInfo->ItemSize;
+                     int64_t rowsToMoveSize = rowsToMove * pArrayInfo->ItemSize;
+                     int64_t rowSize = rows * pArrayInfo->ItemSize;
 
                      // 2d shift
-                     for (INT64 i = 0; i < cols; i++) {
+                     for (int64_t i = 0; i < cols; i++) {
                         memmove(pDst, pSrc, rowsToMoveSize);
                         pDst += rowSize;
                         pSrc += rowSize;
@@ -2741,7 +2741,7 @@ PyObject *ShiftArrays(PyObject* self, PyObject *args)
                // shiftAmount:  1000
                // deltaShift:   9000 items to move
                //
-               INT64 deltaShift = pArrayInfo->ArrayLength - pShift->shiftAmount;
+               int64_t deltaShift = pArrayInfo->ArrayLength - pShift->shiftAmount;
                if (pShift->shiftAmount < 0) {
                   deltaShift = pArrayInfo->ArrayLength + pShift->shiftAmount;
                }
@@ -2802,14 +2802,14 @@ PyObject *HomogenizeArrays(PyObject* self, PyObject *args) {
    PyObject* inList1 = PyTuple_GetItem(args, 0);
    PyObject* dtypeObject = PyTuple_GetItem(args, 1);
 
-   INT64 totalItemSize = 0;
-   INT64 tupleSize = 0;
+   int64_t totalItemSize = 0;
+   int64_t tupleSize = 0;
 
    // Do not allow jagged rows
    ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, TRUE);
 
    if (aInfo) {
-      INT32 dtype = (INT32)PyLong_AsLong(dtypeObject);
+      int32_t dtype = (int32_t)PyLong_AsLong(dtypeObject);
 
       if (dtype != -1) {
          if (dtype < 0 || dtype > NPY_LONGDOUBLE) {
@@ -2881,8 +2881,8 @@ PyObject *HomogenizeArrays(PyObject* self, PyObject *args) {
 // TODO: When we support runtime CPU detection/dispatching, bring back the original popcnt-based implementation
 //       of this function for systems that don't support AVX2. Also consider implementing an SSE-based version
 //       of this function for the same reason (logic will be very similar, just using __m128i instead).
-// TODO: Consider changing `length` to UINT64 here so it agrees better with the result of sizeof().
-INT64 SumBooleanMask(const INT8* const pData, const INT64 length) {
+// TODO: Consider changing `length` to uint64_t here so it agrees better with the result of sizeof().
+int64_t SumBooleanMask(const int8_t* const pData, const int64_t length) {
    // Basic input validation.
    if (!pData)
    {
@@ -2900,7 +2900,7 @@ INT64 SumBooleanMask(const INT8* const pData, const INT64 length) {
    const auto ulength = static_cast<size_t>(length);
 
    // Holds the accumulated result value.
-   INT64 result = 0;
+   int64_t result = 0;
 
    // YMM (32-byte) vector packed with 32 byte values, each set to 1.
    // NOTE: The obvious thing here would be to use _mm256_set1_epi8(1),
@@ -2998,15 +2998,15 @@ INT64 SumBooleanMask(const INT8* const pData, const INT64 length) {
 
 //--------------------------------------------------------------------------
 // Array copy from one to another using boolean mask
-void CopyItemBooleanMask(void* pSrcV, void* pDestV, INT8* pBoolMask, INT64 arrayLength, INT64 itemsize) {
+void CopyItemBooleanMask(void* pSrcV, void* pDestV, int8_t* pBoolMask, int64_t arrayLength, int64_t itemsize) {
    switch (itemsize) {
 
    case 1:
    {
-      INT8* pSrc = (INT8*)pSrcV;
-      INT8* pDest = (INT8*)pDestV;
+      int8_t* pSrc = (int8_t*)pSrcV;
+      int8_t* pDest = (int8_t*)pDestV;
 
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          if (*pBoolMask++) {
             pDest[i] = *pSrc++;
          }
@@ -3015,10 +3015,10 @@ void CopyItemBooleanMask(void* pSrcV, void* pDestV, INT8* pBoolMask, INT64 array
    }
    case 2:
    {
-      INT16* pSrc = (INT16*)pSrcV;
-      INT16* pDest = (INT16*)pDestV;
+      int16_t* pSrc = (int16_t*)pSrcV;
+      int16_t* pDest = (int16_t*)pDestV;
 
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          if (*pBoolMask++) {
             pDest[i] = *pSrc++;
          }
@@ -3027,10 +3027,10 @@ void CopyItemBooleanMask(void* pSrcV, void* pDestV, INT8* pBoolMask, INT64 array
    }
    case 4:
    {
-      INT32* pSrc = (INT32*)pSrcV;
-      INT32* pDest = (INT32*)pDestV;
+      int32_t* pSrc = (int32_t*)pSrcV;
+      int32_t* pDest = (int32_t*)pDestV;
 
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          if (*pBoolMask++) {
             pDest[i] = *pSrc++;
          }
@@ -3039,10 +3039,10 @@ void CopyItemBooleanMask(void* pSrcV, void* pDestV, INT8* pBoolMask, INT64 array
    }
    case 8:
    {
-      INT64* pSrc = (INT64*)pSrcV;
-      INT64* pDest = (INT64*)pDestV;
+      int64_t* pSrc = (int64_t*)pSrcV;
+      int64_t* pDest = (int64_t*)pDestV;
 
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          if (*pBoolMask++) {
             pDest[i] = *pSrc++;
          }
@@ -3054,7 +3054,7 @@ void CopyItemBooleanMask(void* pSrcV, void* pDestV, INT8* pBoolMask, INT64 array
       char* pSrc = (char*)pSrcV;
       char* pDest = (char*)pDestV;
 
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          if (*pBoolMask++) {
             memcpy(pDest + (itemsize* i), pSrc, itemsize);
             pSrc += itemsize;
@@ -3069,15 +3069,15 @@ void CopyItemBooleanMask(void* pSrcV, void* pDestV, INT8* pBoolMask, INT64 array
 
 //--------------------------------------------------------------------------
 // Copying scalars to array with boolean mask
-void CopyItemBooleanMaskScalar(void* pSrcV, void* pDestV, INT8* pBoolMask, INT64 arrayLength, INT64 itemsize) {
+void CopyItemBooleanMaskScalar(void* pSrcV, void* pDestV, int8_t* pBoolMask, int64_t arrayLength, int64_t itemsize) {
    switch (itemsize) {
 
    case 1:
    {
-      INT8* pSrc = (INT8*)pSrcV;
-      INT8* pDest = (INT8*)pDestV;
+      int8_t* pSrc = (int8_t*)pSrcV;
+      int8_t* pDest = (int8_t*)pDestV;
 
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          if (*pBoolMask++) {
             pDest[i] = *pSrc;
          }
@@ -3086,10 +3086,10 @@ void CopyItemBooleanMaskScalar(void* pSrcV, void* pDestV, INT8* pBoolMask, INT64
    }
    case 2:
    {
-      INT16* pSrc = (INT16*)pSrcV;
-      INT16* pDest = (INT16*)pDestV;
+      int16_t* pSrc = (int16_t*)pSrcV;
+      int16_t* pDest = (int16_t*)pDestV;
 
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          if (*pBoolMask++) {
             pDest[i] = *pSrc;
          }
@@ -3098,10 +3098,10 @@ void CopyItemBooleanMaskScalar(void* pSrcV, void* pDestV, INT8* pBoolMask, INT64
    }
    case 4:
    {
-      INT32* pSrc = (INT32*)pSrcV;
-      INT32* pDest = (INT32*)pDestV;
+      int32_t* pSrc = (int32_t*)pSrcV;
+      int32_t* pDest = (int32_t*)pDestV;
 
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          if (*pBoolMask++) {
             pDest[i] = *pSrc;
          }
@@ -3110,10 +3110,10 @@ void CopyItemBooleanMaskScalar(void* pSrcV, void* pDestV, INT8* pBoolMask, INT64
    }
    case 8:
    {
-      INT64* pSrc = (INT64*)pSrcV;
-      INT64* pDest = (INT64*)pDestV;
+      int64_t* pSrc = (int64_t*)pSrcV;
+      int64_t* pDest = (int64_t*)pDestV;
 
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          if (*pBoolMask++) {
             pDest[i] = *pSrc;
          }
@@ -3125,7 +3125,7 @@ void CopyItemBooleanMaskScalar(void* pSrcV, void* pDestV, INT8* pBoolMask, INT64
       char* pSrc = (char*)pSrcV;
       char* pDest = (char*)pDestV;
 
-      for (INT64 i = 0; i < arrayLength; i++) {
+      for (int64_t i = 0; i < arrayLength; i++) {
          if (*pBoolMask++) {
             memcpy(pDest + (itemsize* i), pSrc, itemsize);
          }
@@ -3140,12 +3140,12 @@ void CopyItemBooleanMaskScalar(void* pSrcV, void* pDestV, INT8* pBoolMask, INT64
 
 //--------------------------------------------------------------------------
 //
-PyObject* SetItemBooleanMask(PyArrayObject* arr, PyArrayObject* mask, PyArrayObject* inValues, INT64 arrayLength) {
+PyObject* SetItemBooleanMask(PyArrayObject* arr, PyArrayObject* mask, PyArrayObject* inValues, int64_t arrayLength) {
 
    //PyObject* boolsum =
    //   ReduceInternal(mask, REDUCE_SUM);
-   INT8* pBoolMask = (INT8*)PyArray_BYTES(mask);
-   INT64 bsum = SumBooleanMask(pBoolMask, ArrayLength(mask));
+   int8_t* pBoolMask = (int8_t*)PyArray_BYTES(mask);
+   int64_t bsum = SumBooleanMask(pBoolMask, ArrayLength(mask));
 
    // Sum the boolean array
    if (bsum > 0 && bsum == ArrayLength(inValues)) {
@@ -3171,15 +3171,15 @@ PyObject* SetItemBooleanMask(PyArrayObject* arr, PyArrayObject* mask, PyArrayObj
 
 //--------------------------------------------------------------------------
 // TODO: Refactor this method and SetItemBooleanMask
-PyObject* SetItemBooleanMaskLarge(PyArrayObject* arr, PyArrayObject* mask, PyArrayObject* inValues, INT64 arrayLength) {
+PyObject* SetItemBooleanMaskLarge(PyArrayObject* arr, PyArrayObject* mask, PyArrayObject* inValues, int64_t arrayLength) {
    struct ST_BOOLCOUNTER {
-      INT8*    pBoolMask;
-      INT64*   pCounts;
-      INT64    sections;
-      INT64    maskLength;
+      int8_t*    pBoolMask;
+      int64_t*   pCounts;
+      int64_t    sections;
+      int64_t    maskLength;
       char*    pSrc;
       char*    pDest;
-      INT64    itemSize;
+      int64_t    itemSize;
 
    } stBoolCounter;
 
@@ -3190,23 +3190,23 @@ PyObject* SetItemBooleanMaskLarge(PyArrayObject* arr, PyArrayObject* mask, PyArr
    stBoolCounter.maskLength = ArrayLength(mask);
    stBoolCounter.sections = (stBoolCounter.maskLength + (SETITEM_PARTITION_SIZE-1)) / SETITEM_PARTITION_SIZE;
 
-   INT64 allocSize = stBoolCounter.sections * sizeof(INT64);
-   const INT64 maxStackAlloc = 1024 * 1024;  // 1 MB
+   int64_t allocSize = stBoolCounter.sections * sizeof(int64_t);
+   const int64_t maxStackAlloc = 1024 * 1024;  // 1 MB
 
    if (allocSize > maxStackAlloc) {
-      stBoolCounter.pCounts = (INT64*)WORKSPACE_ALLOC(allocSize);
+      stBoolCounter.pCounts = (int64_t*)WORKSPACE_ALLOC(allocSize);
    }
    else {
-      stBoolCounter.pCounts = (INT64*)alloca(allocSize);
+      stBoolCounter.pCounts = (int64_t*)alloca(allocSize);
    }
    if (stBoolCounter.pCounts) {
-      stBoolCounter.pBoolMask = (INT8*)PyArray_BYTES(mask);
+      stBoolCounter.pBoolMask = (int8_t*)PyArray_BYTES(mask);
 
-      auto lambdaCallback = [](void* callbackArgT, int core, INT64 workIndex) -> BOOL {
+      auto lambdaCallback = [](void* callbackArgT, int core, int64_t workIndex) -> BOOL {
          ST_BOOLCOUNTER* pstBoolCounter = (ST_BOOLCOUNTER*)callbackArgT;
-         INT64 t = workIndex;
+         int64_t t = workIndex;
 
-         INT64 lastCount = SETITEM_PARTITION_SIZE;
+         int64_t lastCount = SETITEM_PARTITION_SIZE;
          if (t == pstBoolCounter->sections - 1) {
             lastCount = pstBoolCounter->maskLength & (SETITEM_PARTITION_SIZE - 1);
             if (lastCount == 0) lastCount = SETITEM_PARTITION_SIZE;
@@ -3220,27 +3220,27 @@ PyObject* SetItemBooleanMaskLarge(PyArrayObject* arr, PyArrayObject* mask, PyArr
       g_cMathWorker->DoMultiThreadedWork((int)stBoolCounter.sections, lambdaCallback, &stBoolCounter);
 
       // calculate the sum for each section
-      INT64 bsum = 0;
+      int64_t bsum = 0;
       for (int i = 0; i < stBoolCounter.sections; i++) {
-         INT64 temp = bsum;
+         int64_t temp = bsum;
          bsum += stBoolCounter.pCounts[i];
          stBoolCounter.pCounts[i] = temp;
       }
 
-      INT64 arrlength = ArrayLength(inValues);
+      int64_t arrlength = ArrayLength(inValues);
 
       if (bsum > 0 && bsum == arrlength) {
 
-         auto lambda2Callback = [](void* callbackArgT, int core, INT64 workIndex) -> BOOL {
+         auto lambda2Callback = [](void* callbackArgT, int core, int64_t workIndex) -> BOOL {
             ST_BOOLCOUNTER* pstBoolCounter = (ST_BOOLCOUNTER*)callbackArgT;
-            INT64 t = workIndex;
+            int64_t t = workIndex;
 
-            INT64 lastCount = SETITEM_PARTITION_SIZE;
+            int64_t lastCount = SETITEM_PARTITION_SIZE;
             if (t == pstBoolCounter->sections - 1) {
                lastCount = pstBoolCounter->maskLength & (SETITEM_PARTITION_SIZE - 1);
                if (lastCount == 0) lastCount = SETITEM_PARTITION_SIZE;
             }
-            INT64 adjustment = (SETITEM_PARTITION_SIZE * workIndex * pstBoolCounter->itemSize);
+            int64_t adjustment = (SETITEM_PARTITION_SIZE * workIndex * pstBoolCounter->itemSize);
             CopyItemBooleanMask(
                pstBoolCounter->pSrc + (pstBoolCounter->pCounts[workIndex] * pstBoolCounter->itemSize),
                pstBoolCounter->pDest + adjustment,
@@ -3261,16 +3261,16 @@ PyObject* SetItemBooleanMaskLarge(PyArrayObject* arr, PyArrayObject* mask, PyArr
 
       if (bsum > 0 && arrlength == 1) {
 
-         auto lambda2Callback = [](void* callbackArgT, int core, INT64 workIndex) -> BOOL {
+         auto lambda2Callback = [](void* callbackArgT, int core, int64_t workIndex) -> BOOL {
             ST_BOOLCOUNTER* pstBoolCounter = (ST_BOOLCOUNTER*)callbackArgT;
-            INT64 t = workIndex;
+            int64_t t = workIndex;
 
-            INT64 lastCount = SETITEM_PARTITION_SIZE;
+            int64_t lastCount = SETITEM_PARTITION_SIZE;
             if (t == pstBoolCounter->sections - 1) {
                lastCount = pstBoolCounter->maskLength & (SETITEM_PARTITION_SIZE - 1);
                if (lastCount == 0) lastCount = SETITEM_PARTITION_SIZE;
             }
-            INT64 adjustment = (SETITEM_PARTITION_SIZE * workIndex * pstBoolCounter->itemSize);
+            int64_t adjustment = (SETITEM_PARTITION_SIZE * workIndex * pstBoolCounter->itemSize);
             CopyItemBooleanMaskScalar(
                pstBoolCounter->pSrc,
                pstBoolCounter->pDest + adjustment,
@@ -3344,7 +3344,7 @@ PyObject *SetItem(PyObject* self, PyObject *args)
             int arrType = PyArray_TYPE(mask);
 
             if (arrType == NPY_BOOL) {
-               INT64 arrayLength = ArrayLength(arr);
+               int64_t arrayLength = ArrayLength(arr);
 
                if (arrayLength == ArrayLength(mask)) {
 
@@ -3413,13 +3413,13 @@ PyObject *PutMask(PyObject* self, PyObject *args)
 
       if (PyArray_TYPE(mask) == NPY_BOOL) {
 
-         INT64 itemSizeOut = PyArray_ITEMSIZE(arr);
-         INT64 itemSizeIn = PyArray_ITEMSIZE(inValues);
+         int64_t itemSizeOut = PyArray_ITEMSIZE(arr);
+         int64_t itemSizeIn = PyArray_ITEMSIZE(inValues);
 
          // check for strides... ?
-         INT64 arrayLength = ArrayLength(arr);
+         int64_t arrayLength = ArrayLength(arr);
          if (arrayLength == ArrayLength(mask) && itemSizeOut == PyArray_STRIDE(arr,0)) {
-            INT64 valLength = ArrayLength(inValues);
+            int64_t valLength = ArrayLength(inValues);
 
             if (arrayLength == valLength) {
                int outDType = PyArray_TYPE(arr);
@@ -3433,9 +3433,9 @@ PyObject *PutMask(PyObject* self, PyObject *args)
                      MASK_CONVERT_SAFE maskSafe;
                      char* pIn;
                      char* pOut;
-                     INT64 itemSizeOut;
-                     INT64 itemSizeIn;
-                     INT8* pMask;
+                     int64_t itemSizeOut;
+                     int64_t itemSizeIn;
+                     int8_t* pMask;
                      void* pBadInput1;
                      void* pBadOutput1;
 
@@ -3444,11 +3444,11 @@ PyObject *PutMask(PyObject* self, PyObject *args)
                   MASK_CALLBACK_STRUCT stMask;
 
                   // This is the routine that will be called back from multiple threads
-                  auto lambdaMaskCallback = [](void* callbackArgT, int core, INT64 start, INT64 length) -> BOOL {
+                  auto lambdaMaskCallback = [](void* callbackArgT, int core, int64_t start, int64_t length) -> BOOL {
                      MASK_CALLBACK_STRUCT* callbackArg = (MASK_CALLBACK_STRUCT*)callbackArgT;
 
                      //printf("[%d] Mask %lld %lld\n", core, start, length);
-                     //maskSafe(pIn, pOut, (INT8*)pMask, length, pBadInput1, pBadOutput1);
+                     //maskSafe(pIn, pOut, (int8_t*)pMask, length, pBadInput1, pBadOutput1);
                      // Auto adjust pointers
                      callbackArg->maskSafe(
                         callbackArg->pIn + (start * callbackArg->itemSizeIn),
@@ -3468,7 +3468,7 @@ PyObject *PutMask(PyObject* self, PyObject *args)
 
                   stMask.pIn = (char*)PyArray_BYTES(inValues);
                   stMask.pOut = (char*)PyArray_BYTES(arr);
-                  stMask.pMask = (INT8*)PyArray_BYTES(mask);
+                  stMask.pMask = (int8_t*)PyArray_BYTES(mask);
                   stMask.maskSafe = maskSafe;
 
                   g_cMathWorker->DoMultiThreadedChunkWork(arrayLength, lambdaMaskCallback, &stMask);
@@ -3524,14 +3524,14 @@ PyObject *ApplyRows(PyObject* self, PyObject *args, PyObject* kwargs)
       PyObject* inList1 = PyTuple_GetItem(args, 0);
       PyObject* dtypeObject= PyTuple_GetItem(args, 1);
 
-      INT64 totalItemSize = 0;
-      INT64 tupleSize = 0;
+      int64_t totalItemSize = 0;
+      int64_t tupleSize = 0;
 
       // Do not allow jagged rows
       ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, TRUE);
 
       if (aInfo) {
-         INT32 dtype = (INT32)PyLong_AsLong(dtypeObject);
+         int32_t dtype = (int32_t)PyLong_AsLong(dtypeObject);
 
          if (dtype != -1) {
             if (dtype < 0 || dtype > NPY_LONGDOUBLE) {

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -442,15 +442,15 @@ static UNARY_FUNC GetConversionStep2(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvert;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvert;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvert;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvert;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvert;
+   CASE_NPY_INT64:
+   
       return ConvertBase<T, int64_t>::OneStubConvert;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvert;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvert;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvert;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvert;
+   CASE_NPY_UINT64:
+   
       return ConvertBase<T, uint64_t>::OneStubConvert;
    }
    return NULL;
@@ -466,15 +466,15 @@ static CONVERT_SAFE GetConversionStep2Safe(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafe;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafe;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafe;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafe;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafe;
+   CASE_NPY_INT64:
+   
            return ConvertBase<T, int64_t>::OneStubConvertSafe;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafe;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafe;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafe;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafe;
+   CASE_NPY_UINT64:
+   
           return ConvertBase<T, uint64_t>::OneStubConvertSafe;
    }
    return NULL;
@@ -492,15 +492,15 @@ static CONVERT_SAFE GetConversionStep2Unsafe(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertUnsafe;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertUnsafe;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertUnsafe;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertUnsafe;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertUnsafe;
+   CASE_NPY_INT64:
+   
            return ConvertBase<T, int64_t>::OneStubConvertUnsafe;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertUnsafe;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertUnsafe;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertUnsafe;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertUnsafe;
+   CASE_NPY_UINT64:
+   
           return ConvertBase<T, uint64_t>::OneStubConvertUnsafe;
    }
    return NULL;
@@ -517,15 +517,15 @@ static CONVERT_SAFE GetConversionStep2SafeFromFloat(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   CASE_NPY_INT64:
+   
            return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   CASE_NPY_UINT64:
+   
           return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
    }
    return NULL;
@@ -541,15 +541,15 @@ static CONVERT_SAFE GetConversionStep2SafeFromDouble(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   CASE_NPY_INT64:
+   
            return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   CASE_NPY_UINT64:
+   
           return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
    }
    return NULL;
@@ -566,15 +566,15 @@ static CONVERT_SAFE GetConversionStep2SafeFloat(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   CASE_NPY_INT64:
+   
            return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   CASE_NPY_UINT64:
+   
           return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
    }
    return NULL;
@@ -592,14 +592,14 @@ static CONVERT_SAFE GetConversionFunctionSafeCopy(int inputType) {
    case NPY_INT16:
    case NPY_UINT16:  return ConvertBase<int16_t, int16_t>::OneStubConvertSafeCopy;
 
-   case NPY_INT32:
-   case NPY_UINT32:
+   CASE_NPY_INT32:
+   CASE_NPY_UINT32:
    case NPY_FLOAT:  return ConvertBase<int32_t, int32_t>::OneStubConvertSafeCopy;
 
-   case NPY_INT64:
-   case NPY_LONGLONG:   
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_INT64:
+      
+   CASE_NPY_UINT64:
+   
    case NPY_DOUBLE: return ConvertBase<int64_t, int64_t>::OneStubConvertSafeCopy;
 
    case NPY_LONGDOUBLE: return ConvertBase<long double, long double>::OneStubConvertSafeCopy;
@@ -624,9 +624,9 @@ static CONVERT_SAFE GetConversionFunctionSafe(int inputType, int outputType) {
    case NPY_LONGDOUBLE: return GetConversionStep2SafeFloat<long double>(outputType);
    case NPY_BYTE:   return GetConversionStep2Safe<int8_t>(outputType);
    case NPY_INT16:  return GetConversionStep2Safe<int16_t>(outputType);
-   case NPY_INT32:  return GetConversionStep2Safe<int32_t>(outputType);
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return GetConversionStep2Safe<int32_t>(outputType);
+   CASE_NPY_INT64:
+   
            return GetConversionStep2Safe<int64_t>(outputType);
 
    // DISCUSSION -- uint8_t and the value 255 or 0xFF will not be a sentinel
@@ -634,9 +634,9 @@ static CONVERT_SAFE GetConversionFunctionSafe(int inputType, int outputType) {
    case NPY_UBYTE:  return GetConversionStep2Safe<uint8_t>(outputType);
 
    case NPY_UINT16: return GetConversionStep2Safe<uint16_t>(outputType);
-   case NPY_UINT32: return GetConversionStep2Safe<uint32_t>(outputType);
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT32: return GetConversionStep2Safe<uint32_t>(outputType);
+   CASE_NPY_UINT64:
+   
           return GetConversionStep2Safe<uint64_t>(outputType);
 
    }
@@ -659,15 +659,15 @@ static CONVERT_SAFE GetConversionFunctionUnsafe(int inputType, int outputType) {
    case NPY_LONGDOUBLE: return GetConversionStep2Unsafe<long double>(outputType);
    case NPY_BYTE:   return GetConversionStep2Unsafe<int8_t>(outputType);
    case NPY_INT16:  return GetConversionStep2Unsafe<int16_t>(outputType);
-   case NPY_INT32:  return GetConversionStep2Unsafe<int32_t>(outputType);
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return GetConversionStep2Unsafe<int32_t>(outputType);
+   CASE_NPY_INT64:
+   
            return GetConversionStep2Unsafe<int64_t>(outputType);
    case NPY_UBYTE:  return GetConversionStep2Unsafe<uint8_t>(outputType);
    case NPY_UINT16: return GetConversionStep2Unsafe<uint16_t>(outputType);
-   case NPY_UINT32: return GetConversionStep2Unsafe<uint32_t>(outputType);
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT32: return GetConversionStep2Unsafe<uint32_t>(outputType);
+   CASE_NPY_UINT64:
+   
           return GetConversionStep2Unsafe<uint64_t>(outputType);
 
    }
@@ -685,15 +685,15 @@ static MASK_CONVERT_SAFE GetConversionPutMask2Float(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::PutMaskCopyFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::PutMaskCopyFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::PutMaskCopyFloat;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopyFloat;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopyFloat;
+   CASE_NPY_INT64:
+   
            return ConvertBase<T, int64_t>::PutMaskCopyFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::PutMaskCopyFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::PutMaskCopyFloat;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopyFloat;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopyFloat;
+   CASE_NPY_UINT64:
+   
           return ConvertBase<T, uint64_t>::PutMaskCopyFloat;
    }
    return NULL;
@@ -710,15 +710,15 @@ static MASK_CONVERT_SAFE GetConversionPutMask2(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::PutMaskCopy;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::PutMaskCopy;
    case NPY_INT16:  return ConvertBase<T, int16_t>::PutMaskCopy;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopy;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopy;
+   CASE_NPY_INT64:
+   
            return ConvertBase<T, int64_t>::PutMaskCopy;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::PutMaskCopy;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::PutMaskCopy;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopy;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopy;
+   CASE_NPY_UINT64:
+   
           return ConvertBase<T, uint64_t>::PutMaskCopy;
    }
    return NULL;
@@ -737,14 +737,14 @@ static MASK_CONVERT_SAFE GetConversionPutMask(int inputType, int outputType) {
       case NPY_INT16:
       case NPY_UINT16:  return ConvertBase<int16_t, int16_t>::PutMaskFast;
 
-      case NPY_INT32:
-      case NPY_UINT32:
+      CASE_NPY_INT32:
+      CASE_NPY_UINT32:
       case NPY_FLOAT:  return ConvertBase<int32_t, int32_t>::PutMaskFast;
 
-      case NPY_INT64:
-      case NPY_LONGLONG:
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_INT64:
+      
+      CASE_NPY_UINT64:
+      
       case NPY_DOUBLE: return ConvertBase<int64_t, int64_t>::PutMaskFast;
 
       case NPY_LONGDOUBLE: return ConvertBase<long double, long double>::PutMaskFast;
@@ -760,9 +760,9 @@ static MASK_CONVERT_SAFE GetConversionPutMask(int inputType, int outputType) {
    case NPY_LONGDOUBLE: return GetConversionPutMask2Float<long double>(outputType);
    case NPY_BYTE:   return GetConversionPutMask2<int8_t>(outputType);
    case NPY_INT16:  return GetConversionPutMask2<int16_t>(outputType);
-   case NPY_INT32:  return GetConversionPutMask2<int32_t>(outputType);
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return GetConversionPutMask2<int32_t>(outputType);
+   CASE_NPY_INT64:
+   
            return GetConversionPutMask2<int64_t>(outputType);
 
       // DISCUSSION -- uint8_t and the value 255 or 0xFF will not be a sentinel
@@ -770,9 +770,9 @@ static MASK_CONVERT_SAFE GetConversionPutMask(int inputType, int outputType) {
    case NPY_UBYTE:  return GetConversionPutMask2<uint8_t>(outputType);
 
    case NPY_UINT16: return GetConversionPutMask2<uint16_t>(outputType);
-   case NPY_UINT32: return GetConversionPutMask2<uint32_t>(outputType);
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT32: return GetConversionPutMask2<uint32_t>(outputType);
+   CASE_NPY_UINT64:
+   
           return GetConversionPutMask2<uint64_t>(outputType);
 
    }
@@ -1147,9 +1147,9 @@ static COMBINE_MASK GetCombineFunction(int outputType) {
    switch (outputType) {
    case NPY_INT8:   return CombineMask<int8_t>;
    case NPY_INT16:  return CombineMask<int16_t>;
-   case NPY_INT32:  return CombineMask<int32_t>;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return CombineMask<int32_t>;
+   CASE_NPY_INT64:
+   
            return CombineMask<int64_t>;
    }
    return NULL;
@@ -1254,12 +1254,12 @@ CombineFilter(PyObject *self, PyObject *args)
       pFunction = GetCombineFunction(numpyOutType);
       break;
 
-   case NPY_INT32:
+   CASE_NPY_INT32:
       pFunction = GetCombineFunction(numpyOutType);
       break;
 
-   case NPY_INT64:
-      case NPY_LONGLONG:
+   CASE_NPY_INT64:
+      
       pFunction = GetCombineFunction(numpyOutType);
       break;
    }
@@ -1402,9 +1402,9 @@ static COMBINE_ACCUM2_MASK GetCombineAccum2Function(int outputType) {
    switch (outputType) {
    case NPY_INT8:   return CombineAccum2Mask<T,U,int8_t>;
    case NPY_INT16:  return CombineAccum2Mask<T,U,int16_t>;
-   case NPY_INT32:  return CombineAccum2Mask<T,U,int32_t>;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return CombineAccum2Mask<T,U,int32_t>;
+   CASE_NPY_INT64:
+   
            return CombineAccum2Mask<T,U,int64_t>;
    }
    return NULL;
@@ -1575,9 +1575,9 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int8_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int8_t, int16_t>(numpyOutType);  break;
-      case NPY_INT32:  pFunction = GetCombineAccum2Function<int8_t, int32_t>(numpyOutType);  break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<int8_t, int32_t>(numpyOutType);  break;
+      CASE_NPY_INT64:
+      
            pFunction = GetCombineAccum2Function<int8_t, int64_t>(numpyOutType);  break;
       }
       break;
@@ -1586,32 +1586,32 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int16_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int16_t, int16_t>(numpyOutType);  break;
-      case NPY_INT32:  pFunction = GetCombineAccum2Function<int16_t, int32_t>(numpyOutType);  break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<int16_t, int32_t>(numpyOutType);  break;
+      CASE_NPY_INT64:
+      
            pFunction = GetCombineAccum2Function<int16_t, int64_t>(numpyOutType);  break;
       }
       break;
 
-   case NPY_INT32:
+   CASE_NPY_INT32:
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int32_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int32_t, int16_t>(numpyOutType);  break;
-      case NPY_INT32:  pFunction = GetCombineAccum2Function<int32_t, int32_t>(numpyOutType);  break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<int32_t, int32_t>(numpyOutType);  break;
+      CASE_NPY_INT64:
+      
            pFunction = GetCombineAccum2Function<int32_t, int64_t>(numpyOutType);  break;
       }
       break;
 
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int64_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int64_t, int16_t>(numpyOutType);  break;
-      case NPY_INT32:  pFunction = GetCombineAccum2Function<int64_t, int32_t>(numpyOutType);  break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<int64_t, int32_t>(numpyOutType);  break;
+      CASE_NPY_INT64:
+      
            pFunction = GetCombineAccum2Function<int64_t, int64_t>(numpyOutType);  break;
       }
       break;
@@ -1930,11 +1930,11 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
    case NPY_INT16:
       pFunction = Combine1Filter<int16_t>;
       break;
-   case NPY_INT32:
+   CASE_NPY_INT32:
       pFunction = Combine1Filter<int32_t>;
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
          
       pFunction = Combine1Filter<int64_t>;
       break;
@@ -2168,10 +2168,10 @@ MakeiFirst(PyObject *self, PyObject *args) {
       case NPY_INT16:
          pFunction = iLastFilter<int16_t>;
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          pFunction = iLastFilter<int32_t>;
          break;
-      case NPY_INT64:
+      CASE_NPY_INT64:
          pFunction = iLastFilter<int64_t>;
          break;
       }
@@ -2185,10 +2185,10 @@ MakeiFirst(PyObject *self, PyObject *args) {
       case NPY_INT16:
          pFunction = iFirstFilter<int16_t>;
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          pFunction = iFirstFilter<int32_t>;
          break;
-      case NPY_INT64:
+      CASE_NPY_INT64:
          pFunction = iFirstFilter<int64_t>;
          break;
       }

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -442,13 +442,13 @@ static UNARY_FUNC GetConversionStep2(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvert;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvert;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvert;
-   case NPY_INT:  return ConvertBase<T, int32_t>::OneStubConvert;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvert;
    case NPY_INT64:
    case NPY_LONGLONG:
       return ConvertBase<T, int64_t>::OneStubConvert;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvert;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvert;
-   case NPY_UINT: return ConvertBase<T, uint32_t>::OneStubConvert;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvert;
    case NPY_UINT64:
    case NPY_ULONGLONG:
       return ConvertBase<T, uint64_t>::OneStubConvert;
@@ -466,13 +466,13 @@ static CONVERT_SAFE GetConversionStep2Safe(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafe;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafe;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafe;
-   case NPY_INT:  return ConvertBase<T, int32_t>::OneStubConvertSafe;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafe;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::OneStubConvertSafe;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafe;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafe;
-   case NPY_UINT: return ConvertBase<T, uint32_t>::OneStubConvertSafe;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafe;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::OneStubConvertSafe;
@@ -492,13 +492,13 @@ static CONVERT_SAFE GetConversionStep2Unsafe(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertUnsafe;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertUnsafe;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertUnsafe;
-   case NPY_INT:  return ConvertBase<T, int32_t>::OneStubConvertUnsafe;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertUnsafe;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::OneStubConvertUnsafe;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertUnsafe;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertUnsafe;
-   case NPY_UINT: return ConvertBase<T, uint32_t>::OneStubConvertUnsafe;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertUnsafe;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::OneStubConvertUnsafe;
@@ -517,13 +517,13 @@ static CONVERT_SAFE GetConversionStep2SafeFromFloat(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
-   case NPY_INT:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
-   case NPY_UINT: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
@@ -541,13 +541,13 @@ static CONVERT_SAFE GetConversionStep2SafeFromDouble(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
-   case NPY_INT:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
-   case NPY_UINT: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
@@ -566,13 +566,13 @@ static CONVERT_SAFE GetConversionStep2SafeFloat(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
-   case NPY_INT:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
-   case NPY_UINT: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
@@ -592,8 +592,8 @@ static CONVERT_SAFE GetConversionFunctionSafeCopy(int inputType) {
    case NPY_INT16:
    case NPY_UINT16:  return ConvertBase<int16_t, int16_t>::OneStubConvertSafeCopy;
 
-   case NPY_INT:
-   case NPY_UINT:
+   case NPY_INT32:
+   case NPY_UINT32:
    case NPY_FLOAT:  return ConvertBase<int32_t, int32_t>::OneStubConvertSafeCopy;
 
    case NPY_INT64:
@@ -624,7 +624,7 @@ static CONVERT_SAFE GetConversionFunctionSafe(int inputType, int outputType) {
    case NPY_LONGDOUBLE: return GetConversionStep2SafeFloat<long double>(outputType);
    case NPY_BYTE:   return GetConversionStep2Safe<int8_t>(outputType);
    case NPY_INT16:  return GetConversionStep2Safe<int16_t>(outputType);
-   case NPY_INT:  return GetConversionStep2Safe<int32_t>(outputType);
+   case NPY_INT32:  return GetConversionStep2Safe<int32_t>(outputType);
    case NPY_INT64:
    case NPY_LONGLONG:
            return GetConversionStep2Safe<int64_t>(outputType);
@@ -634,7 +634,7 @@ static CONVERT_SAFE GetConversionFunctionSafe(int inputType, int outputType) {
    case NPY_UBYTE:  return GetConversionStep2Safe<uint8_t>(outputType);
 
    case NPY_UINT16: return GetConversionStep2Safe<uint16_t>(outputType);
-   case NPY_UINT: return GetConversionStep2Safe<uint32_t>(outputType);
+   case NPY_UINT32: return GetConversionStep2Safe<uint32_t>(outputType);
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return GetConversionStep2Safe<uint64_t>(outputType);
@@ -659,13 +659,13 @@ static CONVERT_SAFE GetConversionFunctionUnsafe(int inputType, int outputType) {
    case NPY_LONGDOUBLE: return GetConversionStep2Unsafe<long double>(outputType);
    case NPY_BYTE:   return GetConversionStep2Unsafe<int8_t>(outputType);
    case NPY_INT16:  return GetConversionStep2Unsafe<int16_t>(outputType);
-   case NPY_INT:  return GetConversionStep2Unsafe<int32_t>(outputType);
+   case NPY_INT32:  return GetConversionStep2Unsafe<int32_t>(outputType);
    case NPY_INT64:
    case NPY_LONGLONG:
            return GetConversionStep2Unsafe<int64_t>(outputType);
    case NPY_UBYTE:  return GetConversionStep2Unsafe<uint8_t>(outputType);
    case NPY_UINT16: return GetConversionStep2Unsafe<uint16_t>(outputType);
-   case NPY_UINT: return GetConversionStep2Unsafe<uint32_t>(outputType);
+   case NPY_UINT32: return GetConversionStep2Unsafe<uint32_t>(outputType);
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return GetConversionStep2Unsafe<uint64_t>(outputType);
@@ -685,13 +685,13 @@ static MASK_CONVERT_SAFE GetConversionPutMask2Float(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::PutMaskCopyFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::PutMaskCopyFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::PutMaskCopyFloat;
-   case NPY_INT:  return ConvertBase<T, int32_t>::PutMaskCopyFloat;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopyFloat;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::PutMaskCopyFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::PutMaskCopyFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::PutMaskCopyFloat;
-   case NPY_UINT: return ConvertBase<T, uint32_t>::PutMaskCopyFloat;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopyFloat;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::PutMaskCopyFloat;
@@ -710,13 +710,13 @@ static MASK_CONVERT_SAFE GetConversionPutMask2(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::PutMaskCopy;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::PutMaskCopy;
    case NPY_INT16:  return ConvertBase<T, int16_t>::PutMaskCopy;
-   case NPY_INT:  return ConvertBase<T, int32_t>::PutMaskCopy;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopy;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::PutMaskCopy;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::PutMaskCopy;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::PutMaskCopy;
-   case NPY_UINT: return ConvertBase<T, uint32_t>::PutMaskCopy;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopy;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::PutMaskCopy;
@@ -737,8 +737,8 @@ static MASK_CONVERT_SAFE GetConversionPutMask(int inputType, int outputType) {
       case NPY_INT16:
       case NPY_UINT16:  return ConvertBase<int16_t, int16_t>::PutMaskFast;
 
-      case NPY_INT:
-      case NPY_UINT:
+      case NPY_INT32:
+      case NPY_UINT32:
       case NPY_FLOAT:  return ConvertBase<int32_t, int32_t>::PutMaskFast;
 
       case NPY_INT64:
@@ -760,7 +760,7 @@ static MASK_CONVERT_SAFE GetConversionPutMask(int inputType, int outputType) {
    case NPY_LONGDOUBLE: return GetConversionPutMask2Float<long double>(outputType);
    case NPY_BYTE:   return GetConversionPutMask2<int8_t>(outputType);
    case NPY_INT16:  return GetConversionPutMask2<int16_t>(outputType);
-   case NPY_INT:  return GetConversionPutMask2<int32_t>(outputType);
+   case NPY_INT32:  return GetConversionPutMask2<int32_t>(outputType);
    case NPY_INT64:
    case NPY_LONGLONG:
            return GetConversionPutMask2<int64_t>(outputType);
@@ -770,7 +770,7 @@ static MASK_CONVERT_SAFE GetConversionPutMask(int inputType, int outputType) {
    case NPY_UBYTE:  return GetConversionPutMask2<uint8_t>(outputType);
 
    case NPY_UINT16: return GetConversionPutMask2<uint16_t>(outputType);
-   case NPY_UINT: return GetConversionPutMask2<uint32_t>(outputType);
+   case NPY_UINT32: return GetConversionPutMask2<uint32_t>(outputType);
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return GetConversionPutMask2<uint64_t>(outputType);
@@ -1147,7 +1147,7 @@ static COMBINE_MASK GetCombineFunction(int outputType) {
    switch (outputType) {
    case NPY_INT8:   return CombineMask<int8_t>;
    case NPY_INT16:  return CombineMask<int16_t>;
-   case NPY_INT:  return CombineMask<int32_t>;
+   case NPY_INT32:  return CombineMask<int32_t>;
    case NPY_INT64:
    case NPY_LONGLONG:
            return CombineMask<int64_t>;
@@ -1254,7 +1254,7 @@ CombineFilter(PyObject *self, PyObject *args)
       pFunction = GetCombineFunction(numpyOutType);
       break;
 
-   case NPY_INT:
+   case NPY_INT32:
       pFunction = GetCombineFunction(numpyOutType);
       break;
 
@@ -1402,7 +1402,7 @@ static COMBINE_ACCUM2_MASK GetCombineAccum2Function(int outputType) {
    switch (outputType) {
    case NPY_INT8:   return CombineAccum2Mask<T,U,int8_t>;
    case NPY_INT16:  return CombineAccum2Mask<T,U,int16_t>;
-   case NPY_INT:  return CombineAccum2Mask<T,U,int32_t>;
+   case NPY_INT32:  return CombineAccum2Mask<T,U,int32_t>;
    case NPY_INT64:
    case NPY_LONGLONG:
            return CombineAccum2Mask<T,U,int64_t>;
@@ -1553,7 +1553,7 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
    int64_t typeSizeOut = 8;
 
    if (hashSize < 2000000000) {
-      numpyOutType = NPY_INT;
+      numpyOutType = NPY_INT32;
       typeSizeOut = 4;
    }
    if (hashSize < 32000) {
@@ -1575,7 +1575,7 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int8_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int8_t, int16_t>(numpyOutType);  break;
-      case NPY_INT:  pFunction = GetCombineAccum2Function<int8_t, int32_t>(numpyOutType);  break;
+      case NPY_INT32:  pFunction = GetCombineAccum2Function<int8_t, int32_t>(numpyOutType);  break;
       case NPY_INT64:
       case NPY_LONGLONG:
            pFunction = GetCombineAccum2Function<int8_t, int64_t>(numpyOutType);  break;
@@ -1586,18 +1586,18 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int16_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int16_t, int16_t>(numpyOutType);  break;
-      case NPY_INT:  pFunction = GetCombineAccum2Function<int16_t, int32_t>(numpyOutType);  break;
+      case NPY_INT32:  pFunction = GetCombineAccum2Function<int16_t, int32_t>(numpyOutType);  break;
       case NPY_INT64:
       case NPY_LONGLONG:
            pFunction = GetCombineAccum2Function<int16_t, int64_t>(numpyOutType);  break;
       }
       break;
 
-   case NPY_INT:
+   case NPY_INT32:
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int32_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int32_t, int16_t>(numpyOutType);  break;
-      case NPY_INT:  pFunction = GetCombineAccum2Function<int32_t, int32_t>(numpyOutType);  break;
+      case NPY_INT32:  pFunction = GetCombineAccum2Function<int32_t, int32_t>(numpyOutType);  break;
       case NPY_INT64:
       case NPY_LONGLONG:
            pFunction = GetCombineAccum2Function<int32_t, int64_t>(numpyOutType);  break;
@@ -1609,7 +1609,7 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int64_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int64_t, int16_t>(numpyOutType);  break;
-      case NPY_INT:  pFunction = GetCombineAccum2Function<int64_t, int32_t>(numpyOutType);  break;
+      case NPY_INT32:  pFunction = GetCombineAccum2Function<int64_t, int32_t>(numpyOutType);  break;
       case NPY_INT64:
       case NPY_LONGLONG:
            pFunction = GetCombineAccum2Function<int64_t, int64_t>(numpyOutType);  break;
@@ -1639,7 +1639,7 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
          void* pCountArray = NULL;
 
          if (bWantCount) {
-            countArray = AllocateNumpyArray(1, (npy_intp*)&hashSize, is64bithash ? NPY_INT64 : NPY_INT);
+            countArray = AllocateNumpyArray(1, (npy_intp*)&hashSize, is64bithash ? NPY_INT64 : NPY_INT32);
             CHECK_MEMORY_ERROR(countArray);
             if (countArray) {
                pCountArray = (int64_t*)PyArray_BYTES(countArray);
@@ -1930,7 +1930,7 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
    case NPY_INT16:
       pFunction = Combine1Filter<int16_t>;
       break;
-   case NPY_INT:
+   case NPY_INT32:
       pFunction = Combine1Filter<int32_t>;
       break;
    case NPY_INT64:
@@ -1944,7 +1944,7 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
       PyArrayObject* outArray = AllocateNumpyArray(ndim, dims, dtype, 0, PyArray_IS_F_CONTIGUOUS(inArr1));
       CHECK_MEMORY_ERROR(outArray);
 
-      PyArrayObject* firstArray = AllocateNumpyArray(1, (npy_intp*)&arraySize1, NPY_INT);  // TODO: bump up to int64_t for large arrays
+      PyArrayObject* firstArray = AllocateNumpyArray(1, (npy_intp*)&arraySize1, NPY_INT32);  // TODO: bump up to int64_t for large arrays
       CHECK_MEMORY_ERROR(firstArray);
 
       if (outArray && firstArray) {
@@ -1961,7 +1961,7 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
 
          if (uniqueCount < arraySize1) {
             // fixup first to hold only the uniques
-            PyArrayObject* firstArrayReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, NPY_INT);  // TODO: bump up to int64_t for large arrays
+            PyArrayObject* firstArrayReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, NPY_INT32);  // TODO: bump up to int64_t for large arrays
             CHECK_MEMORY_ERROR(firstArrayReduced);
 
             if (firstArrayReduced) {
@@ -2168,7 +2168,7 @@ MakeiFirst(PyObject *self, PyObject *args) {
       case NPY_INT16:
          pFunction = iLastFilter<int16_t>;
          break;
-      case NPY_INT:
+      case NPY_INT32:
          pFunction = iLastFilter<int32_t>;
          break;
       case NPY_INT64:
@@ -2185,7 +2185,7 @@ MakeiFirst(PyObject *self, PyObject *args) {
       case NPY_INT16:
          pFunction = iFirstFilter<int16_t>;
          break;
-      case NPY_INT:
+      case NPY_INT32:
          pFunction = iFirstFilter<int32_t>;
          break;
       case NPY_INT64:

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -442,13 +442,13 @@ static UNARY_FUNC GetConversionStep2(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvert;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvert;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvert;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvert;
+   case NPY_INT:  return ConvertBase<T, int32_t>::OneStubConvert;
    case NPY_INT64:
    case NPY_LONGLONG:
       return ConvertBase<T, int64_t>::OneStubConvert;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvert;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvert;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvert;
+   case NPY_UINT: return ConvertBase<T, uint32_t>::OneStubConvert;
    case NPY_UINT64:
    case NPY_ULONGLONG:
       return ConvertBase<T, uint64_t>::OneStubConvert;
@@ -466,13 +466,13 @@ static CONVERT_SAFE GetConversionStep2Safe(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafe;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafe;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafe;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafe;
+   case NPY_INT:  return ConvertBase<T, int32_t>::OneStubConvertSafe;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::OneStubConvertSafe;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafe;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafe;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafe;
+   case NPY_UINT: return ConvertBase<T, uint32_t>::OneStubConvertSafe;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::OneStubConvertSafe;
@@ -492,13 +492,13 @@ static CONVERT_SAFE GetConversionStep2Unsafe(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertUnsafe;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertUnsafe;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertUnsafe;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertUnsafe;
+   case NPY_INT:  return ConvertBase<T, int32_t>::OneStubConvertUnsafe;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::OneStubConvertUnsafe;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertUnsafe;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertUnsafe;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertUnsafe;
+   case NPY_UINT: return ConvertBase<T, uint32_t>::OneStubConvertUnsafe;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::OneStubConvertUnsafe;
@@ -517,13 +517,13 @@ static CONVERT_SAFE GetConversionStep2SafeFromFloat(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   case NPY_INT:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   case NPY_UINT: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
@@ -541,13 +541,13 @@ static CONVERT_SAFE GetConversionStep2SafeFromDouble(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   case NPY_INT:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   case NPY_UINT: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
@@ -566,13 +566,13 @@ static CONVERT_SAFE GetConversionStep2SafeFloat(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   case NPY_INT:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   case NPY_UINT: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
@@ -592,8 +592,8 @@ static CONVERT_SAFE GetConversionFunctionSafeCopy(int inputType) {
    case NPY_INT16:
    case NPY_UINT16:  return ConvertBase<int16_t, int16_t>::OneStubConvertSafeCopy;
 
-   case NPY_INT32:
-   case NPY_UINT32:
+   case NPY_INT:
+   case NPY_UINT:
    case NPY_FLOAT:  return ConvertBase<int32_t, int32_t>::OneStubConvertSafeCopy;
 
    case NPY_INT64:
@@ -624,7 +624,7 @@ static CONVERT_SAFE GetConversionFunctionSafe(int inputType, int outputType) {
    case NPY_LONGDOUBLE: return GetConversionStep2SafeFloat<long double>(outputType);
    case NPY_BYTE:   return GetConversionStep2Safe<int8_t>(outputType);
    case NPY_INT16:  return GetConversionStep2Safe<int16_t>(outputType);
-   case NPY_INT32:  return GetConversionStep2Safe<int32_t>(outputType);
+   case NPY_INT:  return GetConversionStep2Safe<int32_t>(outputType);
    case NPY_INT64:
    case NPY_LONGLONG:
            return GetConversionStep2Safe<int64_t>(outputType);
@@ -634,7 +634,7 @@ static CONVERT_SAFE GetConversionFunctionSafe(int inputType, int outputType) {
    case NPY_UBYTE:  return GetConversionStep2Safe<uint8_t>(outputType);
 
    case NPY_UINT16: return GetConversionStep2Safe<uint16_t>(outputType);
-   case NPY_UINT32: return GetConversionStep2Safe<uint32_t>(outputType);
+   case NPY_UINT: return GetConversionStep2Safe<uint32_t>(outputType);
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return GetConversionStep2Safe<uint64_t>(outputType);
@@ -659,13 +659,13 @@ static CONVERT_SAFE GetConversionFunctionUnsafe(int inputType, int outputType) {
    case NPY_LONGDOUBLE: return GetConversionStep2Unsafe<long double>(outputType);
    case NPY_BYTE:   return GetConversionStep2Unsafe<int8_t>(outputType);
    case NPY_INT16:  return GetConversionStep2Unsafe<int16_t>(outputType);
-   case NPY_INT32:  return GetConversionStep2Unsafe<int32_t>(outputType);
+   case NPY_INT:  return GetConversionStep2Unsafe<int32_t>(outputType);
    case NPY_INT64:
    case NPY_LONGLONG:
            return GetConversionStep2Unsafe<int64_t>(outputType);
    case NPY_UBYTE:  return GetConversionStep2Unsafe<uint8_t>(outputType);
    case NPY_UINT16: return GetConversionStep2Unsafe<uint16_t>(outputType);
-   case NPY_UINT32: return GetConversionStep2Unsafe<uint32_t>(outputType);
+   case NPY_UINT: return GetConversionStep2Unsafe<uint32_t>(outputType);
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return GetConversionStep2Unsafe<uint64_t>(outputType);
@@ -685,13 +685,13 @@ static MASK_CONVERT_SAFE GetConversionPutMask2Float(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::PutMaskCopyFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::PutMaskCopyFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::PutMaskCopyFloat;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopyFloat;
+   case NPY_INT:  return ConvertBase<T, int32_t>::PutMaskCopyFloat;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::PutMaskCopyFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::PutMaskCopyFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::PutMaskCopyFloat;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopyFloat;
+   case NPY_UINT: return ConvertBase<T, uint32_t>::PutMaskCopyFloat;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::PutMaskCopyFloat;
@@ -710,13 +710,13 @@ static MASK_CONVERT_SAFE GetConversionPutMask2(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::PutMaskCopy;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::PutMaskCopy;
    case NPY_INT16:  return ConvertBase<T, int16_t>::PutMaskCopy;
-   case NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopy;
+   case NPY_INT:  return ConvertBase<T, int32_t>::PutMaskCopy;
    case NPY_INT64:
    case NPY_LONGLONG:
            return ConvertBase<T, int64_t>::PutMaskCopy;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::PutMaskCopy;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::PutMaskCopy;
-   case NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopy;
+   case NPY_UINT: return ConvertBase<T, uint32_t>::PutMaskCopy;
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return ConvertBase<T, uint64_t>::PutMaskCopy;
@@ -737,8 +737,8 @@ static MASK_CONVERT_SAFE GetConversionPutMask(int inputType, int outputType) {
       case NPY_INT16:
       case NPY_UINT16:  return ConvertBase<int16_t, int16_t>::PutMaskFast;
 
-      case NPY_INT32:
-      case NPY_UINT32:
+      case NPY_INT:
+      case NPY_UINT:
       case NPY_FLOAT:  return ConvertBase<int32_t, int32_t>::PutMaskFast;
 
       case NPY_INT64:
@@ -760,7 +760,7 @@ static MASK_CONVERT_SAFE GetConversionPutMask(int inputType, int outputType) {
    case NPY_LONGDOUBLE: return GetConversionPutMask2Float<long double>(outputType);
    case NPY_BYTE:   return GetConversionPutMask2<int8_t>(outputType);
    case NPY_INT16:  return GetConversionPutMask2<int16_t>(outputType);
-   case NPY_INT32:  return GetConversionPutMask2<int32_t>(outputType);
+   case NPY_INT:  return GetConversionPutMask2<int32_t>(outputType);
    case NPY_INT64:
    case NPY_LONGLONG:
            return GetConversionPutMask2<int64_t>(outputType);
@@ -770,7 +770,7 @@ static MASK_CONVERT_SAFE GetConversionPutMask(int inputType, int outputType) {
    case NPY_UBYTE:  return GetConversionPutMask2<uint8_t>(outputType);
 
    case NPY_UINT16: return GetConversionPutMask2<uint16_t>(outputType);
-   case NPY_UINT32: return GetConversionPutMask2<uint32_t>(outputType);
+   case NPY_UINT: return GetConversionPutMask2<uint32_t>(outputType);
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return GetConversionPutMask2<uint64_t>(outputType);
@@ -1147,7 +1147,7 @@ static COMBINE_MASK GetCombineFunction(int outputType) {
    switch (outputType) {
    case NPY_INT8:   return CombineMask<int8_t>;
    case NPY_INT16:  return CombineMask<int16_t>;
-   case NPY_INT32:  return CombineMask<int32_t>;
+   case NPY_INT:  return CombineMask<int32_t>;
    case NPY_INT64:
    case NPY_LONGLONG:
            return CombineMask<int64_t>;
@@ -1254,7 +1254,7 @@ CombineFilter(PyObject *self, PyObject *args)
       pFunction = GetCombineFunction(numpyOutType);
       break;
 
-   case NPY_INT32:
+   case NPY_INT:
       pFunction = GetCombineFunction(numpyOutType);
       break;
 
@@ -1402,7 +1402,7 @@ static COMBINE_ACCUM2_MASK GetCombineAccum2Function(int outputType) {
    switch (outputType) {
    case NPY_INT8:   return CombineAccum2Mask<T,U,int8_t>;
    case NPY_INT16:  return CombineAccum2Mask<T,U,int16_t>;
-   case NPY_INT32:  return CombineAccum2Mask<T,U,int32_t>;
+   case NPY_INT:  return CombineAccum2Mask<T,U,int32_t>;
    case NPY_INT64:
    case NPY_LONGLONG:
            return CombineAccum2Mask<T,U,int64_t>;
@@ -1553,7 +1553,7 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
    int64_t typeSizeOut = 8;
 
    if (hashSize < 2000000000) {
-      numpyOutType = NPY_INT32;
+      numpyOutType = NPY_INT;
       typeSizeOut = 4;
    }
    if (hashSize < 32000) {
@@ -1575,7 +1575,7 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int8_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int8_t, int16_t>(numpyOutType);  break;
-      case NPY_INT32:  pFunction = GetCombineAccum2Function<int8_t, int32_t>(numpyOutType);  break;
+      case NPY_INT:  pFunction = GetCombineAccum2Function<int8_t, int32_t>(numpyOutType);  break;
       case NPY_INT64:
       case NPY_LONGLONG:
            pFunction = GetCombineAccum2Function<int8_t, int64_t>(numpyOutType);  break;
@@ -1586,18 +1586,18 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int16_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int16_t, int16_t>(numpyOutType);  break;
-      case NPY_INT32:  pFunction = GetCombineAccum2Function<int16_t, int32_t>(numpyOutType);  break;
+      case NPY_INT:  pFunction = GetCombineAccum2Function<int16_t, int32_t>(numpyOutType);  break;
       case NPY_INT64:
       case NPY_LONGLONG:
            pFunction = GetCombineAccum2Function<int16_t, int64_t>(numpyOutType);  break;
       }
       break;
 
-   case NPY_INT32:
+   case NPY_INT:
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int32_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int32_t, int16_t>(numpyOutType);  break;
-      case NPY_INT32:  pFunction = GetCombineAccum2Function<int32_t, int32_t>(numpyOutType);  break;
+      case NPY_INT:  pFunction = GetCombineAccum2Function<int32_t, int32_t>(numpyOutType);  break;
       case NPY_INT64:
       case NPY_LONGLONG:
            pFunction = GetCombineAccum2Function<int32_t, int64_t>(numpyOutType);  break;
@@ -1609,7 +1609,7 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int64_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int64_t, int16_t>(numpyOutType);  break;
-      case NPY_INT32:  pFunction = GetCombineAccum2Function<int64_t, int32_t>(numpyOutType);  break;
+      case NPY_INT:  pFunction = GetCombineAccum2Function<int64_t, int32_t>(numpyOutType);  break;
       case NPY_INT64:
       case NPY_LONGLONG:
            pFunction = GetCombineAccum2Function<int64_t, int64_t>(numpyOutType);  break;
@@ -1639,7 +1639,7 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
          void* pCountArray = NULL;
 
          if (bWantCount) {
-            countArray = AllocateNumpyArray(1, (npy_intp*)&hashSize, is64bithash ? NPY_INT64 : NPY_INT32);
+            countArray = AllocateNumpyArray(1, (npy_intp*)&hashSize, is64bithash ? NPY_INT64 : NPY_INT);
             CHECK_MEMORY_ERROR(countArray);
             if (countArray) {
                pCountArray = (int64_t*)PyArray_BYTES(countArray);
@@ -1930,7 +1930,7 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
    case NPY_INT16:
       pFunction = Combine1Filter<int16_t>;
       break;
-   case NPY_INT32:
+   case NPY_INT:
       pFunction = Combine1Filter<int32_t>;
       break;
    case NPY_INT64:
@@ -1944,7 +1944,7 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
       PyArrayObject* outArray = AllocateNumpyArray(ndim, dims, dtype, 0, PyArray_IS_F_CONTIGUOUS(inArr1));
       CHECK_MEMORY_ERROR(outArray);
 
-      PyArrayObject* firstArray = AllocateNumpyArray(1, (npy_intp*)&arraySize1, NPY_INT32);  // TODO: bump up to int64_t for large arrays
+      PyArrayObject* firstArray = AllocateNumpyArray(1, (npy_intp*)&arraySize1, NPY_INT);  // TODO: bump up to int64_t for large arrays
       CHECK_MEMORY_ERROR(firstArray);
 
       if (outArray && firstArray) {
@@ -1961,7 +1961,7 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
 
          if (uniqueCount < arraySize1) {
             // fixup first to hold only the uniques
-            PyArrayObject* firstArrayReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, NPY_INT32);  // TODO: bump up to int64_t for large arrays
+            PyArrayObject* firstArrayReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, NPY_INT);  // TODO: bump up to int64_t for large arrays
             CHECK_MEMORY_ERROR(firstArrayReduced);
 
             if (firstArrayReduced) {
@@ -2168,7 +2168,7 @@ MakeiFirst(PyObject *self, PyObject *args) {
       case NPY_INT16:
          pFunction = iLastFilter<int16_t>;
          break;
-      case NPY_INT32:
+      case NPY_INT:
          pFunction = iLastFilter<int32_t>;
          break;
       case NPY_INT64:
@@ -2185,7 +2185,7 @@ MakeiFirst(PyObject *self, PyObject *args) {
       case NPY_INT16:
          pFunction = iFirstFilter<int16_t>;
          break;
-      case NPY_INT32:
+      case NPY_INT:
          pFunction = iFirstFilter<int32_t>;
          break;
       case NPY_INT64:

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -442,12 +442,16 @@ static UNARY_FUNC GetConversionStep2(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvert;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvert;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvert;
-   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvert;
-   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::OneStubConvert;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvert;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+      return ConvertBase<T, int64_t>::OneStubConvert;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvert;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvert;
-   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvert;
-   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::OneStubConvert;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvert;
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+      return ConvertBase<T, uint64_t>::OneStubConvert;
    }
    return NULL;
 
@@ -462,12 +466,16 @@ static CONVERT_SAFE GetConversionStep2Safe(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafe;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafe;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafe;
-   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafe;
-   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::OneStubConvertSafe;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafe;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+           return ConvertBase<T, int64_t>::OneStubConvertSafe;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafe;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafe;
-   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafe;
-   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::OneStubConvertSafe;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafe;
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+          return ConvertBase<T, uint64_t>::OneStubConvertSafe;
    }
    return NULL;
 
@@ -484,12 +492,16 @@ static CONVERT_SAFE GetConversionStep2Unsafe(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertUnsafe;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertUnsafe;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertUnsafe;
-   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertUnsafe;
-   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::OneStubConvertUnsafe;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertUnsafe;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+           return ConvertBase<T, int64_t>::OneStubConvertUnsafe;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertUnsafe;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertUnsafe;
-   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertUnsafe;
-   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::OneStubConvertUnsafe;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertUnsafe;
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+          return ConvertBase<T, uint64_t>::OneStubConvertUnsafe;
    }
    return NULL;
 
@@ -505,12 +517,16 @@ static CONVERT_SAFE GetConversionStep2SafeFromFloat(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
-   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
-   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+           return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
-   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
-   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+          return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
    }
    return NULL;
 
@@ -525,12 +541,16 @@ static CONVERT_SAFE GetConversionStep2SafeFromDouble(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
-   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
-   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+           return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
-   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
-   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+          return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
    }
    return NULL;
 
@@ -546,12 +566,16 @@ static CONVERT_SAFE GetConversionStep2SafeFloat(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::OneStubConvertSafeFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::OneStubConvertSafeFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::OneStubConvertSafeFloat;
-   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
-   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::OneStubConvertSafeFloat;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+           return ConvertBase<T, int64_t>::OneStubConvertSafeFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::OneStubConvertSafeFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::OneStubConvertSafeFloat;
-   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
-   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::OneStubConvertSafeFloat;
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+          return ConvertBase<T, uint64_t>::OneStubConvertSafeFloat;
    }
    return NULL;
 
@@ -568,12 +592,14 @@ static CONVERT_SAFE GetConversionFunctionSafeCopy(int inputType) {
    case NPY_INT16:
    case NPY_UINT16:  return ConvertBase<int16_t, int16_t>::OneStubConvertSafeCopy;
 
-   CASE_NPY_INT32:
-   CASE_NPY_UINT32:
+   case NPY_INT32:
+   case NPY_UINT32:
    case NPY_FLOAT:  return ConvertBase<int32_t, int32_t>::OneStubConvertSafeCopy;
 
-   CASE_NPY_INT64:
-   CASE_NPY_UINT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:   
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
    case NPY_DOUBLE: return ConvertBase<int64_t, int64_t>::OneStubConvertSafeCopy;
 
    case NPY_LONGDOUBLE: return ConvertBase<long double, long double>::OneStubConvertSafeCopy;
@@ -598,16 +624,20 @@ static CONVERT_SAFE GetConversionFunctionSafe(int inputType, int outputType) {
    case NPY_LONGDOUBLE: return GetConversionStep2SafeFloat<long double>(outputType);
    case NPY_BYTE:   return GetConversionStep2Safe<int8_t>(outputType);
    case NPY_INT16:  return GetConversionStep2Safe<int16_t>(outputType);
-   CASE_NPY_INT32:  return GetConversionStep2Safe<int32_t>(outputType);
-   CASE_NPY_INT64:  return GetConversionStep2Safe<int64_t>(outputType);
+   case NPY_INT32:  return GetConversionStep2Safe<int32_t>(outputType);
+   case NPY_INT64:
+   case NPY_LONGLONG:
+           return GetConversionStep2Safe<int64_t>(outputType);
 
    // DISCUSSION -- uint8_t and the value 255 or 0xFF will not be a sentinel
    //case NPY_UBYTE:  return GetConversionStep2Unsafe<uint8_t>(outputType);
    case NPY_UBYTE:  return GetConversionStep2Safe<uint8_t>(outputType);
 
    case NPY_UINT16: return GetConversionStep2Safe<uint16_t>(outputType);
-   CASE_NPY_UINT32: return GetConversionStep2Safe<uint32_t>(outputType);
-   CASE_NPY_UINT64: return GetConversionStep2Safe<uint64_t>(outputType);
+   case NPY_UINT32: return GetConversionStep2Safe<uint32_t>(outputType);
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+          return GetConversionStep2Safe<uint64_t>(outputType);
 
    }
    return NULL;
@@ -629,12 +659,16 @@ static CONVERT_SAFE GetConversionFunctionUnsafe(int inputType, int outputType) {
    case NPY_LONGDOUBLE: return GetConversionStep2Unsafe<long double>(outputType);
    case NPY_BYTE:   return GetConversionStep2Unsafe<int8_t>(outputType);
    case NPY_INT16:  return GetConversionStep2Unsafe<int16_t>(outputType);
-   CASE_NPY_INT32:  return GetConversionStep2Unsafe<int32_t>(outputType);
-   CASE_NPY_INT64:  return GetConversionStep2Unsafe<int64_t>(outputType);
+   case NPY_INT32:  return GetConversionStep2Unsafe<int32_t>(outputType);
+   case NPY_INT64:
+   case NPY_LONGLONG:
+           return GetConversionStep2Unsafe<int64_t>(outputType);
    case NPY_UBYTE:  return GetConversionStep2Unsafe<uint8_t>(outputType);
    case NPY_UINT16: return GetConversionStep2Unsafe<uint16_t>(outputType);
-   CASE_NPY_UINT32: return GetConversionStep2Unsafe<uint32_t>(outputType);
-   CASE_NPY_UINT64: return GetConversionStep2Unsafe<uint64_t>(outputType);
+   case NPY_UINT32: return GetConversionStep2Unsafe<uint32_t>(outputType);
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+          return GetConversionStep2Unsafe<uint64_t>(outputType);
 
    }
    return NULL;
@@ -651,12 +685,16 @@ static MASK_CONVERT_SAFE GetConversionPutMask2Float(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::PutMaskCopyFloat;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::PutMaskCopyFloat;
    case NPY_INT16:  return ConvertBase<T, int16_t>::PutMaskCopyFloat;
-   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopyFloat;
-   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::PutMaskCopyFloat;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopyFloat;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+           return ConvertBase<T, int64_t>::PutMaskCopyFloat;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::PutMaskCopyFloat;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::PutMaskCopyFloat;
-   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopyFloat;
-   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::PutMaskCopyFloat;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopyFloat;
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+          return ConvertBase<T, uint64_t>::PutMaskCopyFloat;
    }
    return NULL;
 
@@ -672,12 +710,16 @@ static MASK_CONVERT_SAFE GetConversionPutMask2(int outputType) {
    case NPY_LONGDOUBLE: return ConvertBase<T, long double>::PutMaskCopy;
    case NPY_BYTE:   return ConvertBase<T, int8_t>::PutMaskCopy;
    case NPY_INT16:  return ConvertBase<T, int16_t>::PutMaskCopy;
-   CASE_NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopy;
-   CASE_NPY_INT64:  return ConvertBase<T, int64_t>::PutMaskCopy;
+   case NPY_INT32:  return ConvertBase<T, int32_t>::PutMaskCopy;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+           return ConvertBase<T, int64_t>::PutMaskCopy;
    case NPY_UBYTE:  return ConvertBase<T, uint8_t>::PutMaskCopy;
    case NPY_UINT16: return ConvertBase<T, uint16_t>::PutMaskCopy;
-   CASE_NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopy;
-   CASE_NPY_UINT64: return ConvertBase<T, uint64_t>::PutMaskCopy;
+   case NPY_UINT32: return ConvertBase<T, uint32_t>::PutMaskCopy;
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+          return ConvertBase<T, uint64_t>::PutMaskCopy;
    }
    return NULL;
 
@@ -695,12 +737,14 @@ static MASK_CONVERT_SAFE GetConversionPutMask(int inputType, int outputType) {
       case NPY_INT16:
       case NPY_UINT16:  return ConvertBase<int16_t, int16_t>::PutMaskFast;
 
-      CASE_NPY_INT32:
-      CASE_NPY_UINT32:
+      case NPY_INT32:
+      case NPY_UINT32:
       case NPY_FLOAT:  return ConvertBase<int32_t, int32_t>::PutMaskFast;
 
-      CASE_NPY_INT64:
-      CASE_NPY_UINT64:
+      case NPY_INT64:
+      case NPY_LONGLONG:
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
       case NPY_DOUBLE: return ConvertBase<int64_t, int64_t>::PutMaskFast;
 
       case NPY_LONGDOUBLE: return ConvertBase<long double, long double>::PutMaskFast;
@@ -716,16 +760,20 @@ static MASK_CONVERT_SAFE GetConversionPutMask(int inputType, int outputType) {
    case NPY_LONGDOUBLE: return GetConversionPutMask2Float<long double>(outputType);
    case NPY_BYTE:   return GetConversionPutMask2<int8_t>(outputType);
    case NPY_INT16:  return GetConversionPutMask2<int16_t>(outputType);
-   CASE_NPY_INT32:  return GetConversionPutMask2<int32_t>(outputType);
-   CASE_NPY_INT64:  return GetConversionPutMask2<int64_t>(outputType);
+   case NPY_INT32:  return GetConversionPutMask2<int32_t>(outputType);
+   case NPY_INT64:
+   case NPY_LONGLONG:
+           return GetConversionPutMask2<int64_t>(outputType);
 
       // DISCUSSION -- uint8_t and the value 255 or 0xFF will not be a sentinel
       //case NPY_UBYTE:  return GetConversionStep2Unsafe<uint8_t>(outputType);
    case NPY_UBYTE:  return GetConversionPutMask2<uint8_t>(outputType);
 
    case NPY_UINT16: return GetConversionPutMask2<uint16_t>(outputType);
-   CASE_NPY_UINT32: return GetConversionPutMask2<uint32_t>(outputType);
-   CASE_NPY_UINT64: return GetConversionPutMask2<uint64_t>(outputType);
+   case NPY_UINT32: return GetConversionPutMask2<uint32_t>(outputType);
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+          return GetConversionPutMask2<uint64_t>(outputType);
 
    }
    return NULL;
@@ -748,8 +796,8 @@ struct CONVERT_CALLBACK {
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL ConvertThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
-   BOOL didSomeWork = FALSE;
+static bool ConvertThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
+   bool didSomeWork = false;
    CONVERT_CALLBACK* Callback = (CONVERT_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    char* pDataIn = (char *)Callback->pDataIn;
@@ -766,7 +814,7 @@ static BOOL ConvertThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int 
       Callback->anyConvertCallback(pDataIn + inputAdj, pDataOut + outputAdj, lenX, Callback->pBadInput1, Callback->pBadOutput1, Callback->typeSizeIn, Callback->typeSizeOut);
 
       // Indicate we completed a block
-      didSomeWork = TRUE;
+      didSomeWork = true;
 
       // tell others we completed this work block
       pstWorkerItem->CompleteWorkBlock();
@@ -783,7 +831,7 @@ static BOOL ConvertThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int 
 void* GetInvalid(int dtype) {
    void* pBadInput = GetDefaultForType(dtype);
    if (dtype == NPY_BOOL) {
-      // We do not want FALSE to become a sentinel
+      // We do not want false to become a sentinel
       pBadInput = GetDefaultForType(NPY_INT8);
    }
    return pBadInput;
@@ -842,7 +890,7 @@ ConvertSafeInternal(
    void* pDataOut = PyArray_BYTES(outArray);
    void* pBadInput1 = GetInvalid(numpyInType);
 
-   // if output is boolean, bad means FALSE
+   // if output is boolean, bad means false
    void* pBadOutput1 = GetDefaultForType(numpyOutType);
 
    // Check the strides of both the input and output to make sure we can handle
@@ -1023,7 +1071,7 @@ ConvertUnsafeInternal(
 
    void* pBadInput1 = GetInvalid(numpyInType);
 
-   // if output is boolean, bad means FALSE
+   // if output is boolean, bad means false
    void* pBadOutput1 = GetDefaultForType(numpyOutType);
 
    stMATH_WORKER_ITEM* pWorkItem = g_cMathWorker->GetWorkItem(len);
@@ -1099,8 +1147,10 @@ static COMBINE_MASK GetCombineFunction(int outputType) {
    switch (outputType) {
    case NPY_INT8:   return CombineMask<int8_t>;
    case NPY_INT16:  return CombineMask<int16_t>;
-   CASE_NPY_INT32:  return CombineMask<int32_t>;
-   CASE_NPY_INT64:  return CombineMask<int64_t>;
+   case NPY_INT32:  return CombineMask<int32_t>;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+           return CombineMask<int64_t>;
    }
    return NULL;
 
@@ -1122,8 +1172,8 @@ struct COMBINE_CALLBACK {
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL CombineThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
-   BOOL didSomeWork = FALSE;
+static bool CombineThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
+   bool didSomeWork = false;
    COMBINE_CALLBACK* Callback = (COMBINE_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    char* pDataIn = (char *)Callback->pDataIn;
@@ -1140,7 +1190,7 @@ static BOOL CombineThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int 
       Callback->anyCombineCallback(pDataIn + inputAdj, pDataOut + inputAdj, lenX, Callback->pFilter + filterAdj);
 
       // Indicate we completed a block
-      didSomeWork = TRUE;
+      didSomeWork = true;
 
       // tell others we completed this work block
       pstWorkerItem->CompleteWorkBlock();
@@ -1204,11 +1254,12 @@ CombineFilter(PyObject *self, PyObject *args)
       pFunction = GetCombineFunction(numpyOutType);
       break;
 
-   CASE_NPY_INT32:
+   case NPY_INT32:
       pFunction = GetCombineFunction(numpyOutType);
       break;
 
-   CASE_NPY_INT64:
+   case NPY_INT64:
+      case NPY_LONGLONG:
       pFunction = GetCombineFunction(numpyOutType);
       break;
    }
@@ -1351,8 +1402,10 @@ static COMBINE_ACCUM2_MASK GetCombineAccum2Function(int outputType) {
    switch (outputType) {
    case NPY_INT8:   return CombineAccum2Mask<T,U,int8_t>;
    case NPY_INT16:  return CombineAccum2Mask<T,U,int16_t>;
-   CASE_NPY_INT32:  return CombineAccum2Mask<T,U,int32_t>;
-   CASE_NPY_INT64:  return CombineAccum2Mask<T,U,int64_t>;
+   case NPY_INT32:  return CombineAccum2Mask<T,U,int32_t>;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+           return CombineAccum2Mask<T,U,int64_t>;
    }
    return NULL;
 
@@ -1380,8 +1433,8 @@ struct COMBINE_ACCUM2_CALLBACK {
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL CombineThreadAccum2Callback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
-   BOOL didSomeWork = FALSE;
+static bool CombineThreadAccum2Callback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
+   bool didSomeWork = false;
    COMBINE_ACCUM2_CALLBACK* Callback = (COMBINE_ACCUM2_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    char* pDataIn1 = (char *)Callback->pDataIn1;
@@ -1414,7 +1467,7 @@ static BOOL CombineThreadAccum2Callback(struct stMATH_WORKER_ITEM* pstWorkerItem
          Callback->pFilter ? (Callback->pFilter + filterAdj) : NULL);
 
       // Indicate we completed a block
-      didSomeWork = TRUE;
+      didSomeWork = true;
 
       // tell others we completed this work block
       pstWorkerItem->CompleteWorkBlock();
@@ -1522,8 +1575,10 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int8_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int8_t, int16_t>(numpyOutType);  break;
-      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<int8_t, int32_t>(numpyOutType);  break;
-      CASE_NPY_INT64:  pFunction = GetCombineAccum2Function<int8_t, int64_t>(numpyOutType);  break;
+      case NPY_INT32:  pFunction = GetCombineAccum2Function<int8_t, int32_t>(numpyOutType);  break;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           pFunction = GetCombineAccum2Function<int8_t, int64_t>(numpyOutType);  break;
       }
       break;
 
@@ -1531,31 +1586,38 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int16_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int16_t, int16_t>(numpyOutType);  break;
-      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<int16_t, int32_t>(numpyOutType);  break;
-      CASE_NPY_INT64:  pFunction = GetCombineAccum2Function<int16_t, int64_t>(numpyOutType);  break;
+      case NPY_INT32:  pFunction = GetCombineAccum2Function<int16_t, int32_t>(numpyOutType);  break;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           pFunction = GetCombineAccum2Function<int16_t, int64_t>(numpyOutType);  break;
       }
       break;
 
-   CASE_NPY_INT32:
+   case NPY_INT32:
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int32_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int32_t, int16_t>(numpyOutType);  break;
-      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<int32_t, int32_t>(numpyOutType);  break;
-      CASE_NPY_INT64:  pFunction = GetCombineAccum2Function<int32_t, int64_t>(numpyOutType);  break;
+      case NPY_INT32:  pFunction = GetCombineAccum2Function<int32_t, int32_t>(numpyOutType);  break;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           pFunction = GetCombineAccum2Function<int32_t, int64_t>(numpyOutType);  break;
       }
       break;
 
-   CASE_NPY_INT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       switch (type2) {
       case NPY_INT8:   pFunction = GetCombineAccum2Function<int64_t, int8_t>(numpyOutType);  break;
       case NPY_INT16:  pFunction = GetCombineAccum2Function<int64_t, int16_t>(numpyOutType);  break;
-      CASE_NPY_INT32:  pFunction = GetCombineAccum2Function<int64_t, int32_t>(numpyOutType);  break;
-      CASE_NPY_INT64:  pFunction = GetCombineAccum2Function<int64_t, int64_t>(numpyOutType);  break;
+      case NPY_INT32:  pFunction = GetCombineAccum2Function<int64_t, int32_t>(numpyOutType);  break;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           pFunction = GetCombineAccum2Function<int64_t, int64_t>(numpyOutType);  break;
       }
       break;
    }
 
-   BOOL bWantCount = FALSE;
+   bool bWantCount = false;
 
    if (pFunction != NULL) {
       PyArrayObject* outArray = AllocateNumpyArray(ndim, dims, numpyOutType, 0, PyArray_IS_F_CONTIGUOUS(inArr1));
@@ -1563,14 +1625,14 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
 
       if (outArray) {
          void* pDataOut = PyArray_BYTES(outArray);
-         BOOL is64bithash = FALSE;
+         bool is64bithash = false;
          int64_t sizeofhash = 4;
 
          // 32 bit count limitation here
          PyArrayObject* countArray = NULL;
 
          if (hashSize > 2147480000) {
-            is64bithash = TRUE;
+            is64bithash = true;
             sizeofhash = 8;
          }
 
@@ -1595,9 +1657,9 @@ CombineAccum2Filter(PyObject *self, PyObject *args)
          else {
 
             // TODO: steal from hash
-            INT numCores = g_cMathWorker->WorkerThreadCount + 1;
+            int32_t numCores = g_cMathWorker->WorkerThreadCount + 1;
             int64_t sizeToAlloc = numCores * hashSize * sizeofhash;
-            PVOID pWorkSpace = 0;
+            void* pWorkSpace = 0;
 
             if (bWantCount) {
                pWorkSpace = WORKSPACE_ALLOC(sizeToAlloc);
@@ -1868,10 +1930,12 @@ CombineAccum1Filter(PyObject *self, PyObject *args)
    case NPY_INT16:
       pFunction = Combine1Filter<int16_t>;
       break;
-   CASE_NPY_INT32:
+   case NPY_INT32:
       pFunction = Combine1Filter<int32_t>;
       break;
-   CASE_NPY_INT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:
+         
       pFunction = Combine1Filter<int64_t>;
       break;
    }
@@ -2373,7 +2437,7 @@ PyObject *GetUpcastNum(PyObject* self, PyObject *args)
 
    // Allow jagged rows
    // Do not copy
-   ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, FALSE, FALSE);
+   ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, false, false);
 
    if (aInfo) {
       int dtype = GetUpcastDtype(aInfo, tupleSize);
@@ -2412,7 +2476,7 @@ PyObject *HStack(PyObject* self, PyObject *args)
    int64_t tupleSize = 0;
 
    // Allow jagged rows
-   ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, FALSE);
+   ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, false);
 
    if (aInfo) {
 
@@ -2425,12 +2489,12 @@ PyObject *HStack(PyObject* self, PyObject *args)
 
          if (dtype <  0 || dtype > NPY_LONGDOUBLE) {
 
-            BOOL isSameDtype = TRUE;
+            bool isSameDtype = true;
 
             // Check for all strings or all unicode which we know how to stack
             for (int t = 0; t < tupleSize; t++) {
                if (dtype != aInfo[t].NumpyDType) {
-                  isSameDtype = FALSE;
+                  isSameDtype = false;
                   break;
                }
                // track max itemsize since for a string we must match it
@@ -2511,7 +2575,7 @@ PyObject *HStack(PyObject* self, PyObject *args)
 
                LOGGING("MT string hstack work on %lld\n", tupleSize);
 
-               auto lambdaHSCallback = [](void* callbackArgT, int core, int64_t workIndex) -> BOOL {
+               auto lambdaHSCallback = [](void* callbackArgT, int core, int64_t workIndex) -> bool {
                   stSHSTACK* callbackArg = (stSHSTACK*)callbackArgT;
                   int64_t t = workIndex;
                   callbackArg->pHStack[t].ConvertSafeString(
@@ -2521,7 +2585,7 @@ PyObject *HStack(PyObject* self, PyObject *args)
                      callbackArg->aInfo[t].ItemSize,
                      callbackArg->ItemSizeOutput);
 
-                  return TRUE;
+                  return true;
                };
 
                g_cMathWorker->DoMultiThreadedWork((int)tupleSize, lambdaHSCallback, &myhstack);
@@ -2563,7 +2627,7 @@ PyObject *HStack(PyObject* self, PyObject *args)
 
          if (outputArray) {
 
-            // if output is boolean, bad means FALSE
+            // if output is boolean, bad means false
             void* pBadOutput1 = GetDefaultForType(dtype);
 
             int64_t strideOut = PyArray_STRIDE(outputArray, 0);
@@ -2601,7 +2665,7 @@ PyObject *HStack(PyObject* self, PyObject *args)
 
                LOGGING("MT hstack work on %lld\n", tupleSize);
 
-               auto lambdaHSCallback = [](void* callbackArgT, int core, int64_t workIndex) -> BOOL {
+               auto lambdaHSCallback = [](void* callbackArgT, int core, int64_t workIndex) -> bool {
                   stSHSTACK* callbackArg = (stSHSTACK*)callbackArgT;
                   int64_t t = workIndex;
                   callbackArg->pHStack[t].ConvertSafe(
@@ -2613,7 +2677,7 @@ PyObject *HStack(PyObject* self, PyObject *args)
                      PyArray_STRIDE(callbackArg->aInfo[t].pObject, 0),
                      callbackArg->StrideOut);
 
-                  return TRUE;
+                  return true;
                };
 
                g_cMathWorker->DoMultiThreadedWork((int)tupleSize, lambdaHSCallback, &myhstack);
@@ -2660,7 +2724,7 @@ PyObject *ShiftArrays(PyObject* self, PyObject *args)
    int64_t tupleSize = 0;
 
    // Allow jagged rows
-   ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, FALSE);
+   ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, false);
 
    if (aInfo) {
 
@@ -2676,7 +2740,7 @@ PyObject *ShiftArrays(PyObject* self, PyObject *args)
       myshift.aInfo = aInfo;
       myshift.shiftAmount = shiftAmount;
 
-      auto lambdaShiftCallback = [](void* callbackArgT, int core, int64_t workIndex) -> BOOL {
+      auto lambdaShiftCallback = [](void* callbackArgT, int core, int64_t workIndex) -> bool {
          stSHIFT* pShift = (stSHIFT*)callbackArgT;
          int64_t t = workIndex;
 
@@ -2764,7 +2828,7 @@ PyObject *ShiftArrays(PyObject* self, PyObject *args)
                }
             }
          }
-         return TRUE;
+         return true;
       };
 
       g_cMathWorker->DoMultiThreadedWork((int)tupleSize, lambdaShiftCallback, &myshift);
@@ -2806,7 +2870,7 @@ PyObject *HomogenizeArrays(PyObject* self, PyObject *args) {
    int64_t tupleSize = 0;
 
    // Do not allow jagged rows
-   ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, TRUE);
+   ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, true);
 
    if (aInfo) {
       int32_t dtype = (int32_t)PyLong_AsLong(dtypeObject);
@@ -2825,7 +2889,7 @@ PyObject *HomogenizeArrays(PyObject* self, PyObject *args) {
       }
 
       // Now convert?
-      // if output is boolean, bad means FALSE
+      // if output is boolean, bad means false
       void* pBadOutput1 = GetDefaultForType(dtype);
 
       PyObject*  returnList = PyList_New(0);
@@ -3202,7 +3266,7 @@ PyObject* SetItemBooleanMaskLarge(PyArrayObject* arr, PyArrayObject* mask, PyArr
    if (stBoolCounter.pCounts) {
       stBoolCounter.pBoolMask = (int8_t*)PyArray_BYTES(mask);
 
-      auto lambdaCallback = [](void* callbackArgT, int core, int64_t workIndex) -> BOOL {
+      auto lambdaCallback = [](void* callbackArgT, int core, int64_t workIndex) -> bool {
          ST_BOOLCOUNTER* pstBoolCounter = (ST_BOOLCOUNTER*)callbackArgT;
          int64_t t = workIndex;
 
@@ -3214,7 +3278,7 @@ PyObject* SetItemBooleanMaskLarge(PyArrayObject* arr, PyArrayObject* mask, PyArr
          pstBoolCounter->pCounts[workIndex] = SumBooleanMask(pstBoolCounter->pBoolMask + (SETITEM_PARTITION_SIZE * workIndex), lastCount);
          //printf("isum %lld %lld %lld\n", workIndex, pstBoolCounter->pCounts[workIndex], lastCount);
 
-         return TRUE;
+         return true;
       };
 
       g_cMathWorker->DoMultiThreadedWork((int)stBoolCounter.sections, lambdaCallback, &stBoolCounter);
@@ -3231,7 +3295,7 @@ PyObject* SetItemBooleanMaskLarge(PyArrayObject* arr, PyArrayObject* mask, PyArr
 
       if (bsum > 0 && bsum == arrlength) {
 
-         auto lambda2Callback = [](void* callbackArgT, int core, int64_t workIndex) -> BOOL {
+         auto lambda2Callback = [](void* callbackArgT, int core, int64_t workIndex) -> bool {
             ST_BOOLCOUNTER* pstBoolCounter = (ST_BOOLCOUNTER*)callbackArgT;
             int64_t t = workIndex;
 
@@ -3248,7 +3312,7 @@ PyObject* SetItemBooleanMaskLarge(PyArrayObject* arr, PyArrayObject* mask, PyArr
                lastCount,
                pstBoolCounter->itemSize);
 
-            return TRUE;
+            return true;
          };
 
          g_cMathWorker->DoMultiThreadedWork((int)stBoolCounter.sections, lambda2Callback, &stBoolCounter);
@@ -3261,7 +3325,7 @@ PyObject* SetItemBooleanMaskLarge(PyArrayObject* arr, PyArrayObject* mask, PyArr
 
       if (bsum > 0 && arrlength == 1) {
 
-         auto lambda2Callback = [](void* callbackArgT, int core, int64_t workIndex) -> BOOL {
+         auto lambda2Callback = [](void* callbackArgT, int core, int64_t workIndex) -> bool {
             ST_BOOLCOUNTER* pstBoolCounter = (ST_BOOLCOUNTER*)callbackArgT;
             int64_t t = workIndex;
 
@@ -3278,7 +3342,7 @@ PyObject* SetItemBooleanMaskLarge(PyArrayObject* arr, PyArrayObject* mask, PyArr
                lastCount,
                pstBoolCounter->itemSize);
 
-            return TRUE;
+            return true;
          };
 
          g_cMathWorker->DoMultiThreadedWork((int)stBoolCounter.sections, lambda2Callback, &stBoolCounter);
@@ -3301,8 +3365,8 @@ PyObject* SetItemBooleanMaskLarge(PyArrayObject* arr, PyArrayObject* mask, PyArr
 //   : param fld : boolean or fancy index mask
 //   : param value : scalar, sequence or dataset value as follows
 //
-// returns TRUE if it worked
-// returns FALSE
+// returns true if it worked
+// returns false
 // NOTE: This routine is not finished yet
 PyObject *SetItem(PyObject* self, PyObject *args)
 {
@@ -3388,8 +3452,8 @@ PyObject *SetItem(PyObject* self, PyObject *args)
 //----------------------------------------------------
 // rough equivalvent arr[mask] = value[mask]
 //
-// returns TRUE if it worked
-// returns FALSE
+// returns true if it worked
+// returns false
 PyObject *PutMask(PyObject* self, PyObject *args)
 {
    Py_ssize_t argTupleSize = PyTuple_GET_SIZE(args);
@@ -3444,7 +3508,7 @@ PyObject *PutMask(PyObject* self, PyObject *args)
                   MASK_CALLBACK_STRUCT stMask;
 
                   // This is the routine that will be called back from multiple threads
-                  auto lambdaMaskCallback = [](void* callbackArgT, int core, int64_t start, int64_t length) -> BOOL {
+                  auto lambdaMaskCallback = [](void* callbackArgT, int core, int64_t start, int64_t length) -> bool {
                      MASK_CALLBACK_STRUCT* callbackArg = (MASK_CALLBACK_STRUCT*)callbackArgT;
 
                      //printf("[%d] Mask %lld %lld\n", core, start, length);
@@ -3458,7 +3522,7 @@ PyObject *PutMask(PyObject* self, PyObject *args)
                         callbackArg->pBadInput1,
                         callbackArg->pBadOutput1);
 
-                     return TRUE;
+                     return true;
                   };
 
                   stMask.itemSizeIn = itemSizeIn;
@@ -3528,7 +3592,7 @@ PyObject *ApplyRows(PyObject* self, PyObject *args, PyObject* kwargs)
       int64_t tupleSize = 0;
 
       // Do not allow jagged rows
-      ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, TRUE);
+      ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize, true);
 
       if (aInfo) {
          int32_t dtype = (int32_t)PyLong_AsLong(dtypeObject);
@@ -3544,7 +3608,7 @@ PyObject *ApplyRows(PyObject* self, PyObject *args, PyObject* kwargs)
          }
 
          // Now convert?
-         // if output is boolean, bad means FALSE
+         // if output is boolean, bad means false
          void* pBadOutput1 = GetDefaultForType(dtype);
 
          // Convert any different types... build a new list...

--- a/src/Convert.h
+++ b/src/Convert.h
@@ -4,10 +4,10 @@
 
 
 PyObject *
-ConvertSafeInternal( PyArrayObject *inArr1, INT64 out_dtype);
+ConvertSafeInternal( PyArrayObject *inArr1, int64_t out_dtype);
 
 PyObject *
-ConvertUnsafeInternal(PyArrayObject *inArr1, INT64 out_dtype);
+ConvertUnsafeInternal(PyArrayObject *inArr1, int64_t out_dtype);
 
 PyObject *
 ConvertSafe(PyObject *self, PyObject *args);
@@ -44,4 +44,4 @@ PyObject *ApplyRows(PyObject* self, PyObject *args, PyObject* kwargs);
 
 PyObject *ShiftArrays(PyObject* self, PyObject *args);
 
-INT64 SumBooleanMask(const INT8* pIn, INT64 length);
+int64_t SumBooleanMask(const int8_t* pIn, int64_t length);

--- a/src/DateTime.cpp
+++ b/src/DateTime.cpp
@@ -18,12 +18,12 @@ const char PERIOD = '.';
 // pStart updated on return
 //
 template <typename T>
-FORCE_INLINE INT64 ParseDecimal(const T** ppStart, const T* pEnd) {
+FORCE_INLINE int64_t ParseDecimal(const T** ppStart, const T* pEnd) {
    const T* pStart = *ppStart;
 
    // parse a number
-   INT64 num = 0;
-   INT64 places = 0;
+   int64_t num = 0;
+   int64_t places = 0;
    while (pStart < pEnd) {
       if (*pStart >= '0' && *pStart <= '9') {
          num = num * 10;
@@ -57,7 +57,7 @@ FORCE_INLINE INT64 ParseDecimal(const T** ppStart, const T* pEnd) {
 // will stop at end, stop at nonnumber, or when places reached
 // pStart updated on return
 template <typename T>
-FORCE_INLINE INT64 ParseNumber(const T** ppStart, const T* pEnd, INT64 maxplaces) {
+FORCE_INLINE int64_t ParseNumber(const T** ppStart, const T* pEnd, int64_t maxplaces) {
    const T* pStart = *ppStart;
 
    // skip non numbers in front
@@ -70,8 +70,8 @@ FORCE_INLINE INT64 ParseNumber(const T** ppStart, const T* pEnd, INT64 maxplaces
    }
 
    // parse a number
-   INT64 num = 0;
-   INT64 places = 0;
+   int64_t num = 0;
+   int64_t places = 0;
    while (pStart < pEnd) {
       if (*pStart >= '0' && *pStart <= '9') {
          num = num * 10;
@@ -94,17 +94,17 @@ FORCE_INLINE INT64 ParseNumber(const T** ppStart, const T* pEnd, INT64 maxplaces
 // T is either a char or UCS4 (byte string or unicode string)
 //
 template <typename T>
-void ParseTimeString(INT64* pOutNanoTime, INT64 arrayLength, const T* pString, INT64 itemSize) {
+void ParseTimeString(int64_t* pOutNanoTime, int64_t arrayLength, const T* pString, int64_t itemSize) {
 
-   for (INT64 i = 0; i < arrayLength; i++) {
+   for (int64_t i = 0; i < arrayLength; i++) {
       const T* pStart = &pString[i*itemSize];
       const T* pEnd = pStart + itemSize;
 
-      INT64 hour = 0;
-      INT64 minute = 0;
-      INT64 seconds = 0;
+      int64_t hour = 0;
+      int64_t minute = 0;
+      int64_t seconds = 0;
 
-      BOOL bSuccess = 0;
+      bool bSuccess = 0;
 
       hour = ParseNumber<T>(&pStart, pEnd,2);
 
@@ -142,7 +142,7 @@ void ParseTimeString(INT64* pOutNanoTime, INT64 arrayLength, const T* pString, I
 
 }
 
-INT64 MONTH_SPLITS[12] = {
+int64_t MONTH_SPLITS[12] = {
       0,
       31,
       59,
@@ -156,7 +156,7 @@ INT64 MONTH_SPLITS[12] = {
       304,
       334 };
 
-INT64 MONTH_SPLITS_LEAP[12] = {
+int64_t MONTH_SPLITS_LEAP[12] = {
    0,  // Jan
    31, // Feb
    60, // Mar
@@ -170,14 +170,14 @@ INT64 MONTH_SPLITS_LEAP[12] = {
    305,  // Nov
    335 };
 
-INT64 NANOS_PER_SECOND = 1000000000LL;
-INT64 NANOS_PER_MINUTE = NANOS_PER_SECOND * 60;
-INT64 NANOS_PER_HOUR = NANOS_PER_MINUTE * 60;
-INT64 NANOS_PER_DAY = NANOS_PER_HOUR * 24;
+int64_t NANOS_PER_SECOND = 1000000000LL;
+int64_t NANOS_PER_MINUTE = NANOS_PER_SECOND * 60;
+int64_t NANOS_PER_HOUR = NANOS_PER_MINUTE * 60;
+int64_t NANOS_PER_DAY = NANOS_PER_HOUR * 24;
 
 //==========================================================
 // return -1 for error
-INT64 YearToEpochNano(INT64 year, INT64 month, INT64 day) {
+int64_t YearToEpochNano(int64_t year, int64_t month, int64_t day) {
 
    if (year >= 1970 && year <= 2040 && month >= 1 && month <= 12 && day >= 1 && day <= 31) {
 
@@ -193,8 +193,8 @@ INT64 YearToEpochNano(INT64 year, INT64 month, INT64 day) {
       // 1977 has 2 leap years (7)
       // 1972 has 0 leap years (2)
       year = year - 1970;
-      INT64 extradays = (year + 1) / 4;
-      INT64 daysSinceEpoch = (year * 365) + extradays + day;
+      int64_t extradays = (year + 1) / 4;
+      int64_t daysSinceEpoch = (year * 365) + extradays + day;
 
       return (daysSinceEpoch* NANOS_PER_DAY);
    }
@@ -208,22 +208,22 @@ INT64 YearToEpochNano(INT64 year, INT64 month, INT64 day) {
 // T is either a char or UCS4 (byte string or unicode string)
 //
 template <typename T>
-void ParseDateString(INT64* pOutNanoTime, INT64 arrayLength, const T* pString, INT64 itemSize) {
+void ParseDateString(int64_t* pOutNanoTime, int64_t arrayLength, const T* pString, int64_t itemSize) {
 
-   for (INT64 i = 0; i < arrayLength; i++) {
+   for (int64_t i = 0; i < arrayLength; i++) {
       const T* pStart = &pString[i*itemSize];
       const T* pEnd = pStart + itemSize;
 
-      INT64 year = 0;
-      INT64 month = 0;
-      INT64 day = 0;
+      int64_t year = 0;
+      int64_t month = 0;
+      int64_t day = 0;
 
       year = ParseNumber<T>(&pStart, pEnd, 4);
       // could check for dash here...
       month = ParseNumber<T>(&pStart, pEnd, 2);
       day = ParseNumber<T>(&pStart, pEnd, 2);
       LOGGING("date: %lld:%lld:%lld\n", year, month, day);
-      INT64 result = YearToEpochNano(year, month, day);
+      int64_t result = YearToEpochNano(year, month, day);
       if (result < 0) result = 0;
       pOutNanoTime[i] = result;
    }
@@ -236,29 +236,29 @@ void ParseDateString(INT64* pOutNanoTime, INT64 arrayLength, const T* pString, I
 // T is either a char or UCS4 (byte string or unicode string)
 // Anything invalid is set to 0
 template <typename T>
-void ParseDateTimeString(INT64* pOutNanoTime, INT64 arrayLength, const T* pString, INT64 itemSize) {
+void ParseDateTimeString(int64_t* pOutNanoTime, int64_t arrayLength, const T* pString, int64_t itemSize) {
 
-   for (INT64 i = 0; i < arrayLength; i++) {
+   for (int64_t i = 0; i < arrayLength; i++) {
       const T* pStart = &pString[i*itemSize];
       const T* pEnd = pStart + itemSize;
 
-      INT64 year = 0;
-      INT64 month = 0;
-      INT64 day = 0;
+      int64_t year = 0;
+      int64_t month = 0;
+      int64_t day = 0;
 
       year = ParseNumber<T>(&pStart, pEnd, 4);
       // could check for dash here...
       month = ParseNumber<T>(&pStart, pEnd, 2);
       day = ParseNumber<T>(&pStart, pEnd, 2);
       LOGGING("date: %lld:%lld:%lld\n", year, month, day);
-      INT64 yearresult= YearToEpochNano(year, month, day);
+      int64_t yearresult= YearToEpochNano(year, month, day);
 
       // What if year is negative?
       if (yearresult >= 0) {
-         INT64 hour = 0;
-         INT64 minute = 0;
-         INT64 seconds = 0;
-         BOOL  bSuccess = 0;
+         int64_t hour = 0;
+         int64_t minute = 0;
+         int64_t seconds = 0;
+         bool  bSuccess = 0;
 
          if (ParseSingleNonNumber(pStart, pEnd)) {
             hour = ParseNumber<T>(&pStart, pEnd, 2);
@@ -302,10 +302,10 @@ void ParseDateTimeString(INT64* pOutNanoTime, INT64 arrayLength, const T* pStrin
 }
 
 //--------------------------------------------------------------
-// Arg1: input numpy array time == assumes INT64 for now
+// Arg1: input numpy array time == assumes int64_t for now
 // HH:MM:SS format
 //
-// Output: INT64 numpy array with nanos
+// Output: int64_t numpy array with nanos
 //
 PyObject *
 TimeStringToNanos(PyObject *self, PyObject *args)
@@ -319,10 +319,10 @@ TimeStringToNanos(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   INT32 dType = PyArray_TYPE(inArr);
+   int32_t dType = PyArray_TYPE(inArr);
 
    PyArrayObject* outArray = NULL;
-   INT64 arrayLength = ArrayLength(inArr);
+   int64_t arrayLength = ArrayLength(inArr);
 
    // TODO: Check to make sure inArr and timeArr sizes are the same
    if (dType != NPY_STRING && dType != NPY_UNICODE) {
@@ -334,8 +334,8 @@ TimeStringToNanos(PyObject *self, PyObject *args)
    outArray = AllocateNumpyArray(1, (npy_intp*)&arrayLength, NPY_INT64);
 
    if (outArray) {
-      INT64 itemSize = PyArray_ITEMSIZE(inArr);
-      INT64* pNanoTime = (INT64*)PyArray_BYTES(outArray);
+      int64_t itemSize = PyArray_ITEMSIZE(inArr);
+      int64_t* pNanoTime = (int64_t*)PyArray_BYTES(outArray);
       char* pString = (char*)PyArray_BYTES(inArr);
 
       if (dType == NPY_STRING) {
@@ -343,7 +343,7 @@ TimeStringToNanos(PyObject *self, PyObject *args)
          ParseTimeString<char>(pNanoTime, arrayLength, pString, itemSize);
       }
       else {
-         ParseTimeString<UINT32>(pNanoTime, arrayLength, (UINT32*)pString, itemSize/4);
+         ParseTimeString<uint32_t>(pNanoTime, arrayLength, (uint32_t*)pString, itemSize/4);
 
       }
       return (PyObject*)outArray;
@@ -355,10 +355,10 @@ TimeStringToNanos(PyObject *self, PyObject *args)
 
 
 //--------------------------------------------------------------
-// Arg1: input numpy array time == assumes INT64 for now
+// Arg1: input numpy array time == assumes int64_t for now
 // YYYYMMDD or YYYY-MM-DD
 //
-// Output: INT64 numpy array with nanos
+// Output: int64_t numpy array with nanos
 //
 PyObject *
 DateStringToNanos(PyObject *self, PyObject *args)
@@ -372,10 +372,10 @@ DateStringToNanos(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   INT32 dType = PyArray_TYPE(inArr);
+   int32_t dType = PyArray_TYPE(inArr);
 
    PyArrayObject* outArray = NULL;
-   INT64 arrayLength = ArrayLength(inArr);
+   int64_t arrayLength = ArrayLength(inArr);
 
    // TODO: Check to make sure inArr and timeArr sizes are the same
    if (dType != NPY_STRING && dType != NPY_UNICODE) {
@@ -387,8 +387,8 @@ DateStringToNanos(PyObject *self, PyObject *args)
    outArray = AllocateNumpyArray(1, (npy_intp*)&arrayLength, NPY_INT64);
 
    if (outArray) {
-      INT64 itemSize = PyArray_ITEMSIZE(inArr);
-      INT64* pNanoTime = (INT64*)PyArray_BYTES(outArray);
+      int64_t itemSize = PyArray_ITEMSIZE(inArr);
+      int64_t* pNanoTime = (int64_t*)PyArray_BYTES(outArray);
       char* pString = (char*)PyArray_BYTES(inArr);
 
       if (dType == NPY_STRING) {
@@ -396,7 +396,7 @@ DateStringToNanos(PyObject *self, PyObject *args)
          ParseDateString<char>(pNanoTime, arrayLength, pString, itemSize);
       }
       else {
-         ParseDateString<UINT32>(pNanoTime, arrayLength, (UINT32*)pString, itemSize / 4);
+         ParseDateString<uint32_t>(pNanoTime, arrayLength, (uint32_t*)pString, itemSize / 4);
 
       }
       return (PyObject*)outArray;
@@ -408,10 +408,10 @@ DateStringToNanos(PyObject *self, PyObject *args)
 
 
 //--------------------------------------------------------------
-// Arg1: input numpy array time == assumes INT64 for now
+// Arg1: input numpy array time == assumes int64_t for now
 // YYYYMMDD or YYYY-MM-DD
 //
-// Output: INT64 numpy array with nanos
+// Output: int64_t numpy array with nanos
 //
 PyObject *
 DateTimeStringToNanos(PyObject *self, PyObject *args)
@@ -425,10 +425,10 @@ DateTimeStringToNanos(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   INT32 dType = PyArray_TYPE(inArr);
+   int32_t dType = PyArray_TYPE(inArr);
 
    PyArrayObject* outArray = NULL;
-   INT64 arrayLength = ArrayLength(inArr);
+   int64_t arrayLength = ArrayLength(inArr);
 
    // TODO: Check to make sure inArr and timeArr sizes are the same
    if (dType != NPY_STRING && dType != NPY_UNICODE) {
@@ -440,8 +440,8 @@ DateTimeStringToNanos(PyObject *self, PyObject *args)
    outArray = AllocateNumpyArray(1, (npy_intp*)&arrayLength, NPY_INT64);
 
    if (outArray) {
-      INT64 itemSize = PyArray_ITEMSIZE(inArr);
-      INT64* pNanoTime = (INT64*)PyArray_BYTES(outArray);
+      int64_t itemSize = PyArray_ITEMSIZE(inArr);
+      int64_t* pNanoTime = (int64_t*)PyArray_BYTES(outArray);
       char* pString = (char*)PyArray_BYTES(inArr);
 
       if (dType == NPY_STRING) {
@@ -449,7 +449,7 @@ DateTimeStringToNanos(PyObject *self, PyObject *args)
          ParseDateTimeString<char>(pNanoTime, arrayLength, pString, itemSize);
       }
       else {
-         ParseDateTimeString<UINT32>(pNanoTime, arrayLength, (UINT32*)pString, itemSize / 4);
+         ParseDateTimeString<uint32_t>(pNanoTime, arrayLength, (uint32_t*)pString, itemSize / 4);
 
       }
       return (PyObject*)outArray;
@@ -466,19 +466,19 @@ DateTimeStringToNanos(PyObject *self, PyObject *args)
 // T is either a char or UCS4 (byte string or unicode string)
 // Anything invalid is set to 0
 template<typename T>
-void ParseStrptime(INT64* pOutNanoTime, INT64 arrayLength, const T* pString, INT64 itemSize, const char* pFmt) {
+void ParseStrptime(int64_t* pOutNanoTime, int64_t arrayLength, const T* pString, int64_t itemSize, const char* pFmt) {
 
    tm timeBack;
 
    char* pTempString = (char*)WORKSPACE_ALLOC(itemSize + 8);
    const char* pEnd = pTempString + itemSize;
 
-   for (INT64 i = 0; i < arrayLength; i++) {
+   for (int64_t i = 0; i < arrayLength; i++) {
       const T* pStart = &pString[i*itemSize];
 
       // copy string over (or convert unicode)
       // so we can add a terminating zero
-      for (INT64 j = 0; j < itemSize; j++) {
+      for (int64_t j = 0; j < itemSize; j++) {
          pTempString[j] = (char)pStart[j];
       }
       pTempString[itemSize] = 0;
@@ -489,7 +489,7 @@ void ParseStrptime(INT64* pOutNanoTime, INT64 arrayLength, const T* pString, INT
       const char* pStop;
       pStop = rt_strptime(pTempString, pFmt, &timeBack);
 
-      INT64 yearresult = 0;
+      int64_t yearresult = 0;
 
       // Check if we parsed it correctly
       if (pStop && timeBack.tm_year != 0) {
@@ -533,14 +533,14 @@ void ParseStrptime(INT64* pOutNanoTime, INT64 arrayLength, const T* pString, INT
 // Arg1: input numpy string array time 
 // Arg2: strptime format string (MUSTBE BE BYESTRING)
 //
-// Output: INT64 numpy array with nanos
+// Output: int64_t numpy array with nanos
 //
 PyObject *
 StrptimeToNanos(PyObject *self, PyObject *args)
 {
    PyArrayObject *inArr = NULL;
    const char *strTimeFormat;
-   UINT32 strTimeFormatSize;
+   uint32_t strTimeFormatSize;
 
    if (!PyArg_ParseTuple(
       args, "O!y#",
@@ -551,10 +551,10 @@ StrptimeToNanos(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   INT32 dType = PyArray_TYPE(inArr);
+   int32_t dType = PyArray_TYPE(inArr);
 
    PyArrayObject* outArray = NULL;
-   INT64 arrayLength = ArrayLength(inArr);
+   int64_t arrayLength = ArrayLength(inArr);
 
    // TODO: Check to make sure inArr and timeArr sizes are the same
    if (dType != NPY_STRING && dType != NPY_UNICODE) {
@@ -566,8 +566,8 @@ StrptimeToNanos(PyObject *self, PyObject *args)
    outArray = AllocateNumpyArray(1, (npy_intp*)&arrayLength, NPY_INT64);
 
    if (outArray) {
-      INT64 itemSize = PyArray_ITEMSIZE(inArr);
-      INT64* pNanoTime = (INT64*)PyArray_BYTES(outArray);
+      int64_t itemSize = PyArray_ITEMSIZE(inArr);
+      int64_t* pNanoTime = (int64_t*)PyArray_BYTES(outArray);
       char* pString = (char*)PyArray_BYTES(inArr);
 
       if (dType == NPY_STRING) {
@@ -575,7 +575,7 @@ StrptimeToNanos(PyObject *self, PyObject *args)
       }
       else {
 
-         ParseStrptime<UINT32>(pNanoTime, arrayLength, (UINT32*)pString, itemSize/4, strTimeFormat);
+         ParseStrptime<uint32_t>(pNanoTime, arrayLength, (uint32_t*)pString, itemSize/4, strTimeFormat);
       }
 
       return (PyObject*)outArray;

--- a/src/Ema.cpp
+++ b/src/Ema.cpp
@@ -515,8 +515,8 @@ ROLLING_FUNC GetRollingFunction(int64_t func, int32_t inputType) {
    case NPY_LONGDOUBLE: return EmaBase<long double, long double>::GetRollingFunction(func);
    case NPY_INT8:   return EmaBase<int8_t, int64_t>::GetRollingFunction(func);
    case NPY_INT16:  return EmaBase<int16_t, int64_t>::GetRollingFunction(func);
-   case NPY_INT:  return EmaBase<int32_t, int64_t>::GetRollingFunction(func);
-   case NPY_UINT: return EmaBase<uint32_t, int64_t>::GetRollingFunction(func);
+   case NPY_INT32:  return EmaBase<int32_t, int64_t>::GetRollingFunction(func);
+   case NPY_UINT32: return EmaBase<uint32_t, int64_t>::GetRollingFunction(func);
    case NPY_INT64:
    case NPY_LONGLONG:
       return EmaBase<int64_t, int64_t>::GetRollingFunction(func);
@@ -538,8 +538,8 @@ ROLLING_FUNC GetRollingFunction2(int64_t func, int32_t inputType) {
    case NPY_LONGDOUBLE: return EmaBase<long double, long double>::GetRollingFunction2(func);
    case NPY_INT8:   return EmaBase<int8_t, double>::GetRollingFunction2(func);
    case NPY_INT16:  return EmaBase<int16_t, double>::GetRollingFunction2(func);
-   case NPY_INT:  return EmaBase<int32_t, double>::GetRollingFunction2(func);
-   case NPY_UINT:  return EmaBase<uint32_t, double>::GetRollingFunction2(func);
+   case NPY_INT32:  return EmaBase<int32_t, double>::GetRollingFunction2(func);
+   case NPY_UINT32:  return EmaBase<uint32_t, double>::GetRollingFunction2(func);
    case NPY_INT64:
    case NPY_LONGLONG:
       return EmaBase<int64_t, double>::GetRollingFunction2(func);
@@ -1474,11 +1474,11 @@ static EMA_BY_TWO_FUNC GetEmaByStep2(int timeType, EMA_FUNCTIONS func) {
    case NPY_FLOAT:  return EmaByBase<T, double, float, K>::GetFunc(func);
    case NPY_DOUBLE: return EmaByBase<T, double, double, K>::GetFunc(func);
    case NPY_LONGDOUBLE: return EmaByBase<T, long double, long double, K>::GetFunc(func);
-   case NPY_INT:  return EmaByBase<T, double, int32_t, K>::GetFunc(func);
+   case NPY_INT32:  return EmaByBase<T, double, int32_t, K>::GetFunc(func);
    case NPY_INT64:
    case NPY_LONGLONG:
       return EmaByBase<T, double, int64_t, K>::GetFunc(func);
-   case NPY_UINT: return EmaByBase<T, double, uint32_t, K>::GetFunc(func);
+   case NPY_UINT32: return EmaByBase<T, double, uint32_t, K>::GetFunc(func);
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return EmaByBase<T, double, uint64_t, K>::GetFunc(func);
@@ -1504,14 +1504,14 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_BOOL:   *outputType = NPY_INT64; return CumSum<int8_t, int64_t, K>;
       case NPY_INT8:   *outputType = NPY_INT64; return CumSum<int8_t, int64_t, K>;
       case NPY_INT16:  *outputType = NPY_INT64; return CumSum<int16_t, int64_t, K>;
-      case NPY_INT:  *outputType = NPY_INT64; return CumSum<int32_t, int64_t, K>;
+      case NPY_INT32:  *outputType = NPY_INT64; return CumSum<int32_t, int64_t, K>;
       case NPY_INT64:
       case NPY_LONGLONG:
            *outputType = NPY_INT64; return CumSum<int64_t, int64_t, K>;
 
       case NPY_UINT8:  *outputType = NPY_UINT64; return CumSum<uint8_t,  uint64_t, K>;
       case NPY_UINT16: *outputType = NPY_UINT64; return CumSum<uint16_t, uint64_t, K>;
-      case NPY_UINT: *outputType = NPY_UINT64; return CumSum<uint32_t, uint64_t, K>;
+      case NPY_UINT32: *outputType = NPY_UINT64; return CumSum<uint32_t, uint64_t, K>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           *outputType = NPY_UINT64; return CumSum<uint64_t, uint64_t, K>;
@@ -1527,14 +1527,14 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_BOOL:   *outputType = NPY_INT64; return CumProd<int8_t, int64_t, K>;
       case NPY_INT8:   *outputType = NPY_INT64; return CumProd<int8_t, int64_t, K>;
       case NPY_INT16:  *outputType = NPY_INT64; return CumProd<int16_t, int64_t, K>;
-      case NPY_INT:  *outputType = NPY_INT64; return CumProd<int32_t, int64_t, K>;
+      case NPY_INT32:  *outputType = NPY_INT64; return CumProd<int32_t, int64_t, K>;
       case NPY_INT64:
       case NPY_LONGLONG:
            *outputType = NPY_INT64; return CumProd<int64_t, int64_t, K>;
 
       case NPY_UINT8:  *outputType = NPY_UINT64; return CumProd<uint8_t, uint64_t, K>;
       case NPY_UINT16: *outputType = NPY_UINT64; return CumProd<uint16_t, uint64_t, K>;
-      case NPY_UINT: *outputType = NPY_UINT64; return CumProd<uint32_t, uint64_t, K>;
+      case NPY_UINT32: *outputType = NPY_UINT64; return CumProd<uint32_t, uint64_t, K>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           *outputType = NPY_UINT64; return CumProd<uint64_t, uint64_t, K>;
@@ -1544,7 +1544,7 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
 
 
    case EMA_FINDNTH:
-      *outputType = NPY_INT; return FindNth< int32_t, K>;
+      *outputType = NPY_INT32; return FindNth< int32_t, K>;
       break;
 
    case EMA_NORMAL:
@@ -1558,13 +1558,13 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_LONGDOUBLE: return GetEmaByStep2<long double, K>(timeType, func);
       case NPY_INT8:   return GetEmaByStep2<int8_t, K>(timeType, func);
       case NPY_INT16:  return GetEmaByStep2<int16_t, K>(timeType, func);
-      case NPY_INT:  return GetEmaByStep2<int32_t, K>(timeType, func);
+      case NPY_INT32:  return GetEmaByStep2<int32_t, K>(timeType, func);
       case NPY_INT64:
       case NPY_LONGLONG:
            return GetEmaByStep2<int64_t, K>(timeType, func);
       case NPY_UINT8:  return GetEmaByStep2<uint8_t, K>(timeType, func);
       case NPY_UINT16: return GetEmaByStep2<uint16_t, K>(timeType, func);
-      case NPY_UINT: return GetEmaByStep2<uint32_t, K>(timeType, func);
+      case NPY_UINT32: return GetEmaByStep2<uint32_t, K>(timeType, func);
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return GetEmaByStep2<uint64_t, K>(timeType, func);
@@ -1693,7 +1693,7 @@ EmaAll32(PyObject *self, PyObject *args)
    switch (iKeyType) {
    case NPY_INT8:
    case NPY_INT16:
-   case NPY_INT:
+   case NPY_INT32:
    case NPY_INT64:
    case NPY_LONGLONG:
       break;
@@ -1798,7 +1798,7 @@ EmaAll32(PyObject *self, PyObject *args)
       case NPY_INT16:
          pFunction = GetEmaByFunction<int16_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
-      case NPY_INT:
+      case NPY_INT32:
          pFunction = GetEmaByFunction<int32_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
       case NPY_INT64:

--- a/src/Ema.cpp
+++ b/src/Ema.cpp
@@ -20,7 +20,7 @@
 #define LOGGING(...)
 //#define LOGGING printf
 
-typedef void(*ROLLING_FUNC)(void* pDataIn, void* pDataOut, INT64 len, INT64 windowSize);
+typedef void(*ROLLING_FUNC)(void* pDataIn, void* pDataOut, int64_t len, int64_t windowSize);
 
 // These are non-groupby routine -- straight array
 enum ROLLING_FUNCTIONS {
@@ -50,12 +50,12 @@ enum EMA_FUNCTIONS {
 };
 
 //=========================================================================================================================
-typedef void(*EMA_BY_TWO_FUNC)(void* pKey, void* pAccumBin, void* pColumn, INT64 numUnique, INT64 totalInputRows, void* pTime, INT8* pIncludeMask, INT8* pResetMask, double decayRate);
+typedef void(*EMA_BY_TWO_FUNC)(void* pKey, void* pAccumBin, void* pColumn, int64_t numUnique, int64_t totalInputRows, void* pTime, int8_t* pIncludeMask, int8_t* pResetMask, double decayRate);
 
 struct stEmaReturn {
 
    PyArrayObject*    outArray;
-   INT32             numpyOutType;
+   int32_t             numpyOutType;
    EMA_BY_TWO_FUNC   pFunction;
    PyObject*         returnObject;
 };
@@ -65,18 +65,18 @@ struct stEmaReturn {
 struct stEma32 {
 
    ArrayInfo* aInfo;
-   INT64    tupleSize;
-   INT32    funcNum;
-   INT64    uniqueRows;
-   INT64    totalInputRows;
+   int64_t    tupleSize;
+   int32_t    funcNum;
+   int64_t    uniqueRows;
+   int64_t    totalInputRows;
 
    TYPE_OF_FUNCTION_CALL   typeOfFunctionCall;
    void*   pKey;
 
    // from params
    void*    pTime;
-   INT8*    inIncludeMask;
-   INT8*    inResetMask;
+   int8_t*    inIncludeMask;
+   int8_t*    inResetMask;
    double   doubleParam;
 
    stEmaReturn returnObjects[1];
@@ -96,10 +96,10 @@ public:
 
    // Pass in two vectors and return one vector
    // Used for operations like C = A + B
-   //typedef void(*ANY_TWO_FUNC)(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode);
-   //typedef void(*ANY_ONE_FUNC)(void* pDataIn, void* pDataOut, INT64 len);
+   //typedef void(*ANY_TWO_FUNC)(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode);
+   //typedef void(*ANY_ONE_FUNC)(void* pDataIn, void* pDataOut, int64_t len);
 
-   static void RollingSum(void* pDataIn, void* pDataOut, INT64 len, INT64 windowSize) {
+   static void RollingSum(void* pDataIn, void* pDataOut, int64_t len, int64_t windowSize) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -107,12 +107,12 @@ public:
       U currentSum = 0;
 
       // Priming of the summation
-      for (INT64 i = 0; i < len && i < windowSize; i++) {
+      for (int64_t i = 0; i < len && i < windowSize; i++) {
          currentSum += pIn[i];
          pOut[i] = currentSum;
       }
 
-      for (INT64 i = windowSize; i < len; i++) {
+      for (int64_t i = windowSize; i < len; i++) {
          currentSum += pIn[i];
 
          // subtract the item leaving the window
@@ -123,7 +123,7 @@ public:
    }
 
 
-   static void RollingNanSum(void* pDataIn, void* pDataOut, INT64 len, INT64 windowSize) {
+   static void RollingNanSum(void* pDataIn, void* pDataOut, int64_t len, int64_t windowSize) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -135,7 +135,7 @@ public:
       if (invalid == invalid) {
          // NON_FLOAT
          // Priming of the summation
-         for (INT64 i = 0; i < len && i < windowSize; i++) {
+         for (int64_t i = 0; i < len && i < windowSize; i++) {
             T temp = pIn[i];
 
             if (temp != invalid) {
@@ -144,7 +144,7 @@ public:
             pOut[i] = currentSum;
          }
 
-         for (INT64 i = windowSize; i < len; i++) {
+         for (int64_t i = windowSize; i < len; i++) {
             T temp = pIn[i];
 
             if (temp != invalid)
@@ -161,7 +161,7 @@ public:
       else {
          // FLOAT
          // Priming of the summation
-         for (INT64 i = 0; i < len && i < windowSize; i++) {
+         for (int64_t i = 0; i < len && i < windowSize; i++) {
             T temp = pIn[i];
 
             if (temp == temp) {
@@ -170,7 +170,7 @@ public:
             pOut[i] = currentSum;
          }
 
-         for (INT64 i = windowSize; i < len; i++) {
+         for (int64_t i = windowSize; i < len; i++) {
             T temp = pIn[i];
 
             if (temp == temp)
@@ -187,7 +187,7 @@ public:
    }
 
 
-   static void RollingMean(void* pDataIn, void* pDataOut, INT64 len, INT64 windowSize) {
+   static void RollingMean(void* pDataIn, void* pDataOut, int64_t len, int64_t windowSize) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -195,12 +195,12 @@ public:
       U currentSum = 0;
 
       // Priming of the summation
-      for (INT64 i = 0; i < len && i < windowSize; i++) {
+      for (int64_t i = 0; i < len && i < windowSize; i++) {
          currentSum += pIn[i];
          pOut[i] = currentSum / (i+1);
       }
 
-      for (INT64 i = windowSize; i < len; i++) {
+      for (int64_t i = windowSize; i < len; i++) {
          currentSum += pIn[i];
 
          // subtract the item leaving the window
@@ -211,7 +211,7 @@ public:
    }
 
 
-   static void RollingNanMean(void* pDataIn, void* pDataOut, INT64 len, INT64 windowSize) {
+   static void RollingNanMean(void* pDataIn, void* pDataOut, int64_t len, int64_t windowSize) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -220,7 +220,7 @@ public:
       U count = 0;
 
       // Priming of the summation
-      for (INT64 i = 0; i < len && i < windowSize; i++) {
+      for (int64_t i = 0; i < len && i < windowSize; i++) {
          T temp = pIn[i];
 
          if (temp == temp) {
@@ -230,7 +230,7 @@ public:
          pOut[i] = currentSum/count;
       }
 
-      for (INT64 i = windowSize; i < len; i++) {
+      for (int64_t i = windowSize; i < len; i++) {
          T temp = pIn[i];
 
          if (temp == temp) {
@@ -251,7 +251,7 @@ public:
    }
 
 
-   static void RollingVar(void* pDataIn, void* pDataOut, INT64 len, INT64 windowSize) {
+   static void RollingVar(void* pDataIn, void* pDataOut, int64_t len, int64_t windowSize) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -261,7 +261,7 @@ public:
       U delta;
 
       // Priming of the summation
-      for (INT64 i = 0; i < len && i < windowSize; i++) {
+      for (int64_t i = 0; i < len && i < windowSize; i++) {
          T item = pIn[i];
 
          delta = item - amean;
@@ -272,7 +272,7 @@ public:
 
       U count_inv = (U)1.0 / windowSize;
 
-      for (INT64 i = windowSize; i < len; i++) {
+      for (int64_t i = windowSize; i < len; i++) {
          U item = (U)pIn[i];
          U old = (U)pIn[i - windowSize];
 
@@ -288,7 +288,7 @@ public:
 
 
 
-   static void RollingStd(void* pDataIn, void* pDataOut, INT64 len, INT64 windowSize) {
+   static void RollingStd(void* pDataIn, void* pDataOut, int64_t len, int64_t windowSize) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -298,7 +298,7 @@ public:
       U delta;
 
       // Priming of the summation
-      for (INT64 i = 0; i < len && i < windowSize; i++) {
+      for (int64_t i = 0; i < len && i < windowSize; i++) {
          T item = pIn[i];
 
          delta = item - amean;
@@ -309,7 +309,7 @@ public:
 
       U count_inv = (U)1.0 / windowSize;
 
-      for (INT64 i = windowSize; i < len; i++) {
+      for (int64_t i = windowSize; i < len; i++) {
          U item = (U)pIn[i];
          U old = (U)pIn[i - windowSize];
 
@@ -324,7 +324,7 @@ public:
    }
 
 
-   static void RollingNanVar(void* pDataIn, void* pDataOut, INT64 len, INT64 windowSize) {
+   static void RollingNanVar(void* pDataIn, void* pDataOut, int64_t len, int64_t windowSize) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -335,7 +335,7 @@ public:
       U count = 0;
 
       // Priming of the summation
-      for (INT64 i = 0; i < len && i < windowSize; i++) {
+      for (int64_t i = 0; i < len && i < windowSize; i++) {
          U item = (U)pIn[i];
 
          if (item == item) {
@@ -352,7 +352,7 @@ public:
 
       U count_inv = (U)1.0 / windowSize;
 
-      for (INT64 i = windowSize; i < len; i++) {
+      for (int64_t i = windowSize; i < len; i++) {
          U item = (U)pIn[i];
          U old = (U)pIn[i - windowSize];
 
@@ -404,7 +404,7 @@ public:
 
 
 
-   static void RollingNanStd(void* pDataIn, void* pDataOut, INT64 len, INT64 windowSize) {
+   static void RollingNanStd(void* pDataIn, void* pDataOut, int64_t len, int64_t windowSize) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -415,7 +415,7 @@ public:
       U count = 0;
 
       // Priming of the summation
-      for (INT64 i = 0; i < len && i < windowSize; i++) {
+      for (int64_t i = 0; i < len && i < windowSize; i++) {
          U item = (U)pIn[i];
 
          if (item == item) {
@@ -432,7 +432,7 @@ public:
 
       U count_inv = (U)1.0 / windowSize;
 
-      for (INT64 i = windowSize; i < len; i++) {
+      for (int64_t i = windowSize; i < len; i++) {
          U item = (U)pIn[i];
          U old = (U)pIn[i - windowSize];
 
@@ -483,7 +483,7 @@ public:
 
 
 
-   static ROLLING_FUNC GetRollingFunction(INT64 func) {
+   static ROLLING_FUNC GetRollingFunction(int64_t func) {
       switch (func) {
       case ROLLING_SUM: return RollingSum;
       case ROLLING_NANSUM: return RollingNanSum;
@@ -491,7 +491,7 @@ public:
       return NULL;
    }
 
-   static ROLLING_FUNC GetRollingFunction2(INT64 func) {
+   static ROLLING_FUNC GetRollingFunction2(int64_t func) {
       switch (func) {
       case ROLLING_MEAN: return RollingMean;
       case ROLLING_NANMEAN: return RollingNanMean;
@@ -507,39 +507,39 @@ public:
 
 
 
-ROLLING_FUNC GetRollingFunction(INT64 func, INT32 inputType) {
+ROLLING_FUNC GetRollingFunction(int64_t func, int32_t inputType) {
    switch (inputType) {
-   case NPY_BOOL:   return EmaBase<INT8, INT64>::GetRollingFunction(func);
+   case NPY_BOOL:   return EmaBase<int8_t, int64_t>::GetRollingFunction(func);
    case NPY_FLOAT:  return EmaBase<float, float>::GetRollingFunction(func);
    case NPY_DOUBLE: return EmaBase<double, double>::GetRollingFunction(func);
    case NPY_LONGDOUBLE: return EmaBase<long double, long double>::GetRollingFunction(func);
-   case NPY_INT8:   return EmaBase<INT8, INT64>::GetRollingFunction(func);
-   case NPY_INT16:  return EmaBase<INT16, INT64>::GetRollingFunction(func);
-   CASE_NPY_INT32:  return EmaBase<INT32, INT64>::GetRollingFunction(func);
-   CASE_NPY_UINT32: return EmaBase<UINT32, INT64>::GetRollingFunction(func);
-   CASE_NPY_INT64:  return EmaBase<INT64, INT64>::GetRollingFunction(func);
-   case NPY_UINT8:  return EmaBase<UINT8, INT64>::GetRollingFunction(func);
-   case NPY_UINT16: return EmaBase<UINT16, INT64>::GetRollingFunction(func);
-   CASE_NPY_UINT64: return EmaBase<UINT64, INT64>::GetRollingFunction(func);
+   case NPY_INT8:   return EmaBase<int8_t, int64_t>::GetRollingFunction(func);
+   case NPY_INT16:  return EmaBase<int16_t, int64_t>::GetRollingFunction(func);
+   CASE_NPY_INT32:  return EmaBase<int32_t, int64_t>::GetRollingFunction(func);
+   CASE_NPY_UINT32: return EmaBase<uint32_t, int64_t>::GetRollingFunction(func);
+   CASE_NPY_INT64:  return EmaBase<int64_t, int64_t>::GetRollingFunction(func);
+   case NPY_UINT8:  return EmaBase<uint8_t, int64_t>::GetRollingFunction(func);
+   case NPY_UINT16: return EmaBase<uint16_t, int64_t>::GetRollingFunction(func);
+   CASE_NPY_UINT64: return EmaBase<uint64_t, int64_t>::GetRollingFunction(func);
    }
 
    return NULL;
 }
 
-ROLLING_FUNC GetRollingFunction2(INT64 func, INT32 inputType) {
+ROLLING_FUNC GetRollingFunction2(int64_t func, int32_t inputType) {
    switch (inputType) {
-   case NPY_BOOL:   return EmaBase<INT8, double>::GetRollingFunction2(func);
+   case NPY_BOOL:   return EmaBase<int8_t, double>::GetRollingFunction2(func);
    case NPY_FLOAT:  return EmaBase<float, float>::GetRollingFunction2(func);
    case NPY_DOUBLE: return EmaBase<double, double>::GetRollingFunction2(func);
    case NPY_LONGDOUBLE: return EmaBase<long double, long double>::GetRollingFunction2(func);
-   case NPY_INT8:   return EmaBase<INT8, double>::GetRollingFunction2(func);
-   case NPY_INT16:  return EmaBase<INT16, double>::GetRollingFunction2(func);
-   CASE_NPY_INT32:  return EmaBase<INT32, double>::GetRollingFunction2(func);
-   CASE_NPY_UINT32:  return EmaBase<UINT32, double>::GetRollingFunction2(func);
-   CASE_NPY_INT64:  return EmaBase<INT64, double>::GetRollingFunction2(func);
-   case NPY_UINT8:  return EmaBase<UINT8, double>::GetRollingFunction2(func);
-   case NPY_UINT16: return EmaBase<UINT16, double>::GetRollingFunction2(func);
-   CASE_NPY_UINT64: return EmaBase<UINT64, double>::GetRollingFunction2(func);
+   case NPY_INT8:   return EmaBase<int8_t, double>::GetRollingFunction2(func);
+   case NPY_INT16:  return EmaBase<int16_t, double>::GetRollingFunction2(func);
+   CASE_NPY_INT32:  return EmaBase<int32_t, double>::GetRollingFunction2(func);
+   CASE_NPY_UINT32:  return EmaBase<uint32_t, double>::GetRollingFunction2(func);
+   CASE_NPY_INT64:  return EmaBase<int64_t, double>::GetRollingFunction2(func);
+   case NPY_UINT8:  return EmaBase<uint8_t, double>::GetRollingFunction2(func);
+   case NPY_UINT16: return EmaBase<uint16_t, double>::GetRollingFunction2(func);
+   CASE_NPY_UINT64: return EmaBase<uint64_t, double>::GetRollingFunction2(func);
    }
 
    return NULL;
@@ -558,8 +558,8 @@ PyObject *
 Rolling(PyObject *self, PyObject *args)
 {
    PyArrayObject* inArrObject = NULL;
-   INT64 func = 0;
-   INT64 param1 = 0;
+   int64_t func = 0;
+   int64_t param1 = 0;
 
    if (!PyArg_ParseTuple(
       args, "O!LL",
@@ -571,19 +571,19 @@ Rolling(PyObject *self, PyObject *args)
    }
 
    // TODO: determine based on function
-   INT32 numpyOutType = NPY_FLOAT64;
+   int32_t numpyOutType = NPY_FLOAT64;
 
    // In case user passes in sliced array or reversed array
    PyArrayObject* inArr = EnsureContiguousArray(inArrObject);
    if (!inArr) return NULL;
 
-   INT32 dType = PyArray_TYPE(inArr);
+   int32_t dType = PyArray_TYPE(inArr);
 
    PyArrayObject* outArray = NULL;
-   INT64 size = ArrayLength(inArr);
+   int64_t size = ArrayLength(inArr);
    ROLLING_FUNC pRollingFunc;
 
-   numpyOutType = NPY_INT64;
+   numpyOutType = NPY_int64_t;
 
    if (func >= 100) {
       pRollingFunc = GetRollingFunction2(func, dType);
@@ -602,7 +602,7 @@ Rolling(PyObject *self, PyObject *args)
       pRollingFunc = GetRollingFunction(func, dType);
 
       // Always want some sort of int64 or float
-      numpyOutType = NPY_INT64;
+      numpyOutType = NPY_int64_t;
       if (dType == NPY_FLOAT) {
          numpyOutType = NPY_FLOAT;
       }
@@ -639,17 +639,17 @@ Rolling(PyObject *self, PyObject *args)
 //-------------------------------------------------------------------
 // T = data type as input
 // U = data type as output
-// K = data type for indexing (often INT32* or INT8*)
+// K = data type for indexing (often int32_t* or int8_t*)
 template<typename T, typename U, typename K>
 static void CumSum(
    void*    pKeyT,
    void*    pAccumBin,
    void*    pColumn,
-   INT64    numUnique,
-   INT64    totalInputRows,
+   int64_t    numUnique,
+   int64_t    totalInputRows,
    void*    pTime1, // not used
-   INT8*    pIncludeMask,
-   INT8*    pResetMask,
+   int8_t*    pIncludeMask,
+   int8_t*    pResetMask,
    double   windowSize1) {
 
    T* pSrc = (T*)pColumn;
@@ -658,12 +658,12 @@ static void CumSum(
 
    U Invalid = GET_INVALID(pDest[0]);
 
-   INT32 windowSize = (INT32)windowSize1;
+   int32_t windowSize = (int32_t)windowSize1;
 
-   LOGGING("cumsum %lld  %lld  %lld  %p  %p\n", numUnique, totalInputRows, (INT64)Invalid, pIncludeMask, pResetMask);
+   LOGGING("cumsum %lld  %lld  %lld  %p  %p\n", numUnique, totalInputRows, (int64_t)Invalid, pIncludeMask, pResetMask);
 
    // Alloc a workspace
-   INT64 size = (numUnique + GB_BASE_INDEX) * sizeof(U);
+   int64_t size = (numUnique + GB_BASE_INDEX) * sizeof(U);
    U* pWorkSpace = (U*)WORKSPACE_ALLOC(size);
 
    // Default every bin to 0, including floats
@@ -694,7 +694,7 @@ static void CumSum(
             // Bin 0 is bad
             if (location >= GB_BASE_INDEX) {
                if (pIncludeMask[i] != 0) {
-                  //printf("adding %lld to %lld,", (INT64)pSrc[location], (INT64)pWorkSpace[location]);
+                  //printf("adding %lld to %lld,", (int64_t)pSrc[location], (int64_t)pWorkSpace[location]);
                   pWorkSpace[location] += (U)pSrc[i];
                }
                pDest[i] = pWorkSpace[location];
@@ -733,7 +733,7 @@ static void CumSum(
                pDest[i] = pWorkSpace[location];
             }
             else {
-               // out of range bin printf("!!!%d --- %lld\n", i, (INT64)Invalid);
+               // out of range bin printf("!!!%d --- %lld\n", i, (int64_t)Invalid);
                pDest[i] = Invalid;
             }
          }
@@ -749,17 +749,17 @@ static void CumSum(
 //-------------------------------------------------------------------
 // T = data type as input
 // U = data type as output
-// K = key index pointer type (INT32* or INT8*)
+// K = key index pointer type (int32_t* or int8_t*)
 template<typename T, typename U, typename K>
 static void CumProd(
    void*    pKeyT,
    void*    pAccumBin,
    void*    pColumn,
-   INT64    numUnique,
-   INT64    totalInputRows,
+   int64_t    numUnique,
+   int64_t    totalInputRows,
    void*    pTime1, // not used
-   INT8*    pIncludeMask,
-   INT8*    pResetMask,
+   int8_t*    pIncludeMask,
+   int8_t*    pResetMask,
    double   windowSize1) {
 
    T* pSrc = (T*)pColumn;
@@ -768,12 +768,12 @@ static void CumProd(
 
    U Invalid = GET_INVALID(pDest[0]);
 
-   INT32 windowSize = (INT32)windowSize1;
+   int32_t windowSize = (int32_t)windowSize1;
 
    LOGGING("cumprod %lld  %lld  %p  %p\n", numUnique, totalInputRows, pIncludeMask, pResetMask);
 
    // Alloc a workspace
-   INT64 size = (numUnique + GB_BASE_INDEX) * sizeof(U);
+   int64_t size = (numUnique + GB_BASE_INDEX) * sizeof(U);
    U* pWorkSpace = (U*)WORKSPACE_ALLOC(size);
 
    // Default every bin to 1, including floats
@@ -871,17 +871,17 @@ static void CumProd(
 //-------------------------------------------------------------------
 // T = data type as input (NOT USED)
 // U = data type as output
-// K = key index pointer type (INT32* or INT8*)
+// K = key index pointer type (int32_t* or int8_t*)
 template<typename U, typename K>
 static void FindNth(
    void*    pKeyT,
    void*    pAccumBin,
    void*    pColumn,
-   INT64    numUnique,
-   INT64    totalInputRows,
+   int64_t    numUnique,
+   int64_t    totalInputRows,
    void*    pTime1, // not used
-   INT8*    pIncludeMask,
-   INT8*    pResetMask,
+   int8_t*    pIncludeMask,
+   int8_t*    pResetMask,
    double   windowSize1) {
 
    U* pDest = (U*)pAccumBin;
@@ -890,7 +890,7 @@ static void FindNth(
    LOGGING("FindNth %lld  %lld  %p  %p\n", numUnique, totalInputRows, pIncludeMask, pResetMask);
 
    // Alloc a workspace
-   INT64 size = (numUnique + GB_BASE_INDEX) * sizeof(U);
+   int64_t size = (numUnique + GB_BASE_INDEX) * sizeof(U);
    U* pWorkSpace = (U*)WORKSPACE_ALLOC(size);
 
    memset(pWorkSpace, 0, size);
@@ -933,7 +933,7 @@ static void FindNth(
 // T = data type as input
 // U = data type as output (always double?)
 // V = time datatype
-// K = key index data type (INT32* or INT8*)
+// K = key index data type (int32_t* or int8_t*)
 // thus <float, double, int64> 
 template<typename T, typename U, typename V, typename K>
 class EmaByBase {
@@ -954,11 +954,11 @@ public:
       void*    pKeyT,
       void*    pAccumBin, 
       void*    pColumn, 
-      INT64    numUnique, 
-      INT64    totalInputRows, 
+      int64_t    numUnique, 
+      int64_t    totalInputRows, 
       void*    pTime1,
-      INT8*    pIncludeMask,
-      INT8*    pResetMask, 
+      int8_t*    pIncludeMask,
+      int8_t*    pResetMask, 
       double   decayRate) {
 
       T* pSrc = (T*)pColumn;
@@ -972,7 +972,7 @@ public:
       // lastEma -- type U
       // lastTime -- type V
 
-      INT64 size = (numUnique + GB_BASE_INDEX) * sizeof(U);
+      int64_t size = (numUnique + GB_BASE_INDEX) * sizeof(U);
       U* pLastEma = (U*)WORKSPACE_ALLOC(size);
 
       // Default every bin to 0, including floats
@@ -1089,7 +1089,7 @@ public:
                if (location >= GB_BASE_INDEX) {
                   //printf("inputs: %lf  %lf  %lf  %lf  %lf\n", (double)pSrc[i], (double)pLastEma[location], (double)-decayRate, (double)pTime[i], (double)pLastTime[location] );
                   pLastEma[location] = pSrc[i] + pLastEma[location] * exp(-decayRate * (pTime[i] - pLastTime[location]));
-                  //printf("[%d][%d] %lf\n", i, (INT32)location, (double)pLastEma[location]);
+                  //printf("[%d][%d] %lf\n", i, (int32_t)location, (double)pLastEma[location]);
                   pLastTime[location] = pTime[i];
                   pDest[i] = pLastEma[location];
                }
@@ -1130,11 +1130,11 @@ public:
       void*    pKeyT,
       void*    pAccumBin,
       void*    pColumn,
-      INT64    numUnique,
-      INT64    totalInputRows,
+      int64_t    numUnique,
+      int64_t    totalInputRows,
       void*    pTime1,
-      INT8*    pIncludeMask,
-      INT8*    pResetMask,
+      int8_t*    pIncludeMask,
+      int8_t*    pResetMask,
       double   decayRate) {
 
       T* pSrc = (T*)pColumn;
@@ -1148,14 +1148,14 @@ public:
       // lastEma -- type U
       // lastTime -- type V
 
-      INT64 size = (numUnique + GB_BASE_INDEX) * sizeof(U);
+      int64_t size = (numUnique + GB_BASE_INDEX) * sizeof(U);
       U* pLastEma = (U*)WORKSPACE_ALLOC(size);
 
       // Default every bin to 0, including floats
       //memset(pLastEma, 0, size);
       // the first value should be valid
       // go backwards so that first value is in there
-      for (INT64 i = totalInputRows - 1; i >= 0; i--)
+      for (int64_t i = totalInputRows - 1; i >= 0; i--)
       {
          K location = pKey[i];
          T value = pSrc[i];
@@ -1182,7 +1182,7 @@ public:
       else {
          largeNegative = (V)0x8000000000000000LL;
       }
-      for (INT64 i = 0; i < (numUnique + GB_BASE_INDEX); i++) {
+      for (int64_t i = 0; i < (numUnique + GB_BASE_INDEX); i++) {
          pLastTime[i] = largeNegative;
       }
 
@@ -1192,7 +1192,7 @@ public:
          // filter loop
          if (pResetMask != NULL) {
             // filter + reset
-            for (INT64 i = 0; i < totalInputRows; i++) {
+            for (int64_t i = 0; i < totalInputRows; i++) {
                K location = pKey[i];
                // Bin 0 is bad
                if (location >= GB_BASE_INDEX) {
@@ -1222,7 +1222,7 @@ public:
          }
          else {
             // filter only
-            for (INT64 i = 0; i < totalInputRows; i++) {
+            for (int64_t i = 0; i < totalInputRows; i++) {
                K location = pKey[i];
 
                // Bin 0 is bad
@@ -1250,7 +1250,7 @@ public:
       else {
          if (pResetMask != NULL) {
             // reset loop
-            for (INT64 i = 0; i < totalInputRows; i++) {
+            for (int64_t i = 0; i < totalInputRows; i++) {
                K location = pKey[i];
 
                // Bin 0 is bad
@@ -1269,14 +1269,14 @@ public:
          }
          else {
             // plain loop (no reset / no filter)
-            for (INT64 i = 0; i < totalInputRows; i++) {
+            for (int64_t i = 0; i < totalInputRows; i++) {
                K location = pKey[i];
 
                // Bin 0 is bad
                if (location >= GB_BASE_INDEX) {
                   T value = pSrc[i];
                   //double DW = exp(-decayRate * (pTime[i] - pLastTime[location])); 
-                  //printf("**dw %lf  %lld  %lld\n", DW, (INT64)pTime[i], (INT64)pLastTime[location]);
+                  //printf("**dw %lf  %lld  %lld\n", DW, (int64_t)pTime[i], (int64_t)pLastTime[location]);
                   EMA_NORMAL_FUNC
                }
                else {
@@ -1312,11 +1312,11 @@ public:
       void*    pKeyT,
       void*    pAccumBin,
       void*    pColumn,
-      INT64    numUnique,
-      INT64    totalInputRows,
+      int64_t    numUnique,
+      int64_t    totalInputRows,
       void*    pTime1,
-      INT8*    pIncludeMask,
-      INT8*    pResetMask,
+      int8_t*    pIncludeMask,
+      int8_t*    pResetMask,
       double   decayedWeight) {
 
       T* pSrc = (T*)pColumn;
@@ -1329,7 +1329,7 @@ public:
       // lastEma -- type U
       // lastTime -- type V
 
-      INT64 size = (numUnique + GB_BASE_INDEX) * sizeof(U);
+      int64_t size = (numUnique + GB_BASE_INDEX) * sizeof(U);
       U* pLastEma = (U*)WORKSPACE_ALLOC(size);
 
       // Default every bin to 0, including floats
@@ -1337,7 +1337,7 @@ public:
 
       // the first value should be valid
       // go backwards so that first value is in there
-      for (INT64 i = totalInputRows - 1; i >= 0; i--)
+      for (int64_t i = totalInputRows - 1; i >= 0; i--)
       {
          K location = pKey[i];
          T value = pSrc[i];
@@ -1350,7 +1350,7 @@ public:
          // filter loop
          if (pResetMask != NULL) {
             // filter + reset
-            for (INT64 i = 0; i < totalInputRows; i++) {
+            for (int64_t i = 0; i < totalInputRows; i++) {
                K location = pKey[i];
                // Bin 0 is bad
                if (location >= GB_BASE_INDEX) {
@@ -1375,7 +1375,7 @@ public:
          }
          else {
             // filter only
-            for (INT64 i = 0; i < totalInputRows; i++) {
+            for (int64_t i = 0; i < totalInputRows; i++) {
                K location = pKey[i];
 
                // Bin 0 is bad
@@ -1397,7 +1397,7 @@ public:
       else {
          if (pResetMask != NULL) {
             // reset loop
-            for (INT64 i = 0; i < totalInputRows; i++) {
+            for (int64_t i = 0; i < totalInputRows; i++) {
                K location = pKey[i];
 
                // Bin 0 is bad
@@ -1415,13 +1415,13 @@ public:
          }
          else {
             // plain loop (no reset / no filter)
-            for (INT64 i = 0; i < totalInputRows; i++) {
+            for (int64_t i = 0; i < totalInputRows; i++) {
                K location = pKey[i];
 
                // Bin 0 is bad
                if (location >= GB_BASE_INDEX) {
                   T value = pSrc[i];
-                  //printf("**dw %d  %d   %lld %lld\n", i, (int)location, (INT64)value, (INT64)pLastEma[location]);
+                  //printf("**dw %d  %d   %lld %lld\n", i, (int)location, (int64_t)value, (int64_t)pLastEma[location]);
                   EMA_WEIGHTED_FUNC
                }
                else {
@@ -1466,10 +1466,10 @@ static EMA_BY_TWO_FUNC GetEmaByStep2(int timeType, EMA_FUNCTIONS func) {
    case NPY_FLOAT:  return EmaByBase<T, double, float, K>::GetFunc(func);
    case NPY_DOUBLE: return EmaByBase<T, double, double, K>::GetFunc(func);
    case NPY_LONGDOUBLE: return EmaByBase<T, long double, long double, K>::GetFunc(func);
-   CASE_NPY_INT32:  return EmaByBase<T, double, INT32, K>::GetFunc(func);
-   CASE_NPY_INT64:  return EmaByBase<T, double, INT64, K>::GetFunc(func);
-   CASE_NPY_UINT32: return EmaByBase<T, double, UINT32, K>::GetFunc(func);
-   CASE_NPY_UINT64: return EmaByBase<T, double, UINT64, K>::GetFunc(func);
+   CASE_NPY_INT32:  return EmaByBase<T, double, int32_t, K>::GetFunc(func);
+   CASE_NPY_INT64:  return EmaByBase<T, double, int64_t, K>::GetFunc(func);
+   CASE_NPY_UINT32: return EmaByBase<T, double, uint32_t, K>::GetFunc(func);
+   CASE_NPY_UINT64: return EmaByBase<T, double, uint64_t, K>::GetFunc(func);
    }
    return NULL;
 
@@ -1489,16 +1489,16 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_FLOAT:  *outputType = NPY_FLOAT32; return CumSum<float, float, K>;
       case NPY_DOUBLE: *outputType = NPY_FLOAT64; return CumSum<double, double, K> ;
       case NPY_LONGDOUBLE: *outputType = NPY_FLOAT64; return CumSum<long double, long double, K>;
-      case NPY_BOOL:   *outputType = NPY_INT64; return CumSum<INT8, INT64, K>;
-      case NPY_INT8:   *outputType = NPY_INT64; return CumSum<INT8, INT64, K>;
-      case NPY_INT16:  *outputType = NPY_INT64; return CumSum<INT16, INT64, K>;
-      CASE_NPY_INT32:  *outputType = NPY_INT64; return CumSum<INT32, INT64, K>;
-      CASE_NPY_INT64:  *outputType = NPY_INT64; return CumSum<INT64, INT64, K>;
+      case NPY_BOOL:   *outputType = NPY_int64_t; return CumSum<int8_t, int64_t, K>;
+      case NPY_INT8:   *outputType = NPY_int64_t; return CumSum<int8_t, int64_t, K>;
+      case NPY_INT16:  *outputType = NPY_int64_t; return CumSum<int16_t, int64_t, K>;
+      CASE_NPY_INT32:  *outputType = NPY_int64_t; return CumSum<int32_t, int64_t, K>;
+      CASE_NPY_INT64:  *outputType = NPY_int64_t; return CumSum<int64_t, int64_t, K>;
 
-      case NPY_UINT8:  *outputType = NPY_UINT64; return CumSum<UINT8,  UINT64, K>;
-      case NPY_UINT16: *outputType = NPY_UINT64; return CumSum<UINT16, UINT64, K>;
-      CASE_NPY_UINT32: *outputType = NPY_UINT64; return CumSum<UINT32, UINT64, K>;
-      CASE_NPY_UINT64: *outputType = NPY_UINT64; return CumSum<UINT64, UINT64, K>;
+      case NPY_UINT8:  *outputType = NPY_uint64_t; return CumSum<uint8_t,  uint64_t, K>;
+      case NPY_UINT16: *outputType = NPY_uint64_t; return CumSum<uint16_t, uint64_t, K>;
+      CASE_NPY_UINT32: *outputType = NPY_uint64_t; return CumSum<uint32_t, uint64_t, K>;
+      CASE_NPY_UINT64: *outputType = NPY_uint64_t; return CumSum<uint64_t, uint64_t, K>;
 
       }
       break;
@@ -1508,23 +1508,23 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_FLOAT:  *outputType = NPY_FLOAT32; return CumProd<float, float, K>;
       case NPY_DOUBLE: *outputType = NPY_FLOAT64; return CumProd<double, double, K>;
       case NPY_LONGDOUBLE: *outputType = NPY_FLOAT64; return CumProd<long double, long double, K>;
-      case NPY_BOOL:   *outputType = NPY_INT64; return CumProd<INT8, INT64, K>;
-      case NPY_INT8:   *outputType = NPY_INT64; return CumProd<INT8, INT64, K>;
-      case NPY_INT16:  *outputType = NPY_INT64; return CumProd<INT16, INT64, K>;
-      CASE_NPY_INT32:  *outputType = NPY_INT64; return CumProd<INT32, INT64, K>;
-      CASE_NPY_INT64:  *outputType = NPY_INT64; return CumProd<INT64, INT64, K>;
+      case NPY_BOOL:   *outputType = NPY_int64_t; return CumProd<int8_t, int64_t, K>;
+      case NPY_INT8:   *outputType = NPY_int64_t; return CumProd<int8_t, int64_t, K>;
+      case NPY_INT16:  *outputType = NPY_int64_t; return CumProd<int16_t, int64_t, K>;
+      CASE_NPY_INT32:  *outputType = NPY_int64_t; return CumProd<int32_t, int64_t, K>;
+      CASE_NPY_INT64:  *outputType = NPY_int64_t; return CumProd<int64_t, int64_t, K>;
 
-      case NPY_UINT8:  *outputType = NPY_UINT64; return CumProd<UINT8, UINT64, K>;
-      case NPY_UINT16: *outputType = NPY_UINT64; return CumProd<UINT16, UINT64, K>;
-      CASE_NPY_UINT32: *outputType = NPY_UINT64; return CumProd<UINT32, UINT64, K>;
-      CASE_NPY_UINT64: *outputType = NPY_UINT64; return CumProd<UINT64, UINT64, K>;
+      case NPY_UINT8:  *outputType = NPY_uint64_t; return CumProd<uint8_t, uint64_t, K>;
+      case NPY_UINT16: *outputType = NPY_uint64_t; return CumProd<uint16_t, uint64_t, K>;
+      CASE_NPY_UINT32: *outputType = NPY_uint64_t; return CumProd<uint32_t, uint64_t, K>;
+      CASE_NPY_UINT64: *outputType = NPY_uint64_t; return CumProd<uint64_t, uint64_t, K>;
 
       }
       break;
 
 
    case EMA_FINDNTH:
-      *outputType = NPY_INT32; return FindNth< INT32, K>;
+      *outputType = NPY_int32_t; return FindNth< int32_t, K>;
       break;
 
    case EMA_NORMAL:
@@ -1532,18 +1532,18 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
    case EMA_DECAY:
       *outputType = NPY_FLOAT64;
       switch (inputType) {
-      case NPY_BOOL:   return GetEmaByStep2<INT8, K>(timeType, func);
+      case NPY_BOOL:   return GetEmaByStep2<int8_t, K>(timeType, func);
       case NPY_FLOAT:  return GetEmaByStep2<float, K>(timeType, func);
       case NPY_DOUBLE: return GetEmaByStep2<double, K>(timeType, func);
       case NPY_LONGDOUBLE: return GetEmaByStep2<long double, K>(timeType, func);
-      case NPY_INT8:   return GetEmaByStep2<INT8, K>(timeType, func);
-      case NPY_INT16:  return GetEmaByStep2<INT16, K>(timeType, func);
-      CASE_NPY_INT32:  return GetEmaByStep2<INT32, K>(timeType, func);
-      CASE_NPY_INT64:  return GetEmaByStep2<INT64, K>(timeType, func);
-      case NPY_UINT8:  return GetEmaByStep2<UINT8, K>(timeType, func);
-      case NPY_UINT16: return GetEmaByStep2<UINT16, K>(timeType, func);
-      CASE_NPY_UINT32: return GetEmaByStep2<UINT32, K>(timeType, func);
-      CASE_NPY_UINT64: return GetEmaByStep2<UINT64, K>(timeType, func);
+      case NPY_INT8:   return GetEmaByStep2<int8_t, K>(timeType, func);
+      case NPY_INT16:  return GetEmaByStep2<int16_t, K>(timeType, func);
+      CASE_NPY_INT32:  return GetEmaByStep2<int32_t, K>(timeType, func);
+      CASE_NPY_INT64:  return GetEmaByStep2<int64_t, K>(timeType, func);
+      case NPY_UINT8:  return GetEmaByStep2<uint8_t, K>(timeType, func);
+      case NPY_UINT16: return GetEmaByStep2<uint16_t, K>(timeType, func);
+      CASE_NPY_UINT32: return GetEmaByStep2<uint32_t, K>(timeType, func);
+      CASE_NPY_UINT64: return GetEmaByStep2<uint64_t, K>(timeType, func);
 
       }
       break;
@@ -1562,22 +1562,22 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
 // BOTH groupby versions call this routine
 // ** THIS ROUTINE IS CALLED FROM MULTIPLE CONCURRENT THREADS!
 // i is the column number
-void EmaByCall(void* pEmaBy, INT64 i) {
+void EmaByCall(void* pEmaBy, int64_t i) {
 
    stEma32* pstEma32 = (stEma32*)pEmaBy;
 
    ArrayInfo* aInfo = pstEma32->aInfo;
-   INT64 uniqueRows = pstEma32->uniqueRows;
+   int64_t uniqueRows = pstEma32->uniqueRows;
 
    EMA_FUNCTIONS func = (EMA_FUNCTIONS)pstEma32->funcNum;
 
    // Data in was passed
    void* pDataIn = aInfo[i].pData;
-   INT64 len = aInfo[i].ArrayLength;
+   int64_t len = aInfo[i].ArrayLength;
 
    PyArrayObject* outArray = pstEma32->returnObjects[i].outArray;
    EMA_BY_TWO_FUNC  pFunction = pstEma32->returnObjects[i].pFunction;
-   INT32 numpyOutType = pstEma32->returnObjects[i].numpyOutType;
+   int32_t numpyOutType = pstEma32->returnObjects[i].numpyOutType;
    TYPE_OF_FUNCTION_CALL typeCall = pstEma32->typeOfFunctionCall;
 
    if (outArray && pFunction) {
@@ -1627,7 +1627,7 @@ void EmaByCall(void* pEmaBy, INT64 i) {
 
 //---------------------------------------------------------------
 // Arg1 = LIST of numpy arrays which has the values to accumulate (often all the columns in a dataset)
-// Arg2 = iKey = numpy array (INT32) which has the index to the unique keys (ikey from MultiKeyGroupBy32)
+// Arg2 = iKey = numpy array (int32_t) which has the index to the unique keys (ikey from MultiKeyGroupBy32)
 // Arg3 = integer unique rows
 // Arg4 = integer (function number to execute for cumsum, ema)
 // Arg5 = params for function must be (decay/window, time, includemask, resetmask)
@@ -1645,8 +1645,8 @@ EmaAll32(PyObject *self, PyObject *args)
    PyArrayObject *inResetMask = NULL;
 
    double doubleParam = 0.0;
-   INT64 unique_rows = 0;
-   INT64 funcNum = 0;
+   int64_t unique_rows = 0;
+   int64_t funcNum = 0;
 
    if (!PyArg_ParseTuple(
       args, "OO!LLO",
@@ -1664,7 +1664,7 @@ EmaAll32(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   INT32 iKeyType = PyArray_TYPE(iKey);
+   int32_t iKeyType = PyArray_TYPE(iKey);
 
    switch (iKeyType) {
    case NPY_INT8:
@@ -1714,7 +1714,7 @@ EmaAll32(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   INT64 totalArrayLength = ArrayLength(iKey);
+   int64_t totalArrayLength = ArrayLength(iKey);
 
    if (inResetMask != NULL && (PyArray_TYPE(inResetMask) != 0 || ArrayLength(inResetMask) != totalArrayLength)) {
       PyErr_Format(PyExc_ValueError, "EmaAll32 inResetMask must be a bool mask of same size");
@@ -1731,10 +1731,10 @@ EmaAll32(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   INT32 numpyInType2 = ObjectToDtype(iKey);
+   int32_t numpyInType2 = ObjectToDtype(iKey);
 
-   INT64 totalItemSize = 0;
-   ArrayInfo* aInfo = BuildArrayInfo(inList1, (INT64*)&tupleSize, &totalItemSize);
+   int64_t totalItemSize = 0;
+   ArrayInfo* aInfo = BuildArrayInfo(inList1, (int64_t*)&tupleSize, &totalItemSize);
 
    if (!aInfo) {
       PyErr_Format(PyExc_ValueError, "EmaAll32 failed to produce aInfo");
@@ -1747,15 +1747,15 @@ EmaAll32(PyObject *self, PyObject *args)
    stEma32* pstEma32 = (stEma32*)WORKSPACE_ALLOC((sizeof(stEma32) + 8 + sizeof(stEmaReturn))*tupleSize);
 
    pstEma32->aInfo = aInfo;
-   pstEma32->funcNum = (INT32)funcNum;
-   pstEma32->pKey = (INT32*)PyArray_BYTES(iKey);
+   pstEma32->funcNum = (int32_t)funcNum;
+   pstEma32->pKey = (int32_t*)PyArray_BYTES(iKey);
    pstEma32->tupleSize = tupleSize;
    pstEma32->uniqueRows = unique_rows;
    pstEma32->totalInputRows = totalArrayLength;
    pstEma32->doubleParam = doubleParam;
    pstEma32->pTime = inTime == NULL ? NULL : PyArray_BYTES(inTime);
-   pstEma32->inIncludeMask = inIncludeMask == NULL ? NULL : (INT8*)PyArray_BYTES(inIncludeMask);
-   pstEma32->inResetMask = inResetMask == NULL ? NULL : (INT8*)PyArray_BYTES(inResetMask);
+   pstEma32->inIncludeMask = inIncludeMask == NULL ? NULL : (int8_t*)PyArray_BYTES(inIncludeMask);
+   pstEma32->inResetMask = inResetMask == NULL ? NULL : (int8_t*)PyArray_BYTES(inResetMask);
    pstEma32->typeOfFunctionCall = TYPE_OF_FUNCTION_CALL::ANY_GROUPBY_FUNC;
 
    LOGGING("Ema unique %lld  total: %lld  arrays: %p %p %p\n", unique_rows, totalArrayLength, pstEma32->pTime, pstEma32->inIncludeMask, pstEma32->inResetMask);
@@ -1763,21 +1763,21 @@ EmaAll32(PyObject *self, PyObject *args)
    // Allocate all the memory and output arrays up front since Python is single threaded
    for (int i = 0; i < tupleSize; i++) {
       // TODO: determine based on function
-      INT32 numpyOutType = -1;
+      int32_t numpyOutType = -1;
 
       EMA_BY_TWO_FUNC  pFunction = NULL;
       switch (iKeyType) {
       case NPY_INT8:
-         pFunction = GetEmaByFunction<INT8>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
+         pFunction = GetEmaByFunction<int8_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
       case NPY_INT16:
-         pFunction = GetEmaByFunction<INT16>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
+         pFunction = GetEmaByFunction<int16_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
       CASE_NPY_INT32:
-         pFunction = GetEmaByFunction<INT32>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
+         pFunction = GetEmaByFunction<int32_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
       CASE_NPY_INT64:
-         pFunction = GetEmaByFunction<INT64>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
+         pFunction = GetEmaByFunction<int64_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
       }
 
@@ -1839,7 +1839,7 @@ EmaAll32(PyObject *self, PyObject *args)
 // N: first dimension length
 // M: second dimension length (must be > 1)
 template<typename T>
-void mat_interp_extrap(void* xT, void* xpT, void* ypT, void* outT, INT64 N, INT64 M, INT32 clip) {
+void mat_interp_extrap(void* xT, void* xpT, void* ypT, void* outT, int64_t N, int64_t M, int32_t clip) {
 
    T* x = (T*)xT;
    T* xp = (T*)xpT;
@@ -1850,13 +1850,13 @@ void mat_interp_extrap(void* xT, void* xpT, void* ypT, void* outT, INT64 N, INT6
 
    if (!clip) {
       // auto increment xp and yp
-      for (INT64 i = 0; i < N; ++i, xp += M, yp += M) {
+      for (int64_t i = 0; i < N; ++i, xp += M, yp += M) {
          T xi = x[i];
          T result = mynan;
 
          if (xi == xi) {
             if (xi > xp[0]) {
-               INT64 j = 1;
+               int64_t j = 1;
                while (xi > xp[j] && j < M) j++;
                if (j == M) {
                   T right_slope = (yp[M - 1] - yp[M - 2]) / (xp[M - 1] - xp[M - 2]);
@@ -1877,13 +1877,13 @@ void mat_interp_extrap(void* xT, void* xpT, void* ypT, void* outT, INT64 N, INT6
    }
    else {
       // clipping
-      for (INT64 i = 0; i < N; ++i, xp += M, yp += M) {
+      for (int64_t i = 0; i < N; ++i, xp += M, yp += M) {
          T xi = x[i];
          T result=mynan;
 
          if (xi == xi) {
             if (xi > xp[0]) {
-               INT64 j = 1;
+               int64_t j = 1;
                while (xi > xp[j] && j < M) j++;
                if (j == M) {
                   result = yp[M - 1];
@@ -1904,7 +1904,7 @@ void mat_interp_extrap(void* xT, void* xpT, void* ypT, void* outT, INT64 N, INT6
 
 
 template<typename T>
-void mat_interp(void* xT, void* xpT, void* ypT, void* outT, INT64 N, INT64 M, INT32 clip) {
+void mat_interp(void* xT, void* xpT, void* ypT, void* outT, int64_t N, int64_t M, int32_t clip) {
 
    T* x = (T*)xT;
    T* xp = (T*)xpT;
@@ -1916,13 +1916,13 @@ void mat_interp(void* xT, void* xpT, void* ypT, void* outT, INT64 N, INT64 M, IN
    T mynan = std::numeric_limits<T>::quiet_NaN();
 
    if (!clip) {
-      for (INT64 i = 0; i < N; ++i) {
+      for (int64_t i = 0; i < N; ++i) {
          T xi = x[i];
          T result = mynan;
 
          if (xi == xi) {
             if (xi > xp0) {
-               INT64 j = 1;
+               int64_t j = 1;
                while (xi > xp[j] && j < M) j++;
                if (j == M) {
                   T right_slope = (yp[M - 1] - yp[M - 2]) / (xp[M - 1] - xp[M - 2]);
@@ -1942,13 +1942,13 @@ void mat_interp(void* xT, void* xpT, void* ypT, void* outT, INT64 N, INT64 M, IN
       }
    }
    else {
-      for (INT64 i = 0; i < N; ++i) {
+      for (int64_t i = 0; i < N; ++i) {
          T xi = x[i];
          T result = mynan;
 
          if (xi == xi) {
             if (xi > xp0) {
-               INT64 j = 1;
+               int64_t j = 1;
                while (xi > xp[j] && j < M) j++;
                if (j == M) {
                   // clipped
@@ -1975,10 +1975,10 @@ struct stInterp {
    char* xp;
    char* yp;
    char* out;
-   INT64 N;
-   INT64 M;
-   INT32 mode;
-   INT32 clip;
+   int64_t N;
+   int64_t M;
+   int32_t mode;
+   int32_t clip;
    int itemsize;
 };
 
@@ -1986,15 +1986,15 @@ struct stInterp {
 // multithreaded callback
 // move pointers to start offset
 // shrink N to what length is
-BOOL InterpolateExtrap(void* callbackArgT, int core, INT64 start, INT64 length) {
+bool InterpolateExtrap(void* callbackArgT, int core, int64_t start, int64_t length) {
    stInterp* pInterp = (stInterp*)callbackArgT;
-   INT64 M = pInterp->M;
-   INT64 N = pInterp->N;
-   INT32 clip = pInterp->clip;
+   int64_t M = pInterp->M;
+   int64_t N = pInterp->N;
+   int32_t clip = pInterp->clip;
 
-   INT64 fixup = start * pInterp->itemsize;
+   int64_t fixup = start * pInterp->itemsize;
    if (pInterp->mode == 2) {
-      INT64 fixup2d = start * pInterp->itemsize* M;
+      int64_t fixup2d = start * pInterp->itemsize* M;
       if (pInterp->itemsize == 8) {
          mat_interp_extrap<double>(
             pInterp->x + fixup,
@@ -2055,8 +2055,8 @@ BOOL InterpolateExtrap(void* callbackArgT, int core, INT64 start, INT64 length) 
    PyArrayObject* xp;
    PyArrayObject* yp;
    PyArrayObject* returnArray; // we allocate this
-   INT32 clip = 0;
-   INT32 mode = 0;
+   int32_t clip = 0;
+   int32_t mode = 0;
 
    if (!PyArg_ParseTuple(args, "O!O!O!|i",
       &PyArray_Type, &arr,
@@ -2091,8 +2091,8 @@ BOOL InterpolateExtrap(void* callbackArgT, int core, INT64 start, INT64 length) 
    }
    // NOTE: could check for strides also here
 
-   INT64 N = PyArray_DIM(arr, 0);
-   INT64 M = 0;
+   int64_t N = PyArray_DIM(arr, 0);
+   int64_t M = 0;
 
    if (mode == 2) {
       if ((N != PyArray_DIM(xp, 0)) || (N != PyArray_DIM(yp, 0))) {
@@ -2159,8 +2159,8 @@ BOOL InterpolateExtrap(void* callbackArgT, int core, INT64 start, INT64 length) 
  //  PyArrayObject* arrTime; xp;
  //  PyArrayObject* yp;
  //  PyArrayObject* returnArray; // we allocate this
- //  INT32 clip = 0;
- //  INT32 mode = 0;
+ //  int32_t clip = 0;
+ //  int32_t mode = 0;
 
  //  if (!PyArg_ParseTuple(args, "O!O!O!|i",
  //      &PyArray_Type, &arr,

--- a/src/Ema.cpp
+++ b/src/Ema.cpp
@@ -515,12 +515,16 @@ ROLLING_FUNC GetRollingFunction(int64_t func, int32_t inputType) {
    case NPY_LONGDOUBLE: return EmaBase<long double, long double>::GetRollingFunction(func);
    case NPY_INT8:   return EmaBase<int8_t, int64_t>::GetRollingFunction(func);
    case NPY_INT16:  return EmaBase<int16_t, int64_t>::GetRollingFunction(func);
-   CASE_NPY_INT32:  return EmaBase<int32_t, int64_t>::GetRollingFunction(func);
-   CASE_NPY_UINT32: return EmaBase<uint32_t, int64_t>::GetRollingFunction(func);
-   CASE_NPY_INT64:  return EmaBase<int64_t, int64_t>::GetRollingFunction(func);
+   case NPY_INT32:  return EmaBase<int32_t, int64_t>::GetRollingFunction(func);
+   case NPY_UINT32: return EmaBase<uint32_t, int64_t>::GetRollingFunction(func);
+   case NPY_INT64:
+   case NPY_LONGLONG:
+      return EmaBase<int64_t, int64_t>::GetRollingFunction(func);
    case NPY_UINT8:  return EmaBase<uint8_t, int64_t>::GetRollingFunction(func);
    case NPY_UINT16: return EmaBase<uint16_t, int64_t>::GetRollingFunction(func);
-   CASE_NPY_UINT64: return EmaBase<uint64_t, int64_t>::GetRollingFunction(func);
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+      return EmaBase<uint64_t, int64_t>::GetRollingFunction(func);
    }
 
    return NULL;
@@ -534,12 +538,16 @@ ROLLING_FUNC GetRollingFunction2(int64_t func, int32_t inputType) {
    case NPY_LONGDOUBLE: return EmaBase<long double, long double>::GetRollingFunction2(func);
    case NPY_INT8:   return EmaBase<int8_t, double>::GetRollingFunction2(func);
    case NPY_INT16:  return EmaBase<int16_t, double>::GetRollingFunction2(func);
-   CASE_NPY_INT32:  return EmaBase<int32_t, double>::GetRollingFunction2(func);
-   CASE_NPY_UINT32:  return EmaBase<uint32_t, double>::GetRollingFunction2(func);
-   CASE_NPY_INT64:  return EmaBase<int64_t, double>::GetRollingFunction2(func);
+   case NPY_INT32:  return EmaBase<int32_t, double>::GetRollingFunction2(func);
+   case NPY_UINT32:  return EmaBase<uint32_t, double>::GetRollingFunction2(func);
+   case NPY_INT64:
+   case NPY_LONGLONG:
+      return EmaBase<int64_t, double>::GetRollingFunction2(func);
    case NPY_UINT8:  return EmaBase<uint8_t, double>::GetRollingFunction2(func);
    case NPY_UINT16: return EmaBase<uint16_t, double>::GetRollingFunction2(func);
-   CASE_NPY_UINT64: return EmaBase<uint64_t, double>::GetRollingFunction2(func);
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+      return EmaBase<uint64_t, double>::GetRollingFunction2(func);
    }
 
    return NULL;
@@ -1466,10 +1474,14 @@ static EMA_BY_TWO_FUNC GetEmaByStep2(int timeType, EMA_FUNCTIONS func) {
    case NPY_FLOAT:  return EmaByBase<T, double, float, K>::GetFunc(func);
    case NPY_DOUBLE: return EmaByBase<T, double, double, K>::GetFunc(func);
    case NPY_LONGDOUBLE: return EmaByBase<T, long double, long double, K>::GetFunc(func);
-   CASE_NPY_INT32:  return EmaByBase<T, double, int32_t, K>::GetFunc(func);
-   CASE_NPY_INT64:  return EmaByBase<T, double, int64_t, K>::GetFunc(func);
-   CASE_NPY_UINT32: return EmaByBase<T, double, uint32_t, K>::GetFunc(func);
-   CASE_NPY_UINT64: return EmaByBase<T, double, uint64_t, K>::GetFunc(func);
+   case NPY_INT32:  return EmaByBase<T, double, int32_t, K>::GetFunc(func);
+   case NPY_INT64:
+   case NPY_LONGLONG:
+      return EmaByBase<T, double, int64_t, K>::GetFunc(func);
+   case NPY_UINT32: return EmaByBase<T, double, uint32_t, K>::GetFunc(func);
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+          return EmaByBase<T, double, uint64_t, K>::GetFunc(func);
    }
    return NULL;
 
@@ -1492,13 +1504,17 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_BOOL:   *outputType = NPY_INT64; return CumSum<int8_t, int64_t, K>;
       case NPY_INT8:   *outputType = NPY_INT64; return CumSum<int8_t, int64_t, K>;
       case NPY_INT16:  *outputType = NPY_INT64; return CumSum<int16_t, int64_t, K>;
-      CASE_NPY_INT32:  *outputType = NPY_INT64; return CumSum<int32_t, int64_t, K>;
-      CASE_NPY_INT64:  *outputType = NPY_INT64; return CumSum<int64_t, int64_t, K>;
+      case NPY_INT32:  *outputType = NPY_INT64; return CumSum<int32_t, int64_t, K>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           *outputType = NPY_INT64; return CumSum<int64_t, int64_t, K>;
 
       case NPY_UINT8:  *outputType = NPY_UINT64; return CumSum<uint8_t,  uint64_t, K>;
       case NPY_UINT16: *outputType = NPY_UINT64; return CumSum<uint16_t, uint64_t, K>;
-      CASE_NPY_UINT32: *outputType = NPY_UINT64; return CumSum<uint32_t, uint64_t, K>;
-      CASE_NPY_UINT64: *outputType = NPY_UINT64; return CumSum<uint64_t, uint64_t, K>;
+      case NPY_UINT32: *outputType = NPY_UINT64; return CumSum<uint32_t, uint64_t, K>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          *outputType = NPY_UINT64; return CumSum<uint64_t, uint64_t, K>;
 
       }
       break;
@@ -1511,13 +1527,17 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_BOOL:   *outputType = NPY_INT64; return CumProd<int8_t, int64_t, K>;
       case NPY_INT8:   *outputType = NPY_INT64; return CumProd<int8_t, int64_t, K>;
       case NPY_INT16:  *outputType = NPY_INT64; return CumProd<int16_t, int64_t, K>;
-      CASE_NPY_INT32:  *outputType = NPY_INT64; return CumProd<int32_t, int64_t, K>;
-      CASE_NPY_INT64:  *outputType = NPY_INT64; return CumProd<int64_t, int64_t, K>;
+      case NPY_INT32:  *outputType = NPY_INT64; return CumProd<int32_t, int64_t, K>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           *outputType = NPY_INT64; return CumProd<int64_t, int64_t, K>;
 
       case NPY_UINT8:  *outputType = NPY_UINT64; return CumProd<uint8_t, uint64_t, K>;
       case NPY_UINT16: *outputType = NPY_UINT64; return CumProd<uint16_t, uint64_t, K>;
-      CASE_NPY_UINT32: *outputType = NPY_UINT64; return CumProd<uint32_t, uint64_t, K>;
-      CASE_NPY_UINT64: *outputType = NPY_UINT64; return CumProd<uint64_t, uint64_t, K>;
+      case NPY_UINT32: *outputType = NPY_UINT64; return CumProd<uint32_t, uint64_t, K>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          *outputType = NPY_UINT64; return CumProd<uint64_t, uint64_t, K>;
 
       }
       break;
@@ -1538,12 +1558,16 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_LONGDOUBLE: return GetEmaByStep2<long double, K>(timeType, func);
       case NPY_INT8:   return GetEmaByStep2<int8_t, K>(timeType, func);
       case NPY_INT16:  return GetEmaByStep2<int16_t, K>(timeType, func);
-      CASE_NPY_INT32:  return GetEmaByStep2<int32_t, K>(timeType, func);
-      CASE_NPY_INT64:  return GetEmaByStep2<int64_t, K>(timeType, func);
+      case NPY_INT32:  return GetEmaByStep2<int32_t, K>(timeType, func);
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return GetEmaByStep2<int64_t, K>(timeType, func);
       case NPY_UINT8:  return GetEmaByStep2<uint8_t, K>(timeType, func);
       case NPY_UINT16: return GetEmaByStep2<uint16_t, K>(timeType, func);
-      CASE_NPY_UINT32: return GetEmaByStep2<uint32_t, K>(timeType, func);
-      CASE_NPY_UINT64: return GetEmaByStep2<uint64_t, K>(timeType, func);
+      case NPY_UINT32: return GetEmaByStep2<uint32_t, K>(timeType, func);
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          return GetEmaByStep2<uint64_t, K>(timeType, func);
 
       }
       break;
@@ -1669,8 +1693,9 @@ EmaAll32(PyObject *self, PyObject *args)
    switch (iKeyType) {
    case NPY_INT8:
    case NPY_INT16:
-   CASE_NPY_INT32:
-   CASE_NPY_INT64:
+   case NPY_INT32:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       break;
    default:
       PyErr_Format(PyExc_ValueError, "EmaAll32 key param must int8, int16, int32, int64");
@@ -1773,10 +1798,11 @@ EmaAll32(PyObject *self, PyObject *args)
       case NPY_INT16:
          pFunction = GetEmaByFunction<int16_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
-      CASE_NPY_INT32:
+      case NPY_INT32:
          pFunction = GetEmaByFunction<int32_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
-      CASE_NPY_INT64:
+      case NPY_INT64:
+      case NPY_LONGLONG:
          pFunction = GetEmaByFunction<int64_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
       }
@@ -2039,7 +2065,7 @@ bool InterpolateExtrap(void* callbackArgT, int core, int64_t start, int64_t leng
       }
 
    }
-   return TRUE;
+   return true;
 }
 
 

--- a/src/Ema.cpp
+++ b/src/Ema.cpp
@@ -515,8 +515,8 @@ ROLLING_FUNC GetRollingFunction(int64_t func, int32_t inputType) {
    case NPY_LONGDOUBLE: return EmaBase<long double, long double>::GetRollingFunction(func);
    case NPY_INT8:   return EmaBase<int8_t, int64_t>::GetRollingFunction(func);
    case NPY_INT16:  return EmaBase<int16_t, int64_t>::GetRollingFunction(func);
-   case NPY_INT32:  return EmaBase<int32_t, int64_t>::GetRollingFunction(func);
-   case NPY_UINT32: return EmaBase<uint32_t, int64_t>::GetRollingFunction(func);
+   case NPY_INT:  return EmaBase<int32_t, int64_t>::GetRollingFunction(func);
+   case NPY_UINT: return EmaBase<uint32_t, int64_t>::GetRollingFunction(func);
    case NPY_INT64:
    case NPY_LONGLONG:
       return EmaBase<int64_t, int64_t>::GetRollingFunction(func);
@@ -538,8 +538,8 @@ ROLLING_FUNC GetRollingFunction2(int64_t func, int32_t inputType) {
    case NPY_LONGDOUBLE: return EmaBase<long double, long double>::GetRollingFunction2(func);
    case NPY_INT8:   return EmaBase<int8_t, double>::GetRollingFunction2(func);
    case NPY_INT16:  return EmaBase<int16_t, double>::GetRollingFunction2(func);
-   case NPY_INT32:  return EmaBase<int32_t, double>::GetRollingFunction2(func);
-   case NPY_UINT32:  return EmaBase<uint32_t, double>::GetRollingFunction2(func);
+   case NPY_INT:  return EmaBase<int32_t, double>::GetRollingFunction2(func);
+   case NPY_UINT:  return EmaBase<uint32_t, double>::GetRollingFunction2(func);
    case NPY_INT64:
    case NPY_LONGLONG:
       return EmaBase<int64_t, double>::GetRollingFunction2(func);
@@ -1474,11 +1474,11 @@ static EMA_BY_TWO_FUNC GetEmaByStep2(int timeType, EMA_FUNCTIONS func) {
    case NPY_FLOAT:  return EmaByBase<T, double, float, K>::GetFunc(func);
    case NPY_DOUBLE: return EmaByBase<T, double, double, K>::GetFunc(func);
    case NPY_LONGDOUBLE: return EmaByBase<T, long double, long double, K>::GetFunc(func);
-   case NPY_INT32:  return EmaByBase<T, double, int32_t, K>::GetFunc(func);
+   case NPY_INT:  return EmaByBase<T, double, int32_t, K>::GetFunc(func);
    case NPY_INT64:
    case NPY_LONGLONG:
       return EmaByBase<T, double, int64_t, K>::GetFunc(func);
-   case NPY_UINT32: return EmaByBase<T, double, uint32_t, K>::GetFunc(func);
+   case NPY_UINT: return EmaByBase<T, double, uint32_t, K>::GetFunc(func);
    case NPY_UINT64:
    case NPY_ULONGLONG:
           return EmaByBase<T, double, uint64_t, K>::GetFunc(func);
@@ -1504,14 +1504,14 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_BOOL:   *outputType = NPY_INT64; return CumSum<int8_t, int64_t, K>;
       case NPY_INT8:   *outputType = NPY_INT64; return CumSum<int8_t, int64_t, K>;
       case NPY_INT16:  *outputType = NPY_INT64; return CumSum<int16_t, int64_t, K>;
-      case NPY_INT32:  *outputType = NPY_INT64; return CumSum<int32_t, int64_t, K>;
+      case NPY_INT:  *outputType = NPY_INT64; return CumSum<int32_t, int64_t, K>;
       case NPY_INT64:
       case NPY_LONGLONG:
            *outputType = NPY_INT64; return CumSum<int64_t, int64_t, K>;
 
       case NPY_UINT8:  *outputType = NPY_UINT64; return CumSum<uint8_t,  uint64_t, K>;
       case NPY_UINT16: *outputType = NPY_UINT64; return CumSum<uint16_t, uint64_t, K>;
-      case NPY_UINT32: *outputType = NPY_UINT64; return CumSum<uint32_t, uint64_t, K>;
+      case NPY_UINT: *outputType = NPY_UINT64; return CumSum<uint32_t, uint64_t, K>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           *outputType = NPY_UINT64; return CumSum<uint64_t, uint64_t, K>;
@@ -1527,14 +1527,14 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_BOOL:   *outputType = NPY_INT64; return CumProd<int8_t, int64_t, K>;
       case NPY_INT8:   *outputType = NPY_INT64; return CumProd<int8_t, int64_t, K>;
       case NPY_INT16:  *outputType = NPY_INT64; return CumProd<int16_t, int64_t, K>;
-      case NPY_INT32:  *outputType = NPY_INT64; return CumProd<int32_t, int64_t, K>;
+      case NPY_INT:  *outputType = NPY_INT64; return CumProd<int32_t, int64_t, K>;
       case NPY_INT64:
       case NPY_LONGLONG:
            *outputType = NPY_INT64; return CumProd<int64_t, int64_t, K>;
 
       case NPY_UINT8:  *outputType = NPY_UINT64; return CumProd<uint8_t, uint64_t, K>;
       case NPY_UINT16: *outputType = NPY_UINT64; return CumProd<uint16_t, uint64_t, K>;
-      case NPY_UINT32: *outputType = NPY_UINT64; return CumProd<uint32_t, uint64_t, K>;
+      case NPY_UINT: *outputType = NPY_UINT64; return CumProd<uint32_t, uint64_t, K>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           *outputType = NPY_UINT64; return CumProd<uint64_t, uint64_t, K>;
@@ -1544,7 +1544,7 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
 
 
    case EMA_FINDNTH:
-      *outputType = NPY_INT32; return FindNth< int32_t, K>;
+      *outputType = NPY_INT; return FindNth< int32_t, K>;
       break;
 
    case EMA_NORMAL:
@@ -1558,13 +1558,13 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_LONGDOUBLE: return GetEmaByStep2<long double, K>(timeType, func);
       case NPY_INT8:   return GetEmaByStep2<int8_t, K>(timeType, func);
       case NPY_INT16:  return GetEmaByStep2<int16_t, K>(timeType, func);
-      case NPY_INT32:  return GetEmaByStep2<int32_t, K>(timeType, func);
+      case NPY_INT:  return GetEmaByStep2<int32_t, K>(timeType, func);
       case NPY_INT64:
       case NPY_LONGLONG:
            return GetEmaByStep2<int64_t, K>(timeType, func);
       case NPY_UINT8:  return GetEmaByStep2<uint8_t, K>(timeType, func);
       case NPY_UINT16: return GetEmaByStep2<uint16_t, K>(timeType, func);
-      case NPY_UINT32: return GetEmaByStep2<uint32_t, K>(timeType, func);
+      case NPY_UINT: return GetEmaByStep2<uint32_t, K>(timeType, func);
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return GetEmaByStep2<uint64_t, K>(timeType, func);
@@ -1693,7 +1693,7 @@ EmaAll32(PyObject *self, PyObject *args)
    switch (iKeyType) {
    case NPY_INT8:
    case NPY_INT16:
-   case NPY_INT32:
+   case NPY_INT:
    case NPY_INT64:
    case NPY_LONGLONG:
       break;
@@ -1798,7 +1798,7 @@ EmaAll32(PyObject *self, PyObject *args)
       case NPY_INT16:
          pFunction = GetEmaByFunction<int16_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
-      case NPY_INT32:
+      case NPY_INT:
          pFunction = GetEmaByFunction<int32_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
       case NPY_INT64:

--- a/src/Ema.cpp
+++ b/src/Ema.cpp
@@ -583,7 +583,7 @@ Rolling(PyObject *self, PyObject *args)
    int64_t size = ArrayLength(inArr);
    ROLLING_FUNC pRollingFunc;
 
-   numpyOutType = NPY_int64_t;
+   numpyOutType = NPY_INT64;
 
    if (func >= 100) {
       pRollingFunc = GetRollingFunction2(func, dType);
@@ -602,7 +602,7 @@ Rolling(PyObject *self, PyObject *args)
       pRollingFunc = GetRollingFunction(func, dType);
 
       // Always want some sort of int64 or float
-      numpyOutType = NPY_int64_t;
+      numpyOutType = NPY_INT64;
       if (dType == NPY_FLOAT) {
          numpyOutType = NPY_FLOAT;
       }
@@ -1489,16 +1489,16 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_FLOAT:  *outputType = NPY_FLOAT32; return CumSum<float, float, K>;
       case NPY_DOUBLE: *outputType = NPY_FLOAT64; return CumSum<double, double, K> ;
       case NPY_LONGDOUBLE: *outputType = NPY_FLOAT64; return CumSum<long double, long double, K>;
-      case NPY_BOOL:   *outputType = NPY_int64_t; return CumSum<int8_t, int64_t, K>;
-      case NPY_INT8:   *outputType = NPY_int64_t; return CumSum<int8_t, int64_t, K>;
-      case NPY_INT16:  *outputType = NPY_int64_t; return CumSum<int16_t, int64_t, K>;
-      CASE_NPY_INT32:  *outputType = NPY_int64_t; return CumSum<int32_t, int64_t, K>;
-      CASE_NPY_INT64:  *outputType = NPY_int64_t; return CumSum<int64_t, int64_t, K>;
+      case NPY_BOOL:   *outputType = NPY_INT64; return CumSum<int8_t, int64_t, K>;
+      case NPY_INT8:   *outputType = NPY_INT64; return CumSum<int8_t, int64_t, K>;
+      case NPY_INT16:  *outputType = NPY_INT64; return CumSum<int16_t, int64_t, K>;
+      CASE_NPY_INT32:  *outputType = NPY_INT64; return CumSum<int32_t, int64_t, K>;
+      CASE_NPY_INT64:  *outputType = NPY_INT64; return CumSum<int64_t, int64_t, K>;
 
-      case NPY_UINT8:  *outputType = NPY_uint64_t; return CumSum<uint8_t,  uint64_t, K>;
-      case NPY_UINT16: *outputType = NPY_uint64_t; return CumSum<uint16_t, uint64_t, K>;
-      CASE_NPY_UINT32: *outputType = NPY_uint64_t; return CumSum<uint32_t, uint64_t, K>;
-      CASE_NPY_UINT64: *outputType = NPY_uint64_t; return CumSum<uint64_t, uint64_t, K>;
+      case NPY_UINT8:  *outputType = NPY_UINT64; return CumSum<uint8_t,  uint64_t, K>;
+      case NPY_UINT16: *outputType = NPY_UINT64; return CumSum<uint16_t, uint64_t, K>;
+      CASE_NPY_UINT32: *outputType = NPY_UINT64; return CumSum<uint32_t, uint64_t, K>;
+      CASE_NPY_UINT64: *outputType = NPY_UINT64; return CumSum<uint64_t, uint64_t, K>;
 
       }
       break;
@@ -1508,23 +1508,23 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_FLOAT:  *outputType = NPY_FLOAT32; return CumProd<float, float, K>;
       case NPY_DOUBLE: *outputType = NPY_FLOAT64; return CumProd<double, double, K>;
       case NPY_LONGDOUBLE: *outputType = NPY_FLOAT64; return CumProd<long double, long double, K>;
-      case NPY_BOOL:   *outputType = NPY_int64_t; return CumProd<int8_t, int64_t, K>;
-      case NPY_INT8:   *outputType = NPY_int64_t; return CumProd<int8_t, int64_t, K>;
-      case NPY_INT16:  *outputType = NPY_int64_t; return CumProd<int16_t, int64_t, K>;
-      CASE_NPY_INT32:  *outputType = NPY_int64_t; return CumProd<int32_t, int64_t, K>;
-      CASE_NPY_INT64:  *outputType = NPY_int64_t; return CumProd<int64_t, int64_t, K>;
+      case NPY_BOOL:   *outputType = NPY_INT64; return CumProd<int8_t, int64_t, K>;
+      case NPY_INT8:   *outputType = NPY_INT64; return CumProd<int8_t, int64_t, K>;
+      case NPY_INT16:  *outputType = NPY_INT64; return CumProd<int16_t, int64_t, K>;
+      CASE_NPY_INT32:  *outputType = NPY_INT64; return CumProd<int32_t, int64_t, K>;
+      CASE_NPY_INT64:  *outputType = NPY_INT64; return CumProd<int64_t, int64_t, K>;
 
-      case NPY_UINT8:  *outputType = NPY_uint64_t; return CumProd<uint8_t, uint64_t, K>;
-      case NPY_UINT16: *outputType = NPY_uint64_t; return CumProd<uint16_t, uint64_t, K>;
-      CASE_NPY_UINT32: *outputType = NPY_uint64_t; return CumProd<uint32_t, uint64_t, K>;
-      CASE_NPY_UINT64: *outputType = NPY_uint64_t; return CumProd<uint64_t, uint64_t, K>;
+      case NPY_UINT8:  *outputType = NPY_UINT64; return CumProd<uint8_t, uint64_t, K>;
+      case NPY_UINT16: *outputType = NPY_UINT64; return CumProd<uint16_t, uint64_t, K>;
+      CASE_NPY_UINT32: *outputType = NPY_UINT64; return CumProd<uint32_t, uint64_t, K>;
+      CASE_NPY_UINT64: *outputType = NPY_UINT64; return CumProd<uint64_t, uint64_t, K>;
 
       }
       break;
 
 
    case EMA_FINDNTH:
-      *outputType = NPY_int32_t; return FindNth< int32_t, K>;
+      *outputType = NPY_INT32; return FindNth< int32_t, K>;
       break;
 
    case EMA_NORMAL:

--- a/src/Ema.cpp
+++ b/src/Ema.cpp
@@ -515,15 +515,15 @@ ROLLING_FUNC GetRollingFunction(int64_t func, int32_t inputType) {
    case NPY_LONGDOUBLE: return EmaBase<long double, long double>::GetRollingFunction(func);
    case NPY_INT8:   return EmaBase<int8_t, int64_t>::GetRollingFunction(func);
    case NPY_INT16:  return EmaBase<int16_t, int64_t>::GetRollingFunction(func);
-   case NPY_INT32:  return EmaBase<int32_t, int64_t>::GetRollingFunction(func);
-   case NPY_UINT32: return EmaBase<uint32_t, int64_t>::GetRollingFunction(func);
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return EmaBase<int32_t, int64_t>::GetRollingFunction(func);
+   CASE_NPY_UINT32: return EmaBase<uint32_t, int64_t>::GetRollingFunction(func);
+   CASE_NPY_INT64:
+   
       return EmaBase<int64_t, int64_t>::GetRollingFunction(func);
    case NPY_UINT8:  return EmaBase<uint8_t, int64_t>::GetRollingFunction(func);
    case NPY_UINT16: return EmaBase<uint16_t, int64_t>::GetRollingFunction(func);
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT64:
+   
       return EmaBase<uint64_t, int64_t>::GetRollingFunction(func);
    }
 
@@ -538,15 +538,15 @@ ROLLING_FUNC GetRollingFunction2(int64_t func, int32_t inputType) {
    case NPY_LONGDOUBLE: return EmaBase<long double, long double>::GetRollingFunction2(func);
    case NPY_INT8:   return EmaBase<int8_t, double>::GetRollingFunction2(func);
    case NPY_INT16:  return EmaBase<int16_t, double>::GetRollingFunction2(func);
-   case NPY_INT32:  return EmaBase<int32_t, double>::GetRollingFunction2(func);
-   case NPY_UINT32:  return EmaBase<uint32_t, double>::GetRollingFunction2(func);
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return EmaBase<int32_t, double>::GetRollingFunction2(func);
+   CASE_NPY_UINT32:  return EmaBase<uint32_t, double>::GetRollingFunction2(func);
+   CASE_NPY_INT64:
+   
       return EmaBase<int64_t, double>::GetRollingFunction2(func);
    case NPY_UINT8:  return EmaBase<uint8_t, double>::GetRollingFunction2(func);
    case NPY_UINT16: return EmaBase<uint16_t, double>::GetRollingFunction2(func);
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT64:
+   
       return EmaBase<uint64_t, double>::GetRollingFunction2(func);
    }
 
@@ -1474,13 +1474,13 @@ static EMA_BY_TWO_FUNC GetEmaByStep2(int timeType, EMA_FUNCTIONS func) {
    case NPY_FLOAT:  return EmaByBase<T, double, float, K>::GetFunc(func);
    case NPY_DOUBLE: return EmaByBase<T, double, double, K>::GetFunc(func);
    case NPY_LONGDOUBLE: return EmaByBase<T, long double, long double, K>::GetFunc(func);
-   case NPY_INT32:  return EmaByBase<T, double, int32_t, K>::GetFunc(func);
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  return EmaByBase<T, double, int32_t, K>::GetFunc(func);
+   CASE_NPY_INT64:
+   
       return EmaByBase<T, double, int64_t, K>::GetFunc(func);
-   case NPY_UINT32: return EmaByBase<T, double, uint32_t, K>::GetFunc(func);
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT32: return EmaByBase<T, double, uint32_t, K>::GetFunc(func);
+   CASE_NPY_UINT64:
+   
           return EmaByBase<T, double, uint64_t, K>::GetFunc(func);
    }
    return NULL;
@@ -1504,16 +1504,16 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_BOOL:   *outputType = NPY_INT64; return CumSum<int8_t, int64_t, K>;
       case NPY_INT8:   *outputType = NPY_INT64; return CumSum<int8_t, int64_t, K>;
       case NPY_INT16:  *outputType = NPY_INT64; return CumSum<int16_t, int64_t, K>;
-      case NPY_INT32:  *outputType = NPY_INT64; return CumSum<int32_t, int64_t, K>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *outputType = NPY_INT64; return CumSum<int32_t, int64_t, K>;
+      CASE_NPY_INT64:
+      
            *outputType = NPY_INT64; return CumSum<int64_t, int64_t, K>;
 
       case NPY_UINT8:  *outputType = NPY_UINT64; return CumSum<uint8_t,  uint64_t, K>;
       case NPY_UINT16: *outputType = NPY_UINT64; return CumSum<uint16_t, uint64_t, K>;
-      case NPY_UINT32: *outputType = NPY_UINT64; return CumSum<uint32_t, uint64_t, K>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *outputType = NPY_UINT64; return CumSum<uint32_t, uint64_t, K>;
+      CASE_NPY_UINT64:
+      
           *outputType = NPY_UINT64; return CumSum<uint64_t, uint64_t, K>;
 
       }
@@ -1527,16 +1527,16 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_BOOL:   *outputType = NPY_INT64; return CumProd<int8_t, int64_t, K>;
       case NPY_INT8:   *outputType = NPY_INT64; return CumProd<int8_t, int64_t, K>;
       case NPY_INT16:  *outputType = NPY_INT64; return CumProd<int16_t, int64_t, K>;
-      case NPY_INT32:  *outputType = NPY_INT64; return CumProd<int32_t, int64_t, K>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *outputType = NPY_INT64; return CumProd<int32_t, int64_t, K>;
+      CASE_NPY_INT64:
+      
            *outputType = NPY_INT64; return CumProd<int64_t, int64_t, K>;
 
       case NPY_UINT8:  *outputType = NPY_UINT64; return CumProd<uint8_t, uint64_t, K>;
       case NPY_UINT16: *outputType = NPY_UINT64; return CumProd<uint16_t, uint64_t, K>;
-      case NPY_UINT32: *outputType = NPY_UINT64; return CumProd<uint32_t, uint64_t, K>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *outputType = NPY_UINT64; return CumProd<uint32_t, uint64_t, K>;
+      CASE_NPY_UINT64:
+      
           *outputType = NPY_UINT64; return CumProd<uint64_t, uint64_t, K>;
 
       }
@@ -1558,15 +1558,15 @@ static EMA_BY_TWO_FUNC GetEmaByFunction(int inputType, int *outputType, int time
       case NPY_LONGDOUBLE: return GetEmaByStep2<long double, K>(timeType, func);
       case NPY_INT8:   return GetEmaByStep2<int8_t, K>(timeType, func);
       case NPY_INT16:  return GetEmaByStep2<int16_t, K>(timeType, func);
-      case NPY_INT32:  return GetEmaByStep2<int32_t, K>(timeType, func);
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return GetEmaByStep2<int32_t, K>(timeType, func);
+      CASE_NPY_INT64:
+      
            return GetEmaByStep2<int64_t, K>(timeType, func);
       case NPY_UINT8:  return GetEmaByStep2<uint8_t, K>(timeType, func);
       case NPY_UINT16: return GetEmaByStep2<uint16_t, K>(timeType, func);
-      case NPY_UINT32: return GetEmaByStep2<uint32_t, K>(timeType, func);
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return GetEmaByStep2<uint32_t, K>(timeType, func);
+      CASE_NPY_UINT64:
+      
           return GetEmaByStep2<uint64_t, K>(timeType, func);
 
       }
@@ -1693,9 +1693,9 @@ EmaAll32(PyObject *self, PyObject *args)
    switch (iKeyType) {
    case NPY_INT8:
    case NPY_INT16:
-   case NPY_INT32:
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:
+   CASE_NPY_INT64:
+   
       break;
    default:
       PyErr_Format(PyExc_ValueError, "EmaAll32 key param must int8, int16, int32, int64");
@@ -1798,11 +1798,11 @@ EmaAll32(PyObject *self, PyObject *args)
       case NPY_INT16:
          pFunction = GetEmaByFunction<int16_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          pFunction = GetEmaByFunction<int32_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          pFunction = GetEmaByFunction<int64_t>(aInfo[i].NumpyDType, &numpyOutType, inTime == NULL ? -1 : PyArray_TYPE(inTime), (EMA_FUNCTIONS)funcNum);
          break;
       }

--- a/src/FileReadWrite.cpp
+++ b/src/FileReadWrite.cpp
@@ -41,7 +41,7 @@ CFileReadWrite::~CFileReadWrite()
 // Returns true if cache was successfully flushed
 bool CFileReadWrite::FlushCache(CHAR driveLetter) {
 
-   bool result = FALSE;
+   bool result = false;
    char  szVolumeName[32] = "\\\\.\\X:";
 
    szVolumeName[4] = driveLetter;

--- a/src/FileReadWrite.cpp
+++ b/src/FileReadWrite.cpp
@@ -5,8 +5,8 @@
 
 #define LogVerbose(...)
 
-INT64 LogLevel(
-   INT64 level,
+int64_t LogLevel(
+   int64_t level,
    LPCTSTR        szString,
    ...) {
 
@@ -39,9 +39,9 @@ CFileReadWrite::~CFileReadWrite()
 }
 
 // Returns true if cache was successfully flushed
-BOOLEAN CFileReadWrite::FlushCache(CHAR driveLetter) {
+bool CFileReadWrite::FlushCache(CHAR driveLetter) {
 
-   BOOLEAN result = FALSE;
+   bool result = FALSE;
    char  szVolumeName[32] = "\\\\.\\X:";
 
    szVolumeName[4] = driveLetter;
@@ -76,7 +76,7 @@ BOOLEAN CFileReadWrite::FlushCache(CHAR driveLetter) {
 }
 
 
-BOOLEAN CFileReadWrite::Open(const char* fileName, BOOLEAN writeOption, BOOLEAN overlapped, BOOLEAN directIO)
+bool CFileReadWrite::Open(const char* fileName, bool writeOption, bool overlapped, bool directIO)
 {
    strcpy_s(FileName, sizeof(FileName), fileName);
    WriteOption = writeOption;
@@ -127,7 +127,7 @@ BOOLEAN CFileReadWrite::Open(const char* fileName, BOOLEAN writeOption, BOOLEAN 
 
 
 // Cancels all IO for the Handle
-BOOLEAN CFileReadWrite::CancelIO()
+bool CFileReadWrite::CancelIO()
 {
    return CancelIo(Handle);
 }
@@ -135,7 +135,7 @@ BOOLEAN CFileReadWrite::CancelIO()
 
 //---------------------------------------------------------
 // Standard read ahead
-DWORD CFileReadWrite::ReadChunk(void* buffer, UINT32 count)
+DWORD CFileReadWrite::ReadChunk(void* buffer, uint32_t count)
 {
    DWORD n = 0;
    if (!Overlapped) {
@@ -154,10 +154,10 @@ DWORD CFileReadWrite::ReadChunk(void* buffer, UINT32 count)
       OverlappedIO.hEvent = NULL;
       OverlappedIO.InternalHigh = 0;
       OverlappedIO.Internal = 0;
-      OverlappedIO.OffsetHigh = (UINT32)(BufferPos >> 32);
-      OverlappedIO.Offset = (UINT32)BufferPos;
+      OverlappedIO.OffsetHigh = (uint32_t)(BufferPos >> 32);
+      OverlappedIO.Offset = (uint32_t)BufferPos;
 
-      BOOLEAN bReadDone;
+      bool bReadDone;
 
       OVERLAPPED* pos = &OverlappedIO;
       {
@@ -198,7 +198,7 @@ DWORD CFileReadWrite::ReadChunk(void* buffer, UINT32 count)
 // The API may return and data will be pending
 DWORD CFileReadWrite::ReadChunkAsync(
    void* buffer,
-   UINT32 count,
+   uint32_t count,
    DWORD* lastError,
    OVERLAPPED* pOverlapped)
 {
@@ -218,10 +218,10 @@ DWORD CFileReadWrite::ReadChunkAsync(
    {
       pOverlapped->InternalHigh = 0;
       pOverlapped->Internal = 0;
-      pOverlapped->OffsetHigh = (UINT32)(BufferPos >> 32);
-      pOverlapped->Offset = (UINT32)BufferPos;
+      pOverlapped->OffsetHigh = (uint32_t)(BufferPos >> 32);
+      pOverlapped->Offset = (uint32_t)BufferPos;
 
-      BOOLEAN bReadDone;
+      bool bReadDone;
 
       // Async version of READ
       bReadDone = ReadFile(Handle, buffer, count, &n, pOverlapped);
@@ -255,14 +255,14 @@ DWORD CFileReadWrite::ReadChunkAsync(
 
 //----------------------------------------------------------------------------
 // ONLY if the last call was to ReadAsync can this be called
-BOOLEAN CFileReadWrite::WaitForLastRead(DWORD* lastError, OVERLAPPED* pos)
+bool CFileReadWrite::WaitForLastRead(DWORD* lastError, OVERLAPPED* pos)
 {
    // Check if last time operation was pending
    if (*lastError == ERROR_IO_PENDING)
    {
       DWORD n = 0;
       // Wait for this to complete
-      BOOLEAN bReadDone = GetOverlappedResult(Handle, pos, &n, true);
+      bool bReadDone = GetOverlappedResult(Handle, pos, &n, true);
 
       if (!bReadDone)
       {
@@ -298,11 +298,11 @@ BOOLEAN CFileReadWrite::WaitForLastRead(DWORD* lastError, OVERLAPPED* pos)
 
 
 
-BOOLEAN CFileReadWrite::WaitIoComplete(OVERLAPPED* pos)
+bool CFileReadWrite::WaitIoComplete(OVERLAPPED* pos)
 {
 
    DWORD n = 0;
-   BOOLEAN bWriteDone;
+   bool bWriteDone;
    // Wait for IO to complete
    bWriteDone = GetOverlappedResult(Handle, pos, &n, true);
 
@@ -325,7 +325,7 @@ BOOLEAN CFileReadWrite::WaitIoComplete(OVERLAPPED* pos)
 //---------------------------------------------------------------------------------------------------------------------------------
 // Will write for chunk to be written )non-Async version
 // Returns bytes written
-DWORD CFileReadWrite::WriteChunk(void* buffer, UINT32 count)
+DWORD CFileReadWrite::WriteChunk(void* buffer, uint32_t count)
 {
    DWORD n = 0;
    if (!Overlapped)
@@ -347,10 +347,10 @@ DWORD CFileReadWrite::WriteChunk(void* buffer, UINT32 count)
       OverlappedIO.hEvent = 0;
       OverlappedIO.InternalHigh = 0;
       OverlappedIO.Internal = 0;
-      OverlappedIO.OffsetHigh = (UINT32)(BufferPos >> 32);
-      OverlappedIO.Offset = (UINT32)BufferPos;
+      OverlappedIO.OffsetHigh = (uint32_t)(BufferPos >> 32);
+      OverlappedIO.Offset = (uint32_t)BufferPos;
 
-      BOOLEAN bWriteDone;
+      bool bWriteDone;
 
       OVERLAPPED* pos = &OverlappedIO;
       {
@@ -398,10 +398,10 @@ DWORD CFileReadWrite::WriteChunk(void* buffer, UINT32 count)
 // Returns: error result if any, in lastError
 DWORD CFileReadWrite::WriteChunkAsync(
    void* buffer,
-   UINT32 count,
+   uint32_t count,
    DWORD* lastError,
    OVERLAPPED* pOverlapped,
-   BOOLEAN bWaitOnIO)
+   bool bWaitOnIO)
 {
    DWORD n = 0;
    if (!Overlapped)
@@ -420,10 +420,10 @@ DWORD CFileReadWrite::WriteChunkAsync(
    {
       pOverlapped->InternalHigh = 0;
       pOverlapped->Internal = 0;
-      pOverlapped->OffsetHigh = (UINT32)(BufferPos >> 32);
-      pOverlapped->Offset = (UINT32)BufferPos;
+      pOverlapped->OffsetHigh = (uint32_t)(BufferPos >> 32);
+      pOverlapped->Offset = (uint32_t)BufferPos;
 
-      BOOLEAN bWriteDone;
+      bool bWriteDone;
 
       // Async version of WRITE
       bWriteDone = WriteFile(Handle, buffer, count, &n, pOverlapped);
@@ -469,14 +469,14 @@ DWORD CFileReadWrite::WriteChunkAsync(
 //--------------------------------------------------------------------
 // Seek from current position
 // Returns offset
-INT64 CFileReadWrite::SeekCurrentEx(INT64 pos)
+int64_t CFileReadWrite::SeekCurrentEx(int64_t pos)
 {
-   INT64 result = 0;
+   int64_t result = 0;
 
    LARGE_INTEGER temp;
    temp.QuadPart = pos;
 
-   BOOLEAN bResult =
+   bool bResult =
       SetFilePointerEx(Handle, temp, (PLARGE_INTEGER)&result, SEEK_CUR);
 
    if (!bResult)
@@ -500,14 +500,14 @@ INT64 CFileReadWrite::SeekCurrentEx(INT64 pos)
 //--------------------------------------------------------------------
 // Seek from start of file position
 // Move method = 0 = FILE_BEGIN
-INT64 CFileReadWrite::SeekBeginEx(INT64 pos)
+int64_t CFileReadWrite::SeekBeginEx(int64_t pos)
 {
-   INT64 result = 0;
+   int64_t result = 0;
 
    LARGE_INTEGER temp;
    temp.QuadPart = pos;
 
-   BOOLEAN bResult =
+   bool bResult =
       SetFilePointerEx(Handle, temp, (PLARGE_INTEGER)&result, SEEK_SET);
 
    if (!bResult)
@@ -529,11 +529,11 @@ INT64 CFileReadWrite::SeekBeginEx(INT64 pos)
 
 
 //--------------------------------------------------------------------
-BOOLEAN CFileReadWrite::Close()
+bool CFileReadWrite::Close()
 {
    if (Handle != NULL)
    {
-      BOOLEAN Result = CloseHandle(Handle);
+      bool Result = CloseHandle(Handle);
       Handle = NULL;
       return Result;
    }
@@ -546,9 +546,9 @@ extern "C" {
 
    CFileReadWrite* ReadWriteOpen(
       const char* fullFileName,
-      BOOLEAN writeOption = false,
-      BOOLEAN overlapped = true,
-      BOOLEAN directIO = false
+      bool writeOption = false,
+      bool overlapped = true,
+      bool directIO = false
    ) {
 
       CFileReadWrite* pReadWrite = new CFileReadWrite();
@@ -560,25 +560,25 @@ extern "C" {
       return pReadWrite;
    }
 
-   DWORD ReadChunk(CFileReadWrite* pReadWrite, void* buffer, UINT32 count) {
+   DWORD ReadChunk(CFileReadWrite* pReadWrite, void* buffer, uint32_t count) {
       return pReadWrite->ReadChunk(buffer, count);
    }
 
    DWORD ReadChunkAsync(
       CFileReadWrite* pReadWrite,
       void* buffer,
-      UINT32 count,
+      uint32_t count,
       DWORD* lastError,
       OVERLAPPED* pOverlapped) {
 
       return pReadWrite->ReadChunkAsync(buffer, count, lastError, pOverlapped);
    }
 
-   BOOLEAN ReadWriteClose(CFileReadWrite* pReadWrite) {
+   bool ReadWriteClose(CFileReadWrite* pReadWrite) {
       return pReadWrite->Close();
    }
 
-   BOOLEAN FlushCache(CHAR driveLetter) {
+   bool FlushCache(CHAR driveLetter) {
       return CFileReadWrite::FlushCache(driveLetter);
    }
 };

--- a/src/FileReadWrite.h
+++ b/src/FileReadWrite.h
@@ -3,19 +3,17 @@
 
 //#include "winbase.h"
 
-typedef BYTE BOOLEAN;
-
 class CFileReadWrite
 {
 public:
    CFileReadWrite();
    ~CFileReadWrite();
 
-   BOOLEAN Open(const char* fileName, BOOLEAN writeOption = false, BOOLEAN overlapped = false, BOOLEAN directIO = false);
+   bool Open(const char* fileName, bool writeOption = false, bool overlapped = false, bool directIO = false);
 
-   static BOOLEAN FlushCache(CHAR DriveLetter);
+   static bool FlushCache(CHAR DriveLetter);
 
-   BOOLEAN CancelIO();
+   bool CancelIO();
 
    DWORD ReadChunk(void* buffer, UINT32 count);
 
@@ -25,14 +23,14 @@ public:
       DWORD* lastError,
       OVERLAPPED* pOverlapped);
 
-   BOOLEAN WaitForLastRead(DWORD* lastError, OVERLAPPED* pos);
+   bool WaitForLastRead(DWORD* lastError, OVERLAPPED* pos);
 
-   BOOLEAN WaitIoComplete(OVERLAPPED* pos);
+   bool WaitIoComplete(OVERLAPPED* pos);
 
    DWORD WriteChunk(void* buffer, UINT32 count);
 
    // File existence check
-   static BOOLEAN FileExists(const char* filename) {
+   static bool FileExists(const char* filename) {
 
       if (INVALID_FILE_ATTRIBUTES == GetFileAttributes(filename) && GetLastError() == ERROR_FILE_NOT_FOUND)
       {
@@ -47,7 +45,7 @@ public:
       UINT32 count,
       DWORD* lastError,
       OVERLAPPED* pOverlapped,
-      BOOLEAN bWaitOnIO = false);
+      bool bWaitOnIO = false);
 
    // Seek from current location
    INT64 SeekCurrentEx(INT64 pos);
@@ -55,15 +53,15 @@ public:
    // Seek from beginning of file
    INT64 SeekBeginEx(INT64 pos);
 
-   BOOLEAN Close();
+   bool Close();
 
    //-----------------------------------
    HANDLE Handle = INVALID_HANDLE_VALUE;
    TCHAR  FileName[_MAX_FNAME] = { 0 };
 
-   BOOLEAN WriteOption = FALSE;
-   BOOLEAN Overlapped = FALSE;
-   BOOLEAN DirectIO = FALSE;
+   bool WriteOption = FALSE;
+   bool Overlapped = FALSE;
+   bool DirectIO = FALSE;
 
    INT64 BufferPos = 0;
    OVERLAPPED OverlappedIO;
@@ -82,7 +80,7 @@ public:
    CFileReadWrite();
    ~CFileReadWrite();
 
-   BOOLEAN Open(const char* fileName, BOOLEAN writeOption = false, BOOLEAN overlapped = false, BOOLEAN directIO = false);
+   bool Open(const char* fileName, bool writeOption = false, bool overlapped = false, bool directIO = false);
 
    FILE*    Handle;
 };

--- a/src/FileReadWrite.h
+++ b/src/FileReadWrite.h
@@ -59,9 +59,9 @@ public:
    HANDLE Handle = INVALID_HANDLE_VALUE;
    TCHAR  FileName[_MAX_FNAME] = { 0 };
 
-   bool WriteOption = FALSE;
-   bool Overlapped = FALSE;
-   bool DirectIO = FALSE;
+   bool WriteOption = false;
+   bool Overlapped = false;
+   bool DirectIO = false;
 
    INT64 BufferPos = 0;
    OVERLAPPED OverlappedIO;

--- a/src/GroupBy.cpp
+++ b/src/GroupBy.cpp
@@ -158,7 +158,7 @@ static size_t strip_nans(T *x, size_t n) {
 //-------------------------------------------------------------------
 // Defined as a macro so we can change this in one place
 // The algos look for a range to operate on.  This range can be used when multi-threading.
-#define ACCUM_INNER_LOOP(_index,_binLow,_binHigh) if (_index >= _binLow && index < _binHigh) {
+#define ACCUM_INNER_LOOP(_index,_binLow,_binHigh) if (_index >= _binLow && index < _binHigh)
 
 
 //-------------------------------------------------------------------
@@ -191,7 +191,7 @@ public:
       for (int64_t i = 0; i < len; i++) {
          V index = pIndex[i];
 
-         ACCUM_INNER_LOOP(index, binLow, binHigh)
+         ACCUM_INNER_LOOP(index, binLow, binHigh) {
             pOut[index] += (U)pIn[i];
          }
       }
@@ -232,7 +232,7 @@ public:
       for (int64_t i = 0; i < len; i++) {
          V index = pIndex[i];
 
-         ACCUM_INNER_LOOP(index, binLow, binHigh)
+         ACCUM_INNER_LOOP(index, binLow, binHigh) {
             pOutAccum[index-binLow] += (double)pIn[i];
          }
       }
@@ -267,7 +267,7 @@ public:
             V index = pIndex[i];
 
             //--------------------------------------
-            ACCUM_INNER_LOOP(index, binLow, binHigh)
+            ACCUM_INNER_LOOP(index, binLow, binHigh) {
                T temp = pIn[i];
                if (temp != invalid) {
                   pOut[index] += (U)temp;
@@ -282,7 +282,7 @@ public:
             V index = pIndex[i];
 
             //--------------------------------------
-            ACCUM_INNER_LOOP(index, binLow, binHigh)
+            ACCUM_INNER_LOOP(index, binLow, binHigh) {
                T temp = pIn[i];
                if (temp == temp) {
                   pOut[index] += (U)temp;
@@ -312,7 +312,7 @@ public:
          V index = pIndex[i];
 
          //--------------------------------------
-         ACCUM_INNER_LOOP(index, binLow, binHigh)
+         ACCUM_INNER_LOOP(index, binLow, binHigh) {
             T temp = pIn[i];
             if (pCountOut[index] == 0) {
                // first time
@@ -350,7 +350,7 @@ public:
             V index = pIndex[i];
 
             //--------------------------------------
-            ACCUM_INNER_LOOP(index, binLow, binHigh)
+            ACCUM_INNER_LOOP(index, binLow, binHigh) {
                T temp = pIn[i];
                // Note filled with nans, so comparing with nans
                if (pOut[index] != invalid) {
@@ -370,7 +370,7 @@ public:
             V index = pIndex[i];
 
             //--------------------------------------
-            ACCUM_INNER_LOOP(index, binLow, binHigh)
+            ACCUM_INNER_LOOP(index, binLow, binHigh) {
                T temp = pIn[i];
                // Note filled with nans, so comparing with nans
                if (pOut[index] == pOut[index]) {
@@ -405,7 +405,7 @@ public:
          V index = pIndex[i];
 
          //--------------------------------------
-         ACCUM_INNER_LOOP(index, binLow, binHigh)
+         ACCUM_INNER_LOOP(index, binLow, binHigh) {
             T temp = pIn[i];
             if (pCountOut[index] == 0) {
                // first time
@@ -443,7 +443,7 @@ public:
             V index = pIndex[i];
 
             //--------------------------------------
-            ACCUM_INNER_LOOP(index, binLow, binHigh)
+            ACCUM_INNER_LOOP(index, binLow, binHigh) {
                T temp = pIn[i];
                // Note filled with nans, so comparing with nans
                if (pOut[index] != invalid) {
@@ -463,7 +463,7 @@ public:
             V index = pIndex[i];
 
             //--------------------------------------
-            ACCUM_INNER_LOOP(index, binLow, binHigh)
+            ACCUM_INNER_LOOP(index, binLow, binHigh) {
                T temp = pIn[i];
                // Note filled with nans, so comparing with nans
                if (pOut[index] == pOut[index]) {
@@ -498,7 +498,7 @@ public:
          V index = pIndex[i];
 
          //--------------------------------------
-         ACCUM_INNER_LOOP(index, binLow, binHigh)
+         ACCUM_INNER_LOOP(index, binLow, binHigh) {
             T temp = pIn[i];
             pOut[index] += (U)temp;
             pCountOut[index]++;
@@ -541,7 +541,7 @@ public:
             V index = pIndex[i];
 
             //--------------------------------------
-            ACCUM_INNER_LOOP(index, binLow, binHigh)
+            ACCUM_INNER_LOOP(index, binLow, binHigh) {
                double temp = pIn[i];
                pOut[index - binLow] += (double)temp;
                pCountOut[index]++;
@@ -591,7 +591,7 @@ public:
             V index = pIndex[i];
 
             //--------------------------------------
-            ACCUM_INNER_LOOP(index, binLow, binHigh)
+            ACCUM_INNER_LOOP(index, binLow, binHigh) {
                T temp = pIn[i];
                if (temp == temp) {
                   pOut[index - binLow] += (double)temp;
@@ -634,7 +634,7 @@ public:
          V index = pIndex[i];
 
          //--------------------------------------
-         ACCUM_INNER_LOOP(index, binLow, binHigh)
+         ACCUM_INNER_LOOP(index, binLow, binHigh) {
             T temp = pIn[i];
             if (temp == temp) {
                pOut[index] += (U)temp;
@@ -675,7 +675,7 @@ public:
          V index = pIndex[i];
 
          //--------------------------------------
-         ACCUM_INNER_LOOP(index, binLow, binHigh)
+         ACCUM_INNER_LOOP(index, binLow, binHigh) {
             T temp = pIn[i];
             pOut[index] += (U)temp;
             pCountOut[index]++;
@@ -690,7 +690,7 @@ public:
          V index = pIndex[i];
 
          //--------------------------------------
-         ACCUM_INNER_LOOP(index, binLow, binHigh)
+         ACCUM_INNER_LOOP(index, binLow, binHigh) {
             T temp = pIn[i];
             U diff = (U)temp - pOut[index];
             sumsquares[index] += (diff*diff);
@@ -728,7 +728,7 @@ public:
          V index = pIndex[i];
 
          //--------------------------------------
-         ACCUM_INNER_LOOP(index, binLow, binHigh)
+         ACCUM_INNER_LOOP(index, binLow, binHigh) {
             T temp = pIn[i];
             if (temp == temp) {
                pOut[index] += (U)temp;
@@ -745,7 +745,7 @@ public:
          V index = pIndex[i];
 
          //--------------------------------------
-         ACCUM_INNER_LOOP(index, binLow, binHigh)
+         ACCUM_INNER_LOOP(index, binLow, binHigh) {
             T temp = pIn[i];
             if (temp == temp) {
                U diff = (U)temp - pOut[index];
@@ -2042,30 +2042,37 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: return GatherSum<long double>;
       case NPY_INT8:  return GatherSum<int64_t>;
       case NPY_INT16: return GatherSum<int64_t>;
-      CASE_NPY_INT32: return GatherSum<int64_t>;
-      CASE_NPY_INT64: return GatherSum<int64_t>;
+      case NPY_INT32: return GatherSum<int64_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG: return GatherSum<int64_t>;
       case NPY_UINT8: return GatherSum<uint64_t>;
       case NPY_UINT16:return GatherSum<uint64_t>;
-      CASE_NPY_UINT32:return GatherSum<uint64_t>;
-      CASE_NPY_UINT64:return GatherSum<uint64_t>;
+      case NPY_UINT32:return GatherSum<uint64_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return GatherSum<uint64_t>;
       }
       break;
 
    case GB_MEAN:
    case GB_NANMEAN:
       switch (outputType) {
-      case NPY_FLOAT:  return GatherMean<float>;
+      case NPY_FLOAT:
+         return GatherMean<float>;
       case NPY_BOOL:    
       case NPY_DOUBLE: 
       case NPY_LONGDOUBLE: 
       case NPY_INT8:  
       case NPY_INT16: 
-      CASE_NPY_INT32: 
-      CASE_NPY_INT64: 
+      case NPY_INT32: 
+      case NPY_INT64:
+      case NPY_LONGLONG:
       case NPY_UINT8: 
       case NPY_UINT16:
-      CASE_NPY_UINT32:
-      CASE_NPY_UINT64:return GatherMean<double>;
+      case NPY_UINT32:
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return GatherMean<double>;
       }
       break;
 
@@ -2078,12 +2085,16 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: return GatherMaxFloat<long double>;
       case NPY_INT8:  return GatherMax<int8_t>;
       case NPY_INT16: return GatherMax<int16_t>;
-      CASE_NPY_INT32: return GatherMax<int32_t>;
-      CASE_NPY_INT64: return GatherMax<int64_t>;
+      case NPY_INT32: return GatherMax<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return GatherMax<int64_t>;
       case NPY_UINT8: return GatherMax<uint8_t>;
       case NPY_UINT16:return GatherMax<uint16_t>;
-      CASE_NPY_UINT32:return GatherMax<uint32_t>;
-      CASE_NPY_UINT64:return GatherMax<uint64_t>;
+      case NPY_UINT32:return GatherMax<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return GatherMax<uint64_t>;
       }
       break;
 
@@ -2096,12 +2107,16 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: return GatherMinFloat<long double>;
       case NPY_INT8:  return GatherMin<int8_t>;
       case NPY_INT16: return GatherMin<int16_t>;
-      CASE_NPY_INT32: return GatherMin<int32_t>;
-      CASE_NPY_INT64: return GatherMin<int64_t>;
+      case NPY_INT32: return GatherMin<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return GatherMin<int64_t>;
       case NPY_UINT8: return GatherMin<uint8_t>;
       case NPY_UINT16:return GatherMin<uint16_t>;
-      CASE_NPY_UINT32:return GatherMin<uint32_t>;
-      CASE_NPY_UINT64:return GatherMin<uint64_t>;
+      case NPY_UINT32:return GatherMin<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return GatherMin<uint64_t>;
       }
       break;
    default:
@@ -2118,7 +2133,7 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
 template<typename V>
 static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutputType, int inputType,  GB_FUNCTIONS func) {
 
-   *hasCounts = FALSE;
+   *hasCounts = false;
    switch (func) {
    case GB_SUM:
       switch (inputType) {
@@ -2128,12 +2143,16 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumSum;
       case NPY_INT8:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t,    int64_t,  V>::AccumSum;
       case NPY_INT16:  *wantedOutputType = NPY_INT64; return GroupByBase<int16_t,   int64_t,  V>::AccumSum;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t,   int64_t,  V>::AccumSum;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<int64_t,   int64_t,  V>::AccumSum;
+      case NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t,   int64_t,  V>::AccumSum;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         *wantedOutputType = NPY_INT64; return GroupByBase<int64_t,   int64_t,  V>::AccumSum;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT64; return GroupByBase<uint8_t,  uint64_t, V>::AccumSum;
       case NPY_UINT16: *wantedOutputType = NPY_UINT64; return GroupByBase<uint16_t, uint64_t, V>::AccumSum;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumSum;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumSum;
+      case NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumSum;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumSum;
       default:break;
       }
 
@@ -2146,17 +2165,21 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_BOOL:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t, int64_t, V>::AccumSum;
       case NPY_INT8:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t, int64_t, V>::AccumNanSum;
       case NPY_INT16:  *wantedOutputType = NPY_INT64; return GroupByBase<int16_t, int64_t, V>::AccumNanSum;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t, int64_t, V>::AccumNanSum;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanSum;
+      case NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t, int64_t, V>::AccumNanSum;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanSum;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT64; return GroupByBase<uint8_t, uint64_t, V>::AccumNanSum;
       case NPY_UINT16: *wantedOutputType = NPY_UINT64; return GroupByBase<uint16_t, uint64_t, V>::AccumNanSum;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumNanSum;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanSum;
+      case NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumNanSum;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanSum;
       default:break;
       }
 
    case GB_MIN:
-      *hasCounts = TRUE;
+      *hasCounts = true;
       switch (inputType) {
       case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMin;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumMin;
@@ -2164,35 +2187,43 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumMin;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t,     int8_t, V>::AccumMin;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t,   int16_t, V>::AccumMin;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t,   int32_t, V>::AccumMin;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<int64_t,   int64_t, V>::AccumMin;
+      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t,   int32_t, V>::AccumMin;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         *wantedOutputType = NPY_INT64; return GroupByBase<int64_t,   int64_t, V>::AccumMin;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t,   uint8_t, V>::AccumMin;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumMin;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMin;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumMin;
+      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMin;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumMin;
       default:break;
       }
 
    case GB_NANMIN:
-      *hasCounts = TRUE;
+      *hasCounts = true;
       switch (inputType) {
-      case NPY_FLOAT:  *hasCounts = FALSE; *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumNanMin;
-      case NPY_DOUBLE: *hasCounts = FALSE; *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumNanMin;
-      case NPY_LONGDOUBLE: *hasCounts = FALSE; *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumNanMin;
+      case NPY_FLOAT:  *hasCounts = false; *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumNanMin;
+      case NPY_DOUBLE: *hasCounts = false; *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumNanMin;
+      case NPY_LONGDOUBLE: *hasCounts = false; *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumNanMin;
       case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMin;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumNanMin;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumNanMin;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMin;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanMin;
+      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMin;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanMin;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumNanMin;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumNanMin;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMin;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanMin;
+      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMin;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanMin;
       default:break;
       }
 
    case GB_MAX:
-      *hasCounts = TRUE;
+      *hasCounts = true;
       switch (inputType) {
       case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMax;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumMax;
@@ -2200,18 +2231,22 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumMax;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumMax;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumMax;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumMax;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumMax;
+      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumMax;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumMax;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumMax;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumMax;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMax;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumMax;
+      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMax;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumMax;
       default:break;
       }
 
 
    case GB_NANMAX:
-      *hasCounts = TRUE;
+      *hasCounts = true;
       switch (inputType) {
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumNanMax;
       case NPY_DOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumNanMax;
@@ -2219,17 +2254,21 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMax;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumNanMax;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumNanMax;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMax;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanMax;
+      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMax;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanMax;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumNanMax;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumNanMax;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMax;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanMax;
+      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMax;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanMax;
       default:break;
       }
 
    case GB_MEAN:
-      *hasCounts = TRUE;
+      *hasCounts = true;
       switch (inputType) {
       case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < int8_t,   double, V > ::AccumMean;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float,   float, V>::AccumMeanFloat;
@@ -2237,18 +2276,22 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumMean;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t,     double, V>::AccumMean;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t,   double, V>::AccumMean;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t,   double, V>::AccumMean;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t,   double, V>::AccumMean;
+      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t,   double, V>::AccumMean;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t,   double, V>::AccumMean;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t,   double, V>::AccumMean;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumMean;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumMean;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumMean;
+      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumMean;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumMean;
       default:break;
       }
 
 
    case GB_NANMEAN:
-      *hasCounts = TRUE;
+      *hasCounts = true;
       switch (inputType) {
       case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < int8_t, double, V > ::AccumNanMean;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumNanMeanFloat;
@@ -2256,18 +2299,22 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanMean;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanMean;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanMean;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanMean;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanMean;
+      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanMean;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanMean;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanMean;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanMean;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanMean;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanMean;
+      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanMean;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanMean;
       default:break;
       }
 
 
    case GB_VAR:
-      *hasCounts = TRUE;
+      *hasCounts = true;
       switch (inputType) {
       case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < int8_t, double, V > ::AccumVar;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumVar;
@@ -2275,18 +2322,22 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumVar;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumVar;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumVar;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumVar;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumVar;
+      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumVar;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumVar;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumVar;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumVar;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumVar;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumVar;
+      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumVar;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumVar;
       default:break;
       }
 
 
    case GB_NANVAR:
-      *hasCounts = TRUE;
+      *hasCounts = true;
       switch (inputType) {
       case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < int8_t, double, V > ::AccumNanVar;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumNanVar;
@@ -2294,17 +2345,21 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanVar;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanVar;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanVar;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanVar;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanVar;
+      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanVar;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanVar;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanVar;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanVar;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanVar;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanVar;
+      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanVar;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanVar;
       default:break;
       }
 
    case GB_STD:
-      *hasCounts = TRUE;
+      *hasCounts = true;
       switch (inputType) {
       case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < int8_t, double, V > ::AccumStd;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumStd;
@@ -2312,18 +2367,22 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumStd;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumStd;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumStd;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumStd;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumStd;
+      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumStd;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumStd;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumStd;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumStd;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumStd;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumStd;
+      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumStd;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumStd;
       default:break;
       }
 
 
    case GB_NANSTD:
-      *hasCounts = TRUE;
+      *hasCounts = true;
       switch (inputType) {
       case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < int8_t, double, V > ::AccumNanStd;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumNanStd;
@@ -2331,12 +2390,16 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanStd;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanStd;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanStd;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanStd;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanStd;
+      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanStd;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanStd;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanStd;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanStd;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanStd;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanStd;
+      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanStd;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanStd;
       default:break;
       }
 
@@ -2380,12 +2443,16 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_LONGDOUBLE: return GroupByBase<long double, double, V>::AccumTrimMeanBR;
       case NPY_INT8:   return GroupByBase<int8_t, double, V>::AccumTrimMeanBR;
       case NPY_INT16:  return GroupByBase<int16_t, double, V>::AccumTrimMeanBR;
-      CASE_NPY_INT32:  return GroupByBase<int32_t, double, V>::AccumTrimMeanBR;
-      CASE_NPY_INT64:  return GroupByBase<int64_t, double, V>::AccumTrimMeanBR;
+      case NPY_INT32:  return GroupByBase<int32_t, double, V>::AccumTrimMeanBR;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return GroupByBase<int64_t, double, V>::AccumTrimMeanBR;
       case NPY_UINT8:  return GroupByBase<uint8_t, double, V>::AccumTrimMeanBR;
       case NPY_UINT16: return GroupByBase<uint16_t, double, V>::AccumTrimMeanBR;
-      CASE_NPY_UINT32: return GroupByBase<uint32_t, double, V>::AccumTrimMeanBR;
-      CASE_NPY_UINT64: return GroupByBase<uint64_t, double, V>::AccumTrimMeanBR;
+      case NPY_UINT32: return GroupByBase<uint32_t, double, V>::AccumTrimMeanBR;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return GroupByBase<uint64_t, double, V>::AccumTrimMeanBR;
       }
       return NULL;
    } else
@@ -2393,8 +2460,10 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       switch (inputType) {
       case NPY_INT8:   return GroupByBase<int8_t, int32_t, V>::GetXFunc2(func);
       case NPY_INT16:  return GroupByBase<int16_t, int32_t, V>::GetXFunc2(func);
-      CASE_NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
-      CASE_NPY_INT64:  return GroupByBase<int64_t, int32_t, V>::GetXFunc2(func);
+      case NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return GroupByBase<int64_t, int32_t, V>::GetXFunc2(func);
       }
       return NULL;
    } else
@@ -2408,12 +2477,16 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc2(func);
       case NPY_INT8:   return GroupByBase<int8_t, int8_t, V>::GetXFunc2(func);
       case NPY_INT16:  return GroupByBase<int16_t, int16_t, V>::GetXFunc2(func);
-      CASE_NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
-      CASE_NPY_INT64:  return GroupByBase<int64_t, int64_t, V>::GetXFunc2(func);
+      case NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return GroupByBase<int64_t, int64_t, V>::GetXFunc2(func);
       case NPY_UINT8:  return GroupByBase<uint8_t, uint8_t, V>::GetXFunc2(func);
       case NPY_UINT16: return GroupByBase<uint16_t, uint16_t, V>::GetXFunc2(func);
-      CASE_NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc2(func);
-      CASE_NPY_UINT64: return GroupByBase<uint64_t, uint64_t, V>::GetXFunc2(func);
+      case NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc2(func);
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return GroupByBase<uint64_t, uint64_t, V>::GetXFunc2(func);
       }
       return NULL;
    }
@@ -2428,36 +2501,45 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
          case NPY_LONGDOUBLE: return GroupByBase<long double, double, V>::GetXFunc2(func);
          case NPY_INT8:   return GroupByBase<int8_t, double, V>::GetXFunc2(func);
          case NPY_INT16:  return GroupByBase<int16_t, double, V>::GetXFunc2(func);
-         CASE_NPY_INT32:  return GroupByBase<int32_t, double, V>::GetXFunc2(func);
-         CASE_NPY_INT64:  return GroupByBase<int64_t, double, V>::GetXFunc2(func); 
+         case NPY_INT32:  return GroupByBase<int32_t, double, V>::GetXFunc2(func);
+         case NPY_INT64:
+         case NPY_LONGLONG:
+            return GroupByBase<int64_t, double, V>::GetXFunc2(func); 
          case NPY_UINT8:  return GroupByBase<uint8_t, double, V>::GetXFunc2(func);
          case NPY_UINT16: return GroupByBase<uint16_t, double, V>::GetXFunc2(func);
-         CASE_NPY_UINT32: return GroupByBase<uint32_t, double, V>::GetXFunc2(func);
-         CASE_NPY_UINT64: return GroupByBase<uint64_t, double, V>::GetXFunc2(func);
+         case NPY_UINT32: return GroupByBase<uint32_t, double, V>::GetXFunc2(func);
+         case NPY_UINT64:
+         case NPY_ULONGLONG:
+            return GroupByBase<uint64_t, double, V>::GetXFunc2(func);
          }
          return NULL;
       }
-      else
+      else {
 
-      // due to overflow, all ints become int64_t
-       LOGGING("Rolling+sum called with type %d\n", inputType);
-       switch (inputType) {
+         // due to overflow, all ints become int64_t
+         LOGGING("Rolling+sum called with type %d\n", inputType);
+         switch (inputType) {
           // really need to change output type for accumsum/rolling
-       case NPY_BOOL:   return GroupByBase<int8_t, int64_t, V>::GetXFunc2(func);
-       case NPY_FLOAT:  return GroupByBase<float, float, V>::GetXFunc2(func);
-       case NPY_DOUBLE: return GroupByBase<double, double, V>::GetXFunc2(func);
-       case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc2(func);
-       case NPY_INT8:   return GroupByBase<int8_t, int64_t, V>::GetXFunc2(func);
-       case NPY_INT16:  return GroupByBase<int16_t, int64_t, V>::GetXFunc2(func);
-       CASE_NPY_INT32:  return GroupByBase<int32_t, int64_t, V>::GetXFunc2(func);
-       CASE_NPY_INT64:  return GroupByBase<int64_t, int64_t, V>::GetXFunc2(func);
-       case NPY_UINT8:  return GroupByBase<uint8_t, int64_t, V>::GetXFunc2(func);
-       case NPY_UINT16: return GroupByBase<uint16_t, int64_t, V>::GetXFunc2(func);
-       CASE_NPY_UINT32: return GroupByBase<uint32_t, int64_t, V>::GetXFunc2(func);
-       CASE_NPY_UINT64: return GroupByBase<uint64_t, int64_t, V>::GetXFunc2(func);
-       }
-    }
-    else {
+         case NPY_BOOL:   return GroupByBase<int8_t, int64_t, V>::GetXFunc2(func);
+         case NPY_FLOAT:  return GroupByBase<float, float, V>::GetXFunc2(func);
+         case NPY_DOUBLE: return GroupByBase<double, double, V>::GetXFunc2(func);
+         case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc2(func);
+         case NPY_INT8:   return GroupByBase<int8_t, int64_t, V>::GetXFunc2(func);
+         case NPY_INT16:  return GroupByBase<int16_t, int64_t, V>::GetXFunc2(func);
+         case NPY_INT32:  return GroupByBase<int32_t, int64_t, V>::GetXFunc2(func);
+         case NPY_INT64:
+         case NPY_LONGLONG:
+            return GroupByBase<int64_t, int64_t, V>::GetXFunc2(func);
+         case NPY_UINT8:  return GroupByBase<uint8_t, int64_t, V>::GetXFunc2(func);
+         case NPY_UINT16: return GroupByBase<uint16_t, int64_t, V>::GetXFunc2(func);
+         case NPY_UINT32: return GroupByBase<uint32_t, int64_t, V>::GetXFunc2(func);
+         case NPY_UINT64:
+         case NPY_ULONGLONG:
+            return GroupByBase<uint64_t, int64_t, V>::GetXFunc2(func);
+         }
+      }
+   }
+   else {
       switch (inputType) {
 
       // first,last,median,nth
@@ -2467,12 +2549,16 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc(func);
       case NPY_INT8:   return GroupByBase<int8_t, int8_t, V>::GetXFunc(func);
       case NPY_INT16:  return GroupByBase<int16_t, int16_t, V>::GetXFunc(func);
-      CASE_NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc(func);
-      CASE_NPY_INT64:  return GroupByBase<int64_t, int64_t, V>::GetXFunc(func);
+      case NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc(func);
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return GroupByBase<int64_t, int64_t, V>::GetXFunc(func);
       case NPY_UINT8:  return GroupByBase<uint8_t, uint8_t, V>::GetXFunc(func);
       case NPY_UINT16: return GroupByBase<uint16_t, uint16_t, V>::GetXFunc(func);
-      CASE_NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc(func);
-      CASE_NPY_UINT64: return GroupByBase<uint64_t, uint64_t, V>::GetXFunc(func);
+      case NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc(func);
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+         return GroupByBase<uint64_t, uint64_t, V>::GetXFunc(func);
       case NPY_STRING:
          return GroupByBase<char, char, V>::GetXFuncString(func);
       case NPY_UNICODE:
@@ -2489,7 +2575,7 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
 static bool BandedGroupByCall(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
    // -1 is the first core
    core = core + 1;
-   bool didSomeWork = FALSE;
+   bool didSomeWork = false;
    stGroupBy32* pGroupBy32 = (stGroupBy32*)pstWorkerItem->WorkCallbackArg;
 
    int64_t index;
@@ -2532,7 +2618,7 @@ static bool BandedGroupByCall(struct stMATH_WORKER_ITEM* pstWorkerItem, int core
       pGroupBy32->returnObjects[index].didWork = 1;
 
       // Indicate we completed a block
-      didSomeWork = TRUE;
+      didSomeWork = true;
 
       // tell others we completed this work block
       pstWorkerItem->CompleteWorkBlock();
@@ -2547,7 +2633,7 @@ static bool ScatterGroupByCall(struct stMATH_WORKER_ITEM* pstWorkerItem, int cor
    // -1 is the first core
    core = core + 1;
 
-   bool didSomeWork = FALSE;
+   bool didSomeWork = false;
    stGroupBy32* pGroupBy32 = (stGroupBy32*)pstWorkerItem->WorkCallbackArg;
    ArrayInfo* aInfo = pGroupBy32->aInfo;
 
@@ -2585,7 +2671,7 @@ static bool ScatterGroupByCall(struct stMATH_WORKER_ITEM* pstWorkerItem, int cor
       pGroupBy32->returnObjects[core].didWork = 1;
 
       // Indicate we completed a block
-      didSomeWork = TRUE;
+      didSomeWork = true;
 
       // tell others we completed this work block
       pstWorkerItem->CompleteWorkBlock();
@@ -2724,10 +2810,11 @@ GROUPBY_TWO_FUNC GetGroupByFunctionStep1(int32_t iKeyType, bool* hasCounts, int3
    case NPY_INT16:
       pFunction = GetGroupByFunction<int16_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
-   CASE_NPY_INT32:
+   case NPY_INT32:
       pFunction = GetGroupByFunction<int32_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
-   CASE_NPY_INT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       pFunction = GetGroupByFunction<int64_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
    }
@@ -2757,7 +2844,7 @@ GroupBySingleOpMultiBands(
    int32_t iKeyType = PyArray_TYPE(iKey);
 
    int32_t numpyOutType = aInfo[0].NumpyDType;
-   bool hasCounts = FALSE;
+   bool hasCounts = false;
 
    LOGGING("In banded groupby %d\n", (int)firstFuncNum);
 
@@ -2770,10 +2857,11 @@ GroupBySingleOpMultiBands(
    case NPY_INT16:
       pFunction = GetGroupByXFunction32<int16_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
-   CASE_NPY_INT32:
+   case NPY_INT32:
       pFunction = GetGroupByXFunction32<int32_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
-   CASE_NPY_INT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       pFunction = GetGroupByXFunction32<int64_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
    }
@@ -2782,7 +2870,7 @@ GroupBySingleOpMultiBands(
       void* pDataIn2 = PyArray_BYTES(iKey);
       int64_t arraySizeKey = ArrayLength(iKey);
 
-      INT numCores = g_cMathWorker->WorkerThreadCount + 1;
+      int32_t numCores = g_cMathWorker->WorkerThreadCount + 1;
       int64_t bins = binHigh - binLow;
       int64_t cores = numCores;
       if (bins < cores) cores = bins;
@@ -2892,7 +2980,7 @@ GroupBySingleOpMultiBands(
          LOGGING("before threaded\n");
 
          // This will notify the worker threads of a new work item
-         g_cMathWorker->WorkMain(pWorkItem, cores, 0, 1, FALSE);
+         g_cMathWorker->WorkMain(pWorkItem, cores, 0, 1, false);
          LOGGING("after threaded\n");
 
          WORKSPACE_FREE(pstGroupBy32);
@@ -2933,7 +3021,7 @@ GroupBySingleOpMultithreaded(
    int32_t iKeyType = PyArray_TYPE(iKey);
 
    int32_t numpyOutType = -1;
-   bool hasCounts = FALSE;
+   bool hasCounts = false;
 
    GROUPBY_TWO_FUNC  pFunction =
       GetGroupByFunctionStep1(iKeyType, &hasCounts, &numpyOutType, aInfo[0].NumpyDType, (GB_FUNCTIONS)firstFuncNum);
@@ -2949,7 +3037,7 @@ GroupBySingleOpMultithreaded(
 
       if (pWorkItem != NULL) {
 
-         INT numCores = g_cMathWorker->WorkerThreadCount + 1;
+         int32_t numCores = g_cMathWorker->WorkerThreadCount + 1;
 
          PyArrayObject* outArray = NULL;
 
@@ -3104,8 +3192,9 @@ GroupByAll32(PyObject *self, PyObject *args)
    switch (iKeyType) {
    case NPY_INT8:
    case NPY_INT16:
-   CASE_NPY_INT32:
-   CASE_NPY_INT64:
+   case NPY_INT32:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       break;
    default:
       PyErr_Format(PyExc_ValueError, "GroupByAll32 key param must be int8, int16, int32, int64 not type %d", iKeyType);
@@ -3153,7 +3242,7 @@ GroupByAll32(PyObject *self, PyObject *args)
    PyObject* returnTuple = NULL;
 
    // NOTE: what if bin size 10x larger?
-   if (TRUE && ((unique_rows * 10) < arraySizeKey) && tupleSize == 1) {
+   if (true && ((unique_rows * 10) < arraySizeKey) && tupleSize == 1) {
 
       int64_t binLow = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinLow, 0), &overflow);
       int64_t binHigh = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinHigh, 0), &overflow);
@@ -3200,7 +3289,7 @@ GroupByAll32(PyObject *self, PyObject *args)
 
          // TODO: determine based on function
          int32_t numpyOutType = -1;
-         bool hasCounts = FALSE;
+         bool hasCounts = false;
 
          int overflow = 0;
          int64_t funcNum = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listFuncNum, i), &overflow);
@@ -3349,8 +3438,9 @@ GroupByAllPack32(PyObject *self, PyObject *args)
    switch (iKeyType) {
    case NPY_INT8:
    case NPY_INT16:
-   CASE_NPY_INT32:
-   CASE_NPY_INT64:
+   case NPY_INT32:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       break;
    default:
       PyErr_Format(PyExc_ValueError, "GroupByAllPack32 key param must int8, int16, int32, int64");
@@ -3468,10 +3558,11 @@ GroupByAllPack32(PyObject *self, PyObject *args)
          case NPY_INT16:
             pFunction = GetGroupByXFunction32<int16_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
-         CASE_NPY_INT32:
+         case NPY_INT32:
             pFunction = GetGroupByXFunction32<int32_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
-         CASE_NPY_INT64:
+         case NPY_INT64:
+         case NPY_LONGLONG:
             pFunction = GetGroupByXFunction32<int64_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
          }
@@ -3511,10 +3602,12 @@ GroupByAllPack32(PyObject *self, PyObject *args)
                         case NPY_FLOAT32:
                            numpyOutType = NPY_FLOAT32;
                            break;
-                        CASE_NPY_FLOAT64:
+                        case NPY_DOUBLE:
+                        case NPY_LONGDOUBLE:
                            numpyOutType = NPY_FLOAT64;
                            break;
-                        CASE_NPY_UINT64:
+                        case NPY_UINT64:
+                        case NPY_ULONGLONG:
                            numpyOutType = NPY_UINT64;
                            break;
                         }

--- a/src/GroupBy.cpp
+++ b/src/GroupBy.cpp
@@ -39,7 +39,7 @@ enum GB_FUNCTIONS {
    GB_MODE=104,    // auto handles nan
    GB_TRIMBR=105,  // auto handles nan
 
-   // All int/uints output upgraded to INT64
+   // All int/uints output upgraded to int64_t
    // Output is all elements (not just grouped)
    // Input must be same length
    GB_ROLLING_SUM = 200,
@@ -55,14 +55,14 @@ enum GB_FUNCTIONS {
 
 // Overloads to handle case of bool
 inline  bool   MEDIAN_SPLIT(bool X, bool Y) { return (X | Y); }
-inline  INT8   MEDIAN_SPLIT(INT8 X, INT8 Y) { return (X + Y) / 2; }
-inline  UINT8  MEDIAN_SPLIT(UINT8 X, UINT8 Y) { return (X + Y) / 2; }
-inline  INT16  MEDIAN_SPLIT(INT16 X, INT16 Y) { return (X + Y) / 2; }
-inline  UINT16 MEDIAN_SPLIT(UINT16 X, UINT16 Y) { return (X + Y) / 2; }
-inline  INT32  MEDIAN_SPLIT(INT32 X, INT32 Y) { return (X + Y) / 2; }
-inline  UINT32 MEDIAN_SPLIT(UINT32 X, UINT32 Y) { return (X + Y) / 2; }
-inline  INT64  MEDIAN_SPLIT(INT64 X, INT64 Y) { return (X + Y) / 2; }
-inline  UINT64 MEDIAN_SPLIT(UINT64 X, UINT64 Y) { return (X + Y) / 2; }
+inline  int8_t   MEDIAN_SPLIT(int8_t X, int8_t Y) { return (X + Y) / 2; }
+inline  uint8_t  MEDIAN_SPLIT(uint8_t X, uint8_t Y) { return (X + Y) / 2; }
+inline  int16_t  MEDIAN_SPLIT(int16_t X, int16_t Y) { return (X + Y) / 2; }
+inline  uint16_t MEDIAN_SPLIT(uint16_t X, uint16_t Y) { return (X + Y) / 2; }
+inline  int32_t  MEDIAN_SPLIT(int32_t X, int32_t Y) { return (X + Y) / 2; }
+inline  uint32_t MEDIAN_SPLIT(uint32_t X, uint32_t Y) { return (X + Y) / 2; }
+inline  int64_t  MEDIAN_SPLIT(int64_t X, int64_t Y) { return (X + Y) / 2; }
+inline  uint64_t MEDIAN_SPLIT(uint64_t X, uint64_t Y) { return (X + Y) / 2; }
 inline  float  MEDIAN_SPLIT(float X, float Y) { return (X + Y) / 2; }
 inline  double MEDIAN_SPLIT(double X, double Y) { return (X + Y) / 2; }
 inline  long double MEDIAN_SPLIT(long double X, long double Y) { return (X + Y) / 2; }
@@ -164,7 +164,7 @@ static size_t strip_nans(T *x, size_t n) {
 //-------------------------------------------------------------------
 // T = data type as input
 // U = data type as output
-// V - index type (INT8, INT16, INT32, INT64)
+// V - index type (int8_t, int16_t, int32_t, int64_t)
 // thus <float, int32> converts a float to an int32
 template<typename T, typename U, typename V>
 class GroupByBase {
@@ -174,10 +174,10 @@ public:
 
    // Pass in two vectors and return one vector
    // Used for operations like C = A + B
-   //typedef void(*ANY_TWO_FUNC)(void* pDataIn, void* pDataIn2, void* pDataOut, INT64 len, INT32 scalarMode);
-   //typedef void(*ANY_ONE_FUNC)(void* pDataIn, void* pDataOut, INT64 len);
+   //typedef void(*ANY_TWO_FUNC)(void* pDataIn, void* pDataIn2, void* pDataOut, int64_t len, int32_t scalarMode);
+   //typedef void(*ANY_ONE_FUNC)(void* pDataIn, void* pDataOut, int64_t len);
 
-   static void AccumSum(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumSum(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -188,7 +188,7 @@ public:
          memset(pOut + binLow, 0, sizeof(U) * (binHigh - binLow));
       }
 
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          V index = pIndex[i];
 
          ACCUM_INNER_LOOP(index, binLow, binHigh)
@@ -198,16 +198,16 @@ public:
    }
 
    // This routine is only for float32.  It will upcast to float64, add up all the numbers, then convert back to float32
-   static void AccumSumFloat(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumSumFloat(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
 
       float* pIn = (float*)pDataIn;
       float* pOut = (float*)pDataOut;
       V* pIndex = (V*)pIndexT;
       double* pOutAccum = NULL;
 
-      const INT64 maxStackAlloc = (1024 * 1024);  // 1 MB
+      const int64_t maxStackAlloc = (1024 * 1024);  // 1 MB
 
-      INT64 allocSize = (binHigh - binLow)*sizeof(double);
+      int64_t allocSize = (binHigh - binLow)*sizeof(double);
 
       if (allocSize > maxStackAlloc) {
          pOutAccum = (double*)WORKSPACE_ALLOC(allocSize);
@@ -223,13 +223,13 @@ public:
       }
       else {
          // Upcast from single to double
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
             pOutAccum[i - binLow] = pOut[i];
          }
       }
 
       // Main loop
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          V index = pIndex[i];
 
          ACCUM_INNER_LOOP(index, binLow, binHigh)
@@ -238,7 +238,7 @@ public:
       }
 
       // Downcast from double to single
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
          pOut[i] = (float)pOutAccum[i - binLow];
       }
       if (allocSize > maxStackAlloc) {
@@ -248,7 +248,7 @@ public:
 
 
    //-------------------------------------------------------------------------------
-   static void AccumNanSum(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumNanSum(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
       V* pIndex = (V*)pIndexT;
@@ -263,7 +263,7 @@ public:
 
       if (invalid == invalid) {
          // non-float path
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             V index = pIndex[i];
 
             //--------------------------------------
@@ -278,7 +278,7 @@ public:
       }
       else {
          // float path
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             V index = pIndex[i];
 
             //--------------------------------------
@@ -294,7 +294,7 @@ public:
 
 
    //-------------------------------------------------------------------------------
-   static void AccumMin(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumMin(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
       V* pIndex = (V*)pIndexT;
@@ -303,12 +303,12 @@ public:
       U invalid = GET_INVALID(pOut[0]);
 
       if (pass <= 0) {
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
             pOut[i] = invalid;
          }
       }
 
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          V index = pIndex[i];
 
          //--------------------------------------
@@ -330,7 +330,7 @@ public:
 
 
    //-------------------------------------------------------------------------------
-   static void AccumNanMin(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumNanMin(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
       V* pIndex = (V*)pIndexT;
@@ -339,14 +339,14 @@ public:
       U invalid = GET_INVALID(pOut[0]);
       if (pass <= 0) {
          //printf("NanMin clearing at %p  %lld  %lld\n", pOut, binLow, binHigh);
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
             pOut[i] = invalid;
          }
       }
 
       if (invalid == invalid) {
          // non-float path
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             V index = pIndex[i];
 
             //--------------------------------------
@@ -366,7 +366,7 @@ public:
 
       } else {
          // float path
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             V index = pIndex[i];
 
             //--------------------------------------
@@ -388,7 +388,7 @@ public:
 
 
    //-------------------------------------------------------------------------------
-   static void AccumMax(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumMax(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
       V* pIndex = (V*)pIndexT;
@@ -396,12 +396,12 @@ public:
       // Fill with invalid?
       U invalid = GET_INVALID(pOut[0]);
       if (pass <= 0) {
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
             pOut[i] = invalid;
          }
       }
 
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          V index = pIndex[i];
 
          //--------------------------------------
@@ -424,7 +424,7 @@ public:
 
 
    //-------------------------------------------------------------------------------
-   static void AccumNanMax(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumNanMax(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
       V* pIndex = (V*)pIndexT;
@@ -432,14 +432,14 @@ public:
       // Fill with invalid?
       U invalid = GET_INVALID(pOut[0]);
       if (pass <= 0) {
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
             pOut[i] = invalid;
          }
       }
 
       if (invalid == invalid) {
          // non-float path
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             V index = pIndex[i];
 
             //--------------------------------------
@@ -459,7 +459,7 @@ public:
 
       } else {
          // float path
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             V index = pIndex[i];
 
             //--------------------------------------
@@ -484,7 +484,7 @@ public:
 
 
    //-------------------------------------------------------------------------------
-   static void AccumMean(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumMean(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
       V* pIndex = (V*)pIndexT;
@@ -494,7 +494,7 @@ public:
          memset(pOut + binLow, 0, sizeof(U) * (binHigh - binLow));
       }
 
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          V index = pIndex[i];
 
          //--------------------------------------
@@ -506,7 +506,7 @@ public:
       }
 
       if (pass < 0) {
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
             if (pCountOut[i] > 0) {
                pOut[i] /= (U)(pCountOut[i]);
             }
@@ -520,7 +520,7 @@ public:
 
    // Just for float32 since we can upcast
    //-------------------------------------------------------------------------------
-   static void AccumMeanFloat(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumMeanFloat(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
       T* pIn = (T*)pDataIn;
       U* pOriginalOut = (U*)pDataOut;
       V* pIndex = (V*)pIndexT;
@@ -533,11 +533,11 @@ public:
             memset(pOriginalOut + binLow, 0, sizeof(U) * (binHigh - binLow));
          }
          // copy over original values
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
             pOut[i - binLow] = (double)pOriginalOut[i];
          }
 
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             V index = pIndex[i];
 
             //--------------------------------------
@@ -549,7 +549,7 @@ public:
          }
 
          if (pass < 0) {
-            for (INT64 i = binLow; i < binHigh; i++) {
+            for (int64_t i = binLow; i < binHigh; i++) {
                if (pCountOut[i] > 0) {
                   pOriginalOut[i] = (U)(pOut[i-binLow] / (double)(pCountOut[i]));
                }
@@ -560,7 +560,7 @@ public:
          }
          else {
             // copy over original values
-            for (INT64 i = binLow; i < binHigh; i++) {
+            for (int64_t i = binLow; i < binHigh; i++) {
                pOriginalOut[i] = (U)pOut[i - binLow];
             }
          }
@@ -570,7 +570,7 @@ public:
    }
 
    //-------------------------------------------------------------------------------
-   static void AccumNanMean(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumNanMean(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
       T* pIn = (T*)pDataIn;
       U* pOriginalOut = (U*)pDataOut;
       V* pIndex = (V*)pIndexT;
@@ -583,11 +583,11 @@ public:
             memset(pOriginalOut + binLow, 0, sizeof(U) * (binHigh - binLow));
          }
          // copy over original values
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
             pOut[i - binLow] = (double)pOriginalOut[i];
          }
 
-         for (INT64 i = 0; i < len; i++) {
+         for (int64_t i = 0; i < len; i++) {
             V index = pIndex[i];
 
             //--------------------------------------
@@ -600,7 +600,7 @@ public:
             }
          }
          if (pass < 0) {
-            for (INT64 i = binLow; i < binHigh; i++) {
+            for (int64_t i = binLow; i < binHigh; i++) {
                if (pCountOut[i] > 0) {
                   pOriginalOut[i] = (U)(pOut[i - binLow] / (double)(pCountOut[i]));
                }
@@ -611,7 +611,7 @@ public:
          }
          else {
             // copy over original values
-            for (INT64 i = binLow; i < binHigh; i++) {
+            for (int64_t i = binLow; i < binHigh; i++) {
                pOriginalOut[i] = (U)pOut[i - binLow];
             }
          }
@@ -620,7 +620,7 @@ public:
    }
 
    //-------------------------------------------------------------------------------
-   static void AccumNanMeanFloat(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumNanMeanFloat(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
       V* pIndex = (V*)pIndexT;
@@ -630,7 +630,7 @@ public:
          memset(pOut + binLow, 0, sizeof(U) * (binHigh - binLow));
       }
 
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          V index = pIndex[i];
 
          //--------------------------------------
@@ -644,7 +644,7 @@ public:
       }
 
       if (pass < 0) {
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
             if (pCountOut[i] > 0) {
                pOut[i] /= (U)(pCountOut[i]);
             }
@@ -657,7 +657,7 @@ public:
 
 
    //-------------------------------------------------------------------------------
-   static void AccumVar(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumVar(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
       V* pIndex = (V*)pIndexT;
@@ -671,7 +671,7 @@ public:
       U* sumsquares = (U*)WORKSPACE_ALLOC(sizeof(U) * binHigh);
       memset(sumsquares, 0, sizeof(U) * binHigh);
 
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          V index = pIndex[i];
 
          //--------------------------------------
@@ -682,11 +682,11 @@ public:
          }
       }
 
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
          pOut[i] /= (U)(pCountOut[i]);
       }
 
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          V index = pIndex[i];
 
          //--------------------------------------
@@ -697,7 +697,7 @@ public:
          }
       }
 
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
          if (pCountOut[i] > 1) {
             pOut[i] = sumsquares[i] / (U)(pCountOut[i] - 1);
          }
@@ -711,7 +711,7 @@ public:
 
 
    //-------------------------------------------------------------------------------
-   static void AccumNanVar(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumNanVar(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
       V* pIndex = (V*)pIndexT;
@@ -724,7 +724,7 @@ public:
       U* sumsquares = (U*)WORKSPACE_ALLOC(sizeof(U) * binHigh);
       memset(sumsquares, 0, sizeof(U) * binHigh);
 
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          V index = pIndex[i];
 
          //--------------------------------------
@@ -737,11 +737,11 @@ public:
          }
       }
 
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
          pOut[i] /= (U)(pCountOut[i]);
       }
 
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          V index = pIndex[i];
 
          //--------------------------------------
@@ -754,7 +754,7 @@ public:
          }
       }
 
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
          if (pCountOut[i] > 1) {
             pOut[i] = sumsquares[i] / (U)(pCountOut[i] - 1);
          }
@@ -767,22 +767,22 @@ public:
    }
 
    //-------------------------------------------------------------------------------
-   static void AccumStd(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumStd(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
 
       U* pOut = (U*)pDataOut;
       AccumVar( pDataIn, pIndexT, pCountOut,  pDataOut, len, binLow, binHigh, pass);
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
          pOut[i] = sqrt(pOut[i]);
       }
 
    }
 
    //-------------------------------------------------------------------------------
-   static void AccumNanStd(void* pDataIn, void* pIndexT, INT32* pCountOut, void* pDataOut, INT64 len, INT64 binLow, INT64 binHigh, INT64 pass) {
+   static void AccumNanStd(void* pDataIn, void* pIndexT, int32_t* pCountOut, void* pDataOut, int64_t len, int64_t binLow, int64_t binHigh, int64_t pass) {
       U* pOut = (U*)pDataOut;
 
       AccumNanVar(pDataIn, pIndexT, pCountOut, pDataOut, len, binLow, binHigh, pass);
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
          pOut[i] = sqrt(pOut[i]);
       }
 
@@ -790,22 +790,22 @@ public:
 
    //-------------------------------------------------------------------------------
    // V is is the INDEX Type
-   static void AccumNth(void* pColumn, void* pGroupT, INT32* pFirst, INT32* pCount, void* pAccumBin, INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam) {
+   static void AccumNth(void* pColumn, void* pGroupT, int32_t* pFirst, int32_t* pCount, void* pAccumBin, int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam) {
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
-      INT32 nth = (INT32)funcParam;
+      int32_t nth = (int32_t)funcParam;
 
       U invalid = GET_INVALID(pDest[0]);
 
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
 
          if (pCount[i] > 0 && nth < pCount[i]) {
-            INT32 grpIndex = pFirst[i] + nth;
-            INT32 bin = pGroup[grpIndex];
+            int32_t grpIndex = pFirst[i] + nth;
+            int32_t bin = pGroup[grpIndex];
             pDest[i] = pSrc[bin];
          }
          else {
@@ -816,19 +816,19 @@ public:
 
 
    //-------------------------------------------------------------------------------
-   static void AccumNthString(void* pColumn, void* pGroupT, INT32* pFirst, INT32* pCount, void* pAccumBin, INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam) {
+   static void AccumNthString(void* pColumn, void* pGroupT, int32_t* pFirst, int32_t* pCount, void* pAccumBin, int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam) {
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
-      INT32 nth = (INT32)funcParam;
+      int32_t nth = (int32_t)funcParam;
 
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
          if (pCount[i] > 0 && nth < pCount[i]) {
-            INT32 grpIndex = pFirst[i] + nth;
-            INT32 bin = pGroup[grpIndex];
+            int32_t grpIndex = pFirst[i] + nth;
+            int32_t bin = pGroup[grpIndex];
             memcpy(&pDest[i*itemSize], &pSrc[bin*itemSize], itemSize);
          }
          else {
@@ -841,24 +841,24 @@ public:
 
    //-------------------------------------------------------------------------------
    // V is is the INDEX Type
-   static void AccumFirst(void* pColumn, void* pGroupT, INT32* pFirst, INT32* pCount, void* pAccumBin, INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam) {
+   static void AccumFirst(void* pColumn, void* pGroupT, int32_t* pFirst, int32_t* pCount, void* pAccumBin, int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam) {
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
       LOGGING("in accum first low: %lld  high: %lld   group:%p  first:%p  count:%p\n", binLow, binHigh, pGroup, pFirst, pCount);
 
       U invalid = GET_INVALID(pDest[0]);
 
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
          //printf("[%lld]", i);
          if (pCount[i] > 0) {
-            INT32 grpIndex = pFirst[i];
+            int32_t grpIndex = pFirst[i];
             //printf("(%d)", grpIndex);
-            INT32 bin = pGroup[grpIndex];
-            //printf("{%lld}", (INT64)bin);
+            int32_t bin = pGroup[grpIndex];
+            //printf("{%lld}", (int64_t)bin);
             pDest[i] = pSrc[bin];
          }
          else {
@@ -868,17 +868,17 @@ public:
    }
 
    //-------------------------------------------------------------------------------
-   static void AccumFirstString(void* pColumn, void* pGroupT, INT32* pFirst, INT32* pCount, void* pAccumBin, INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam) {
+   static void AccumFirstString(void* pColumn, void* pGroupT, int32_t* pFirst, int32_t* pCount, void* pAccumBin, int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam) {
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
          if (pCount[i] > 0) {
-            INT32 grpIndex = pFirst[i];
-            INT32 bin = pGroup[grpIndex];
+            int32_t grpIndex = pFirst[i];
+            int32_t bin = pGroup[grpIndex];
             memcpy(&pDest[i*itemSize], &pSrc[bin*itemSize], itemSize);
          }
          else {
@@ -888,22 +888,22 @@ public:
    }
 
    //-------------------------------------------------------------------------------
-   static void AccumLast(void* pColumn, void* pGroupT, INT32* pFirst, INT32* pCount, void* pAccumBin, INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam) {
+   static void AccumLast(void* pColumn, void* pGroupT, int32_t* pFirst, int32_t* pCount, void* pAccumBin, int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam) {
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
       U invalid = GET_INVALID(pDest[0]);
       //printf("last called %lld -- %llu %llu %llu\n", numUnique, sizeof(T), sizeof(U), sizeof(V));
 
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
          //printf("Last:  %d %d\n", (int)pFirst[i], (int)pCount[i]);
          //printf("Last2:  %d\n", (int)(pGroup[pFirst[i] + pCount[i] - 1]));
          if (pCount[i] > 0) {
-            INT32 grpIndex = pFirst[i] + pCount[i] - 1;
-            INT32 bin = pGroup[grpIndex];
+            int32_t grpIndex = pFirst[i] + pCount[i] - 1;
+            int32_t bin = pGroup[grpIndex];
             pDest[i] = pSrc[bin];
          } else {
             pDest[i] = invalid;
@@ -912,17 +912,17 @@ public:
    }
 
    //-------------------------------------------------------------------------------
-   static void AccumLastString(void* pColumn, void* pGroupT, INT32* pFirst, INT32* pCount, void* pAccumBin, INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam) {
+   static void AccumLastString(void* pColumn, void* pGroupT, int32_t* pFirst, int32_t* pCount, void* pAccumBin, int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam) {
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
          if (pCount[i] > 0) {
-            INT32 grpIndex = pFirst[i] + pCount[i] - 1;
-            INT32 bin = pGroup[grpIndex];
+            int32_t grpIndex = pFirst[i] + pCount[i] - 1;
+            int32_t bin = pGroup[grpIndex];
             memcpy(&pDest[i*itemSize], &pSrc[bin*itemSize], itemSize);
          }
          else {
@@ -934,33 +934,33 @@ public:
 
    //------------------------------
    // Rolling uses entire size: totalInputRows
-   // TODO: Check if group is always INT32
+   // TODO: Check if group is always int32_t
    static void AccumRollingSum(
       void* pColumn, 
       void* pGroupT, 
-      INT32* pFirst, 
-      INT32* pCount, 
+      int32_t* pFirst, 
+      int32_t* pCount, 
       void* pAccumBin, 
-      INT64 binLow, 
-      INT64 binHigh, 
-      INT64 totalInputRows, 
-      INT64 itemSize, 
-      INT64 funcParam) {
+      int64_t binLow, 
+      int64_t binHigh, 
+      int64_t totalInputRows, 
+      int64_t itemSize, 
+      int64_t funcParam) {
 
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
-      INT32 windowSize = (INT32)funcParam;
+      int32_t windowSize = (int32_t)funcParam;
       U invalid = GET_INVALID(pDest[0]);
 
       if (binLow == 0) {
          // Mark all invalid if invalid bin
-         INT32 start = pFirst[0];
-         INT32 last = start + pCount[0];
+         int32_t start = pFirst[0];
+         int32_t last = start + pCount[0];
          for (int j = start; j < last; j++) {
-            INT32 index = pGroup[j];
+            int32_t index = pGroup[j];
             pDest[index] = invalid;
          }
          binLow++;
@@ -970,22 +970,22 @@ public:
       if (windowSize < 0) return;
 
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
-         INT32 start = pFirst[i];
-         INT32 last = start + pCount[i];
+      for (int64_t i = binLow; i < binHigh; i++) {
+         int32_t start = pFirst[i];
+         int32_t last = start + pCount[i];
 
          U currentSum = 0;
 
          // Priming of the summation
          for (int j = start; j < last && j < (start + windowSize); j++) {
-            INT32 index = pGroup[j];
+            int32_t index = pGroup[j];
 
             currentSum += (U)pSrc[index];
             pDest[index] = currentSum;
          }
 
          for (int j = start + windowSize; j < last; j++) {
-            INT32 index = pGroup[j];
+            int32_t index = pGroup[j];
 
             currentSum += (U)pSrc[index];
 
@@ -1000,35 +1000,35 @@ public:
 
    //------------------------------
    // Rolling uses entire size: totalInputRows
-   // TODO: Check if group is always INT32
+   // TODO: Check if group is always int32_t
    static void AccumRollingNanSum(
       void* pColumn,
       void* pGroupT,
-      INT32* pFirst,
-      INT32* pCount,
+      int32_t* pFirst,
+      int32_t* pCount,
       void* pAccumBin,
-      INT64 binLow,
-      INT64 binHigh,
-      INT64 totalInputRows,
-      INT64 itemSize,
-      INT64 funcParam) {
+      int64_t binLow,
+      int64_t binHigh,
+      int64_t totalInputRows,
+      int64_t itemSize,
+      int64_t funcParam) {
 
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
 
-      // TODO allow INT64 in the future
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // TODO allow int64_t in the future
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
-      INT32 windowSize = (INT32)funcParam;
+      int32_t windowSize = (int32_t)funcParam;
       U invalid = GET_INVALID(pDest[0]);
 
       if (binLow == 0) {
          // Mark all invalid if invalid bin
-         INT32 start = pFirst[0];
-         INT32 last = start + pCount[0];
+         int32_t start = pFirst[0];
+         int32_t last = start + pCount[0];
          for (int j = start; j < last; j++) {
-            INT32 index = pGroup[j];
+            int32_t index = pGroup[j];
             pDest[index] = invalid;
          }
          binLow++;
@@ -1040,15 +1040,15 @@ public:
       if (invalid == invalid) {
          // NOT FLOAT (integer based)
          // For all the bins we have to fill
-         for (INT64 i = binLow; i < binHigh; i++) {
-            INT32 start = pFirst[i];
-            INT32 last = start + pCount[i];
+         for (int64_t i = binLow; i < binHigh; i++) {
+            int32_t start = pFirst[i];
+            int32_t last = start + pCount[i];
 
             U currentSum = 0;
 
             // Priming of the summation
             for (int j = start; j < last && j < (start + windowSize); j++) {
-               INT32 index = pGroup[j];
+               int32_t index = pGroup[j];
                U value = (U)pSrc[index];
                if (value != invalid) {
                   currentSum +=  value;
@@ -1057,7 +1057,7 @@ public:
             }
 
             for (int j = start + windowSize; j < last; j++) {
-               INT32 index = pGroup[j];
+               int32_t index = pGroup[j];
 
                U value = (U)pSrc[index];
                if (value != invalid) {
@@ -1076,15 +1076,15 @@ public:
       }
       else {
          // FLOAT BASED
-         for (INT64 i = binLow; i < binHigh; i++) {
-            INT32 start = pFirst[i];
-            INT32 last = start + pCount[i];
+         for (int64_t i = binLow; i < binHigh; i++) {
+            int32_t start = pFirst[i];
+            int32_t last = start + pCount[i];
 
             U currentSum = 0;
 
             // Priming of the summation
             for (int j = start; j < last && j < (start + windowSize); j++) {
-               INT32 index = pGroup[j];
+               int32_t index = pGroup[j];
                U value = (U)pSrc[index];
                if (value == value) {
                   currentSum += value;
@@ -1093,7 +1093,7 @@ public:
             }
 
             for (int j = start + windowSize; j < last; j++) {
-               INT32 index = pGroup[j];
+               int32_t index = pGroup[j];
 
                U value = (U)pSrc[index];
                if (value == value) {
@@ -1116,34 +1116,34 @@ public:
 
    //------------------------------
    // Rolling uses entire size: totalInputRows
-   // TODO: Check if group is always INT32
+   // TODO: Check if group is always int32_t
    static void AccumRollingMean(
       void* pColumn,
       void* pGroupT,
-      INT32* pFirst,
-      INT32* pCount,
+      int32_t* pFirst,
+      int32_t* pCount,
       void* pAccumBin,
-      INT64 binLow,
-      INT64 binHigh,
-      INT64 totalInputRows,
-      INT64 itemSize,
-      INT64 funcParam) {
+      int64_t binLow,
+      int64_t binHigh,
+      int64_t totalInputRows,
+      int64_t itemSize,
+      int64_t funcParam) {
 
       T* pSrc = (T*)pColumn;
       double* pDest = (double*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
-      INT32 windowSize = (INT32)funcParam;
+      int32_t windowSize = (int32_t)funcParam;
       U invalid = GET_INVALID((U)0);
       double invalid_out = GET_INVALID(pDest[0]);
 
       if (binLow == 0) {
          // Mark all invalid if invalid bin
-         INT32 start = pFirst[0];
-         INT32 last = start + pCount[0];
+         int32_t start = pFirst[0];
+         int32_t last = start + pCount[0];
          for (int j = start; j < last; j++) {
-            INT32 index = pGroup[j];
+            int32_t index = pGroup[j];
             pDest[index] = invalid_out;
          }
          binLow++;
@@ -1153,22 +1153,22 @@ public:
       if (windowSize < 0) return;
 
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
-         INT32 start = pFirst[i];
-         INT32 last = start + pCount[i];
+      for (int64_t i = binLow; i < binHigh; i++) {
+         int32_t start = pFirst[i];
+         int32_t last = start + pCount[i];
 
          double currentSum = 0;
 
          // Priming of the summation
          for (int j = start; j < last && j < (start + windowSize); j++) {
-            INT32 index = pGroup[j];
+            int32_t index = pGroup[j];
 
             currentSum += pSrc[index];
             pDest[index] = currentSum / (j - start +1) ;
          }
 
          for (int j = start + windowSize; j < last; j++) {
-            INT32 index = pGroup[j];
+            int32_t index = pGroup[j];
 
             currentSum += pSrc[index];
 
@@ -1183,36 +1183,36 @@ public:
 
    //------------------------------
    // Rolling uses entire size: totalInputRows
-   // TODO: Check if group is always INT32
+   // TODO: Check if group is always int32_t
    static void AccumRollingNanMean(
       void* pColumn,
       void* pGroupT,
-      INT32* pFirst,
-      INT32* pCount,
+      int32_t* pFirst,
+      int32_t* pCount,
       void* pAccumBin,
-      INT64 binLow,
-      INT64 binHigh,
-      INT64 totalInputRows,
-      INT64 itemSize,
-      INT64 funcParam) {
+      int64_t binLow,
+      int64_t binHigh,
+      int64_t totalInputRows,
+      int64_t itemSize,
+      int64_t funcParam) {
 
       T* pSrc = (T*)pColumn;
       double* pDest = (double*)pAccumBin;
 
-      // TODO allow INT64 in the future
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // TODO allow int64_t in the future
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
-      INT32 windowSize = (INT32)funcParam;
+      int32_t windowSize = (int32_t)funcParam;
       U invalid = GET_INVALID((U)0);
       double invalid_out = GET_INVALID(pDest[0]);
 
       if (binLow == 0) {
          // Mark all invalid if invalid bin
-         INT32 start = pFirst[0];
-         INT32 last = start + pCount[0];
+         int32_t start = pFirst[0];
+         int32_t last = start + pCount[0];
          for (int j = start; j < last; j++) {
-            INT32 index = pGroup[j];
+            int32_t index = pGroup[j];
             pDest[index] = invalid_out;
          }
          binLow++;
@@ -1224,16 +1224,16 @@ public:
       if (invalid == invalid) {
          // NOT FLOAT (integer based)
          // For all the bins we have to fill
-         for (INT64 i = binLow; i < binHigh; i++) {
-            INT32 start = pFirst[i];
-            INT32 last = start + pCount[i];
+         for (int64_t i = binLow; i < binHigh; i++) {
+            int32_t start = pFirst[i];
+            int32_t last = start + pCount[i];
 
             double currentSum = 0;
             double count = 0;
 
             // Priming of the summation
             for (int j = start; j < last && j < (start + windowSize); j++) {
-               INT32 index = pGroup[j];
+               int32_t index = pGroup[j];
                U value = (U)pSrc[index];
                if (value != invalid) {
                   currentSum += value;
@@ -1243,7 +1243,7 @@ public:
             }
 
             for (int j = start + windowSize; j < last; j++) {
-               INT32 index = pGroup[j];
+               int32_t index = pGroup[j];
 
                U value = (U)pSrc[index];
                if (value != invalid) {
@@ -1264,16 +1264,16 @@ public:
       }
       else {
          // FLOAT BASED
-         for (INT64 i = binLow; i < binHigh; i++) {
-            INT32 start = pFirst[i];
-            INT32 last = start + pCount[i];
+         for (int64_t i = binLow; i < binHigh; i++) {
+            int32_t start = pFirst[i];
+            int32_t last = start + pCount[i];
 
             double currentSum = 0;
             double count = 0;
 
             // Priming of the summation
             for (int j = start; j < last && j < (start + windowSize); j++) {
-               INT32 index = pGroup[j];
+               int32_t index = pGroup[j];
                U value = (U)pSrc[index];
                if (value == value) {
                   currentSum += value;
@@ -1283,7 +1283,7 @@ public:
             }
 
             for (int j = start + windowSize; j < last; j++) {
-               INT32 index = pGroup[j];
+               int32_t index = pGroup[j];
 
                U value = (U)pSrc[index];
                if (value == value) {
@@ -1306,44 +1306,44 @@ public:
 
    //------------------------------
    // Rolling uses entire size: totalInputRows
-   // TODO: Check if group is always INT32
+   // TODO: Check if group is always int32_t
    static void AccumRollingCount(
       void* pColumn,
       void* pGroupT,
-      INT32* pFirst,
-      INT32* pCount,
+      int32_t* pFirst,
+      int32_t* pCount,
       void* pAccumBin,
-      INT64 binLow,
-      INT64 binHigh,
-      INT64 totalInputRows,
-      INT64 itemSize,
-      INT64 funcParam) {
+      int64_t binLow,
+      int64_t binHigh,
+      int64_t totalInputRows,
+      int64_t itemSize,
+      int64_t funcParam) {
 
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
-      INT32 windowSize = (INT32)funcParam;
+      int32_t windowSize = (int32_t)funcParam;
       U invalid = GET_INVALID(pDest[0]);
 
       LOGGING("in rolling count %lld %lld  sizeofdest %lld\n", binLow, binHigh, sizeof(U));
 
       if (binLow == 0) {
          // Mark all invalid if invalid bin
-         INT32 start = pFirst[0];
-         INT32 last = start + pCount[0];
+         int32_t start = pFirst[0];
+         int32_t last = start + pCount[0];
          for (int j = start; j < last; j++) {
-            INT32 index = pGroup[j];
+            int32_t index = pGroup[j];
             pDest[index] = invalid;
          }
          binLow++;
       }
 
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
-         INT32 start = pFirst[i];
-         INT32 last = start + pCount[i];
+      for (int64_t i = binLow; i < binHigh; i++) {
+         int32_t start = pFirst[i];
+         int32_t last = start + pCount[i];
 
          U currentSum = 0;
 
@@ -1351,14 +1351,14 @@ public:
 
          if (windowSize < 0) {
             for (int j = last-1; j >= start; j--) {
-               INT32 index = pGroup[j];
+               int32_t index = pGroup[j];
                pDest[index] = currentSum;
                currentSum += 1;
             }
          }
          else {
             for (int j = start; j < last; j++) {
-               INT32 index = pGroup[j];
+               int32_t index = pGroup[j];
                pDest[index] = currentSum;
                currentSum += 1;
             }
@@ -1370,45 +1370,45 @@ public:
 
    //------------------------------
    // Rolling uses entire size: totalInputRows
-   // TODO: Check if group is always INT32
+   // TODO: Check if group is always int32_t
    // NOTE: pDest/pAccumBin must be the size
-   static void AccumRollingShift(void* pColumn, void* pGroupT, INT32* pFirst, INT32* pCount, void* pAccumBin, INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam) {
+   static void AccumRollingShift(void* pColumn, void* pGroupT, int32_t* pFirst, int32_t* pCount, void* pAccumBin, int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam) {
 
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
-      INT32 windowSize = (INT32)funcParam;
+      int32_t windowSize = (int32_t)funcParam;
       U invalid = GET_INVALID(pDest[0]);
 
       //printf("binlow %lld,  binhigh %lld,  windowSize: %d\n", binLow, binHigh, windowSize);
 
       if (binLow == 0) {
          // Mark all invalid if invalid bin
-         INT32 start = pFirst[0];
-         INT32 last = start + pCount[0];
+         int32_t start = pFirst[0];
+         int32_t last = start + pCount[0];
          for (int j = start; j < last; j++) {
-            INT32 index = pGroup[j];
+            int32_t index = pGroup[j];
             pDest[index] = invalid;
          }
          binLow++;
       }
 
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
-         INT32 start = pFirst[i];
-         INT32 last = start + pCount[i];
+      for (int64_t i = binLow; i < binHigh; i++) {
+         int32_t start = pFirst[i];
+         int32_t last = start + pCount[i];
 
          if (windowSize >= 0) {
             // invalid for window
-            for (INT32 j = start; j < last && j < (start + windowSize); j++) {
-               INT32 index = pGroup[j];
+            for (int32_t j = start; j < last && j < (start + windowSize); j++) {
+               int32_t index = pGroup[j];
                pDest[index] = invalid;
             }
 
-            for (INT32 j = start + windowSize; j < last; j++) {
-               INT32 index = pGroup[j];
+            for (int32_t j = start + windowSize; j < last; j++) {
+               int32_t index = pGroup[j];
                pDest[index] = (U)pSrc[pGroup[j - windowSize]];
             }
          }
@@ -1419,13 +1419,13 @@ public:
             start--;
             //printf("bin[%lld]  start:%d  last:%d  windowSize:%d\n", i, start, last, windowSize);
 
-            for (INT32 j = last; j > start && j > (last - windowSize); j--) {
-               INT32 index = pGroup[j];
+            for (int32_t j = last; j > start && j > (last - windowSize); j--) {
+               int32_t index = pGroup[j];
                pDest[index] = invalid;
             }
 
-            for (INT32 j = last - windowSize; j > start; j--) {
-               INT32 index = pGroup[j];
+            for (int32_t j = last - windowSize; j > start; j--) {
+               int32_t index = pGroup[j];
                pDest[index] = (U)pSrc[pGroup[j + windowSize]];
             }
             // put it back to what it was
@@ -1436,23 +1436,23 @@ public:
 
    //------------------------------
    // Rolling uses entire size: totalInputRows
-   // TODO: Check if group is always INT32
-   static void AccumRollingDiff(void* pColumn, void* pGroupT, INT32* pFirst, INT32* pCount, void* pAccumBin, INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam) {
+   // TODO: Check if group is always int32_t
+   static void AccumRollingDiff(void* pColumn, void* pGroupT, int32_t* pFirst, int32_t* pCount, void* pAccumBin, int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam) {
 
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
-      INT32 windowSize = (INT32)funcParam;
+      int32_t windowSize = (int32_t)funcParam;
       U invalid = GET_INVALID(pDest[0]);
 
       if (binLow == 0) {
          // Mark all invalid if invalid bin
-         INT32 start = pFirst[0];
-         INT32 last = start + pCount[0];
+         int32_t start = pFirst[0];
+         int32_t last = start + pCount[0];
          for (int j = start; j < last; j++) {
-            INT32 index = pGroup[j];
+            int32_t index = pGroup[j];
             pDest[index] = invalid;
          }
          binLow++;
@@ -1460,13 +1460,13 @@ public:
 
       if (windowSize == 1) {
          // For all the bins we have to fill
-         for (INT64 i = binLow; i < binHigh; i++) {
-            INT32 start = pFirst[i];
-            INT32 last = start + pCount[i];
+         for (int64_t i = binLow; i < binHigh; i++) {
+            int32_t start = pFirst[i];
+            int32_t last = start + pCount[i];
 
             if (last > start) {
                // Very first is invalid
-               INT32 index = pGroup[start];
+               int32_t index = pGroup[start];
                U previous = (U)pSrc[index];
                pDest[index] = invalid;
 
@@ -1483,20 +1483,20 @@ public:
       }
       else {
          // For all the bins we have to fill
-         for (INT64 i = binLow; i < binHigh; i++) {
-            INT32 start = pFirst[i];
-            INT32 last = start + pCount[i];
+         for (int64_t i = binLow; i < binHigh; i++) {
+            int32_t start = pFirst[i];
+            int32_t last = start + pCount[i];
             if (windowSize >= 0) {
                // invalid for window
                U previous = 0;
 
                for (int j = start; j < last && j < (start + windowSize); j++) {
-                  INT32 index = pGroup[j];
+                  int32_t index = pGroup[j];
                   pDest[index] = invalid;
                }
 
                for (int j = start + windowSize; j < last; j++) {
-                  INT32 index = pGroup[j];
+                  int32_t index = pGroup[j];
                   U temp = (U)pSrc[index];
                   U previous = (U)pSrc[pGroup[j - windowSize]];
                   pDest[index] = temp - previous;
@@ -1509,12 +1509,12 @@ public:
                start--;
 
                for (int j = last; j > start && j > (last - windowSize); j--) {
-                  INT32 index = pGroup[j];
+                  int32_t index = pGroup[j];
                   pDest[index] = invalid;
                }
 
                for (int j = last - windowSize; j > start; j--) {
-                  INT32 index = pGroup[j];
+                  int32_t index = pGroup[j];
                   U temp = (U)pSrc[index];
                   U previous = (U)pSrc[pGroup[j + windowSize]];
                   pDest[index] = temp - previous;
@@ -1530,12 +1530,12 @@ public:
    //------------------------------
    // median does a sort for now -- but could use nth
    //
-   static void AccumTrimMeanBR(void* pColumn, void* pGroupT, INT32* pFirst, INT32* pCount, void* pAccumBin, INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam) {
+   static void AccumTrimMeanBR(void* pColumn, void* pGroupT, int32_t* pFirst, int32_t* pCount, void* pAccumBin, int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam) {
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
 
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
       // Alloc worst case
       T* pSort = (T*)WORKSPACE_ALLOC(totalInputRows * sizeof(T));
@@ -1545,9 +1545,9 @@ public:
       LOGGING("TrimMean rows: %lld\n", totalInputRows);
 
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
-         INT32 index = pFirst[i];
-         INT32 nCount = pCount[i];
+      for (int64_t i = binLow; i < binHigh; i++) {
+         int32_t index = pFirst[i];
+         int32_t nCount = pCount[i];
 
          if (nCount == 0) {
             pDest[i] = invalid;
@@ -1597,12 +1597,12 @@ public:
 
    //------------------------------
    // mode does a sort (auto handles nans?)
-   // pGroup -> INT8/16/32/64  (V typename)
-   static void AccumMode(void* pColumn, void* pGroupT, INT32* pFirst, INT32* pCount, void* pAccumBin, INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam) {
+   // pGroup -> int8_t/16/32/64  (V typename)
+   static void AccumMode(void* pColumn, void* pGroupT, int32_t* pFirst, int32_t* pCount, void* pAccumBin, int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam) {
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
       // Alloc worst case
       T* pSort = (T*)WORKSPACE_ALLOC(totalInputRows * sizeof(T));
@@ -1611,9 +1611,9 @@ public:
       //printf("Mode %llu\n", totalInputRows);
 
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
-         INT32 index = pFirst[i];
-         INT32 nCount = pCount[i];
+      for (int64_t i = binLow; i < binHigh; i++) {
+         int32_t index = pFirst[i];
+         int32_t nCount = pCount[i];
 
          if (nCount == 0) {
             pDest[i] = GET_INVALID(pDest[i]);
@@ -1636,7 +1636,7 @@ public:
             pEnd--;
          }
          
-         nCount = (INT32)((pEnd + 1) - pSort);
+         nCount = (int32_t)((pEnd + 1) - pSort);
          
          if (nCount == 0) {
             // nothing valid
@@ -1645,8 +1645,8 @@ public:
          }
 
          U currValue = *pSort, bestValue = *pSort;
-         INT32 currCount = 1, bestCount = 1;
-         for (INT32 i = 1; i < nCount; ++i) {
+         int32_t currCount = 1, bestCount = 1;
+         for (int32_t i = 1; i < nCount; ++i) {
             if (pSort[i] == currValue)
                ++currCount;
             else {
@@ -1670,14 +1670,14 @@ public:
    //------------------------------
    // median does a sort
    // auto-nan
-   // pGroup -> INT8/16/32/64  (V typename)
-   static void AccumMedian(void* pColumn, void* pGroupT, INT32* pFirst, INT32* pCount, void* pAccumBin, INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam) {
+   // pGroup -> int8_t/16/32/64  (V typename)
+   static void AccumMedian(void* pColumn, void* pGroupT, int32_t* pFirst, int32_t* pCount, void* pAccumBin, int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam) {
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
-      // pGroup -> INT8/16/32/64  (V typename)
+      // pGroup -> int8_t/16/32/64  (V typename)
 
       // Alloc
       T* pSort = (T*)WORKSPACE_ALLOC(totalInputRows * sizeof(T));
@@ -1685,9 +1685,9 @@ public:
       LOGGING("Median %llu  %lld  %lld  sizeof: %lld %lld %lld\n", totalInputRows, binLow, binHigh, sizeof(T), sizeof(U), sizeof(V));
 
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
-         INT32 index = pFirst[i];
-         INT32 nCount = pCount[i];
+      for (int64_t i = binLow; i < binHigh; i++) {
+         int32_t index = pFirst[i];
+         int32_t nCount = pCount[i];
 
          if (nCount == 0) {
             pDest[i]= GET_INVALID(pDest[i]);
@@ -1696,7 +1696,7 @@ public:
 
          // Copy over the items for this group
          for (int j = 0; j < nCount; j++) {
-            //printf("**[%lld][%d]  %d\n", i, index + j, (INT32)pGroup[index + j]);
+            //printf("**[%lld][%d]  %d\n", i, index + j, (int32_t)pGroup[index + j]);
             pSort[j] = pSrc[pGroup[index + j]];
          }
 
@@ -1712,7 +1712,7 @@ public:
             pEnd--;
          }
          
-         nCount = (INT32)((pEnd + 1) - pSort);
+         nCount = (int32_t)((pEnd + 1) - pSort);
 
          if (nCount == 0) {
             // nothing valid
@@ -1740,15 +1740,15 @@ public:
    }
 
    //-------------------------------------------------------------------------------
-   static void AccumMedianString(void* pColumn, void* pGroupT, INT32* pFirst, INT32* pCount, void* pAccumBin, INT64 binLow, INT64 binHigh, INT64 totalInputRows, INT64 itemSize, INT64 funcParam) {
+   static void AccumMedianString(void* pColumn, void* pGroupT, int32_t* pFirst, int32_t* pCount, void* pAccumBin, int64_t binLow, int64_t binHigh, int64_t totalInputRows, int64_t itemSize, int64_t funcParam) {
       T* pSrc = (T*)pColumn;
       U* pDest = (U*)pAccumBin;
-      // only allow INT32 since comes from group and not ikey
-      INT32* pGroup = (INT32*)pGroupT;
+      // only allow int32_t since comes from group and not ikey
+      int32_t* pGroup = (int32_t*)pGroupT;
 
       //printf("Median string %llu\n", totalInputRows);
       // For all the bins we have to fill
-      for (INT64 i = binLow; i < binHigh; i++) {
+      for (int64_t i = binLow; i < binHigh; i++) {
          for (int j = 0; j < itemSize; j++) {
             pDest[i*itemSize + j] = 0;
          }
@@ -1804,7 +1804,7 @@ public:
    }
 
    static GROUPBY_X_FUNC32 GetXFuncString(GB_FUNCTIONS func) {
-      //void AccumBinFirst(INT32* pGroup, INT32* pFirst, INT32* pCount, char* pAccumBin, char* pColumn, INT64 numUnique, INT64 itemSize, INT64 funcParam) {
+      //void AccumBinFirst(int32_t* pGroup, int32_t* pFirst, int32_t* pCount, char* pAccumBin, char* pColumn, int64_t numUnique, int64_t itemSize, int64_t funcParam) {
 
       // Disable all of this for now...
       switch (func) {
@@ -1831,22 +1831,22 @@ public:
 
 
 //-------------------------------------------------------------------
-typedef void(*GROUPBY_GATHER_FUNC)(stGroupBy32* pstGroupBy32, void* pDataIn, void* pDataOut, INT32* pCountOut, INT64 numUnique, INT64 numCores, INT64 binLow, INT64 binHigh);
+typedef void(*GROUPBY_GATHER_FUNC)(stGroupBy32* pstGroupBy32, void* pDataIn, void* pDataOut, int32_t* pCountOut, int64_t numUnique, int64_t numCores, int64_t binLow, int64_t binHigh);
 
 template<typename U>
-static void GatherSum(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT, INT32* pCountOut, INT64 numUnique, INT64 numCores, INT64 binLow, INT64 binHigh) {
+static void GatherSum(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT, int32_t* pCountOut, int64_t numUnique, int64_t numCores, int64_t binLow, int64_t binHigh) {
    U* pDataInBase = (U*)pDataInT;
    U* pDataOut = (U*)pDataOutT;
 
    memset(pDataOut, 0, sizeof(U) * numUnique);
 
    // Collect the results from the core
-   for (INT64 j = 0; j < numCores; j++) {
+   for (int64_t j = 0; j < numCores; j++) {
 
       if (pstGroupBy32->returnObjects[j].didWork) {
          U* pDataIn = &pDataInBase[j*numUnique];
 
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
             pDataOut[i] += pDataIn[i];
          }
       }
@@ -1856,24 +1856,24 @@ static void GatherSum(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT
 
 
 template<typename U>
-static void GatherMean(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT, INT32* pCountOutBase, INT64 numUnique, INT64 numCores, INT64 binLow, INT64 binHigh) {
+static void GatherMean(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT, int32_t* pCountOutBase, int64_t numUnique, int64_t numCores, int64_t binLow, int64_t binHigh) {
    U* pDataInBase = (U*)pDataInT;
    U* pDataOut = (U*)pDataOutT;
 
-   INT64 allocSize = sizeof(INT32)* numUnique;
-   INT32* pCountOut = (INT32*)WORKSPACE_ALLOC(allocSize);
+   int64_t allocSize = sizeof(int32_t)* numUnique;
+   int32_t* pCountOut = (int32_t*)WORKSPACE_ALLOC(allocSize);
    memset(pCountOut, 0, allocSize);
 
    memset(pDataOut, 0, sizeof(U) * numUnique);
 
    // Collect the results from the core
-   for (INT64 j = 0; j < numCores; j++) {
+   for (int64_t j = 0; j < numCores; j++) {
 
       if (pstGroupBy32->returnObjects[j].didWork) {
          U* pDataIn = &pDataInBase[j*numUnique];
-         INT32* pCountOutCore = &pCountOutBase[j*numUnique];
+         int32_t* pCountOutCore = &pCountOutBase[j*numUnique];
 
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
             pDataOut[i] += pDataIn[i];
             pCountOut[i] += pCountOutCore[i];
          }
@@ -1881,7 +1881,7 @@ static void GatherMean(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOut
    }
 
    // calculate the mean
-   for (INT64 i = binLow; i < binHigh; i++) {
+   for (int64_t i = binLow; i < binHigh; i++) {
       pDataOut[i] = pDataOut[i] / pCountOut[i];
    }
 
@@ -1891,23 +1891,23 @@ static void GatherMean(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOut
 
 
 template<typename U>
-static void GatherMinFloat(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT, INT32* pCountOutBase, INT64 numUnique, INT64 numCores, INT64 binLow, INT64 binHigh) {
+static void GatherMinFloat(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT, int32_t* pCountOutBase, int64_t numUnique, int64_t numCores, int64_t binLow, int64_t binHigh) {
    U* pDataInBase = (U*)pDataInT;
    U* pDataOut = (U*)pDataOutT;
 
    // Fill with invalid
    U invalid = GET_INVALID(pDataOut[0]);
-   for (INT64 i = binLow; i < binHigh; i++) {
+   for (int64_t i = binLow; i < binHigh; i++) {
       pDataOut[i] = invalid;
    }
 
    // Collect the results from the core
-   for (INT64 j = 0; j < numCores; j++) {
+   for (int64_t j = 0; j < numCores; j++) {
 
       if (pstGroupBy32->returnObjects[j].didWork) {
          U* pDataIn = &pDataInBase[j*numUnique];
 
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
 
             U curValue = pDataOut[i];
             U compareValue = pDataIn[i];
@@ -1927,24 +1927,24 @@ static void GatherMinFloat(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDat
 
 
 template<typename U>
-static void GatherMin(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT, INT32* pCountOutBase, INT64 numUnique, INT64 numCores, INT64 binLow, INT64 binHigh) {
+static void GatherMin(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT, int32_t* pCountOutBase, int64_t numUnique, int64_t numCores, int64_t binLow, int64_t binHigh) {
    U* pDataInBase = (U*)pDataInT;
    U* pDataOut = (U*)pDataOutT;
 
    // Fill with invalid
    U invalid = GET_INVALID(pDataOut[0]);
 
-   for (INT64 i = binLow; i < binHigh; i++) {
+   for (int64_t i = binLow; i < binHigh; i++) {
       pDataOut[i] = invalid;
    }
 
    // Collect the results from the core
-   for (INT64 j = 0; j < numCores; j++) {
+   for (int64_t j = 0; j < numCores; j++) {
 
       if (pstGroupBy32->returnObjects[j].didWork) {
          U* pDataIn = &pDataInBase[j*numUnique];
 
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
 
             U curValue = pDataOut[i];
             U compareValue = pDataIn[i];
@@ -1960,24 +1960,24 @@ static void GatherMin(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT
 }
 
 template<typename U>
-static void GatherMaxFloat(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT, INT32* pCountOutBase, INT64 numUnique, INT64 numCores, INT64 binLow, INT64 binHigh) {
+static void GatherMaxFloat(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT, int32_t* pCountOutBase, int64_t numUnique, int64_t numCores, int64_t binLow, int64_t binHigh) {
    U* pDataInBase = (U*)pDataInT;
    U* pDataOut = (U*)pDataOutT;
 
    // Fill with invalid
    U invalid = GET_INVALID(pDataOut[0]);
 
-   for (INT64 i = binLow; i < binHigh; i++) {
+   for (int64_t i = binLow; i < binHigh; i++) {
       pDataOut[i] = invalid;
    }
 
    // Collect the results from the core
-   for (INT64 j = 0; j < numCores; j++) {
+   for (int64_t j = 0; j < numCores; j++) {
 
       if (pstGroupBy32->returnObjects[j].didWork) {
          U* pDataIn = &pDataInBase[j*numUnique];
 
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
 
             U curValue = pDataOut[i];
             U compareValue = pDataIn[i];
@@ -1998,24 +1998,24 @@ static void GatherMaxFloat(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDat
 
 
 template<typename U>
-static void GatherMax(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT, INT32* pCountOutBase, INT64 numUnique, INT64 numCores, INT64 binLow, INT64 binHigh) {
+static void GatherMax(stGroupBy32* pstGroupBy32, void* pDataInT, void* pDataOutT, int32_t* pCountOutBase, int64_t numUnique, int64_t numCores, int64_t binLow, int64_t binHigh) {
    U* pDataInBase = (U*)pDataInT;
    U* pDataOut = (U*)pDataOutT;
 
    // Fill with invalid?
    U invalid = GET_INVALID(pDataOut[0]);
 
-   for (INT64 i = binLow; i < binHigh; i++) {
+   for (int64_t i = binLow; i < binHigh; i++) {
       pDataOut[i] = invalid;
    }
 
    // Collect the results from the core
-   for (INT64 j = 0; j < numCores; j++) {
+   for (int64_t j = 0; j < numCores; j++) {
 
       if (pstGroupBy32->returnObjects[j].didWork) {
          U* pDataIn = &pDataInBase[j*numUnique];
 
-         for (INT64 i = binLow; i < binHigh; i++) {
+         for (int64_t i = binLow; i < binHigh; i++) {
 
             U curValue = pDataOut[i];
             U compareValue = pDataIn[i];
@@ -2036,18 +2036,18 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
    case GB_SUM:
    case GB_NANSUM:
       switch (outputType) {
-      case NPY_BOOL:   return GatherSum<INT64>;
+      case NPY_BOOL:   return GatherSum<int64_t>;
       case NPY_FLOAT:  return GatherSum<float>;
       case NPY_DOUBLE: return GatherSum<double>;
       case NPY_LONGDOUBLE: return GatherSum<long double>;
-      case NPY_INT8:  return GatherSum<INT64>;
-      case NPY_INT16: return GatherSum<INT64>;
-      CASE_NPY_INT32: return GatherSum<INT64>;
-      CASE_NPY_INT64: return GatherSum<INT64>;
-      case NPY_UINT8: return GatherSum<UINT64>;
-      case NPY_UINT16:return GatherSum<UINT64>;
-      CASE_NPY_UINT32:return GatherSum<UINT64>;
-      CASE_NPY_UINT64:return GatherSum<UINT64>;
+      case NPY_INT8:  return GatherSum<int64_t>;
+      case NPY_INT16: return GatherSum<int64_t>;
+      CASE_NPY_INT32: return GatherSum<int64_t>;
+      CASE_NPY_INT64: return GatherSum<int64_t>;
+      case NPY_UINT8: return GatherSum<uint64_t>;
+      case NPY_UINT16:return GatherSum<uint64_t>;
+      CASE_NPY_UINT32:return GatherSum<uint64_t>;
+      CASE_NPY_UINT64:return GatherSum<uint64_t>;
       }
       break;
 
@@ -2072,36 +2072,36 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
    case GB_MAX:
    case GB_NANMAX:
       switch (outputType) {
-      case NPY_BOOL:   return GatherMax<INT8>;
+      case NPY_BOOL:   return GatherMax<int8_t>;
       case NPY_FLOAT:  return GatherMaxFloat<float>;
       case NPY_DOUBLE: return GatherMaxFloat<double>;
       case NPY_LONGDOUBLE: return GatherMaxFloat<long double>;
-      case NPY_INT8:  return GatherMax<INT8>;
-      case NPY_INT16: return GatherMax<INT16>;
-      CASE_NPY_INT32: return GatherMax<INT32>;
-      CASE_NPY_INT64: return GatherMax<INT64>;
-      case NPY_UINT8: return GatherMax<UINT8>;
-      case NPY_UINT16:return GatherMax<UINT16>;
-      CASE_NPY_UINT32:return GatherMax<UINT32>;
-      CASE_NPY_UINT64:return GatherMax<UINT64>;
+      case NPY_INT8:  return GatherMax<int8_t>;
+      case NPY_INT16: return GatherMax<int16_t>;
+      CASE_NPY_INT32: return GatherMax<int32_t>;
+      CASE_NPY_INT64: return GatherMax<int64_t>;
+      case NPY_UINT8: return GatherMax<uint8_t>;
+      case NPY_UINT16:return GatherMax<uint16_t>;
+      CASE_NPY_UINT32:return GatherMax<uint32_t>;
+      CASE_NPY_UINT64:return GatherMax<uint64_t>;
       }
       break;
 
    case GB_MIN:
    case GB_NANMIN:
       switch (outputType) {
-      case NPY_BOOL:   return GatherMin<INT8>;
+      case NPY_BOOL:   return GatherMin<int8_t>;
       case NPY_FLOAT:  return GatherMinFloat<float>;
       case NPY_DOUBLE: return GatherMinFloat<double>;
       case NPY_LONGDOUBLE: return GatherMinFloat<long double>;
-      case NPY_INT8:  return GatherMin<INT8>;
-      case NPY_INT16: return GatherMin<INT16>;
-      CASE_NPY_INT32: return GatherMin<INT32>;
-      CASE_NPY_INT64: return GatherMin<INT64>;
-      case NPY_UINT8: return GatherMin<UINT8>;
-      case NPY_UINT16:return GatherMin<UINT16>;
-      CASE_NPY_UINT32:return GatherMin<UINT32>;
-      CASE_NPY_UINT64:return GatherMin<UINT64>;
+      case NPY_INT8:  return GatherMin<int8_t>;
+      case NPY_INT16: return GatherMin<int16_t>;
+      CASE_NPY_INT32: return GatherMin<int32_t>;
+      CASE_NPY_INT64: return GatherMin<int64_t>;
+      case NPY_UINT8: return GatherMin<uint8_t>;
+      case NPY_UINT16:return GatherMin<uint16_t>;
+      CASE_NPY_UINT32:return GatherMin<uint32_t>;
+      CASE_NPY_UINT64:return GatherMin<uint64_t>;
       }
       break;
    default:
@@ -2114,26 +2114,26 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
 //-------------------------------------------------------------------
 // T is the input type
 // U is the output type
-// V is the index type, like INT32 or INT8
+// V is the index type, like int32_t or int8_t
 template<typename V>
-static GROUPBY_TWO_FUNC GetGroupByFunction(BOOL *hasCounts, INT32 *wantedOutputType, int inputType,  GB_FUNCTIONS func) {
+static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutputType, int inputType,  GB_FUNCTIONS func) {
 
    *hasCounts = FALSE;
    switch (func) {
    case GB_SUM:
       switch (inputType) {
-      case NPY_BOOL:   *wantedOutputType = NPY_INT64; return GroupByBase<INT8,    INT64,  V>::AccumSum;
+      case NPY_BOOL:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t,    int64_t,  V>::AccumSum;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float,   float,  V>::AccumSumFloat;
       case NPY_DOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumSum;
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumSum;
-      case NPY_INT8:   *wantedOutputType = NPY_INT64; return GroupByBase<INT8,    INT64,  V>::AccumSum;
-      case NPY_INT16:  *wantedOutputType = NPY_INT64; return GroupByBase<INT16,   INT64,  V>::AccumSum;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<INT32,   INT64,  V>::AccumSum;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<INT64,   INT64,  V>::AccumSum;
-      case NPY_UINT8:  *wantedOutputType = NPY_UINT64; return GroupByBase<UINT8,  UINT64, V>::AccumSum;
-      case NPY_UINT16: *wantedOutputType = NPY_UINT64; return GroupByBase<UINT16, UINT64, V>::AccumSum;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<UINT32, UINT64, V>::AccumSum;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<UINT64, UINT64, V>::AccumSum;
+      case NPY_INT8:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t,    int64_t,  V>::AccumSum;
+      case NPY_INT16:  *wantedOutputType = NPY_INT64; return GroupByBase<int16_t,   int64_t,  V>::AccumSum;
+      CASE_NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t,   int64_t,  V>::AccumSum;
+      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<int64_t,   int64_t,  V>::AccumSum;
+      case NPY_UINT8:  *wantedOutputType = NPY_UINT64; return GroupByBase<uint8_t,  uint64_t, V>::AccumSum;
+      case NPY_UINT16: *wantedOutputType = NPY_UINT64; return GroupByBase<uint16_t, uint64_t, V>::AccumSum;
+      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumSum;
+      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumSum;
       default:break;
       }
 
@@ -2142,34 +2142,34 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(BOOL *hasCounts, INT32 *wantedOutputT
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumNanSum;
       case NPY_DOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumNanSum;
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumNanSum;
-      // BOOL has no invalid
-      case NPY_BOOL:   *wantedOutputType = NPY_INT64; return GroupByBase<INT8, INT64, V>::AccumSum;
-      case NPY_INT8:   *wantedOutputType = NPY_INT64; return GroupByBase<INT8, INT64, V>::AccumNanSum;
-      case NPY_INT16:  *wantedOutputType = NPY_INT64; return GroupByBase<INT16, INT64, V>::AccumNanSum;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<INT32, INT64, V>::AccumNanSum;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<INT64, INT64, V>::AccumNanSum;
-      case NPY_UINT8:  *wantedOutputType = NPY_UINT64; return GroupByBase<UINT8, UINT64, V>::AccumNanSum;
-      case NPY_UINT16: *wantedOutputType = NPY_UINT64; return GroupByBase<UINT16, UINT64, V>::AccumNanSum;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<UINT32, UINT64, V>::AccumNanSum;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<UINT64, UINT64, V>::AccumNanSum;
+      // bool has no invalid
+      case NPY_BOOL:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t, int64_t, V>::AccumSum;
+      case NPY_INT8:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t, int64_t, V>::AccumNanSum;
+      case NPY_INT16:  *wantedOutputType = NPY_INT64; return GroupByBase<int16_t, int64_t, V>::AccumNanSum;
+      CASE_NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t, int64_t, V>::AccumNanSum;
+      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanSum;
+      case NPY_UINT8:  *wantedOutputType = NPY_UINT64; return GroupByBase<uint8_t, uint64_t, V>::AccumNanSum;
+      case NPY_UINT16: *wantedOutputType = NPY_UINT64; return GroupByBase<uint16_t, uint64_t, V>::AccumNanSum;
+      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumNanSum;
+      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanSum;
       default:break;
       }
 
    case GB_MIN:
       *hasCounts = TRUE;
       switch (inputType) {
-      case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<INT8, INT8, V>::AccumMin;
+      case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMin;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumMin;
       case NPY_DOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumMin;
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumMin;
-      case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<INT8,     INT8, V>::AccumMin;
-      case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<INT16,   INT16, V>::AccumMin;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<INT32,   INT32, V>::AccumMin;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<INT64,   INT64, V>::AccumMin;
-      case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<UINT8,   UINT8, V>::AccumMin;
-      case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<UINT16, UINT16, V>::AccumMin;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<UINT32, UINT32, V>::AccumMin;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<UINT64, UINT64, V>::AccumMin;
+      case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t,     int8_t, V>::AccumMin;
+      case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t,   int16_t, V>::AccumMin;
+      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t,   int32_t, V>::AccumMin;
+      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<int64_t,   int64_t, V>::AccumMin;
+      case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t,   uint8_t, V>::AccumMin;
+      case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumMin;
+      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMin;
+      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumMin;
       default:break;
       }
 
@@ -2179,33 +2179,33 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(BOOL *hasCounts, INT32 *wantedOutputT
       case NPY_FLOAT:  *hasCounts = FALSE; *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumNanMin;
       case NPY_DOUBLE: *hasCounts = FALSE; *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumNanMin;
       case NPY_LONGDOUBLE: *hasCounts = FALSE; *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumNanMin;
-      case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<INT8, INT8, V>::AccumMin;
-      case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<INT8, INT8, V>::AccumNanMin;
-      case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<INT16, INT16, V>::AccumNanMin;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<INT32, INT32, V>::AccumNanMin;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<INT64, INT64, V>::AccumNanMin;
-      case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<UINT8, UINT8, V>::AccumNanMin;
-      case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<UINT16, UINT16, V>::AccumNanMin;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<UINT32, UINT32, V>::AccumNanMin;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<UINT64, UINT64, V>::AccumNanMin;
+      case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMin;
+      case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumNanMin;
+      case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumNanMin;
+      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMin;
+      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanMin;
+      case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumNanMin;
+      case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumNanMin;
+      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMin;
+      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanMin;
       default:break;
       }
 
    case GB_MAX:
       *hasCounts = TRUE;
       switch (inputType) {
-      case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<INT8, INT8, V>::AccumMax;
+      case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMax;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumMax;
       case NPY_DOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumMax;
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumMax;
-      case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<INT8, INT8, V>::AccumMax;
-      case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<INT16, INT16, V>::AccumMax;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<INT32, INT32, V>::AccumMax;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<INT64, INT64, V>::AccumMax;
-      case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<UINT8, UINT8, V>::AccumMax;
-      case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<UINT16, UINT16, V>::AccumMax;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<UINT32, UINT32, V>::AccumMax;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<UINT64, UINT64, V>::AccumMax;
+      case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumMax;
+      case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumMax;
+      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumMax;
+      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumMax;
+      case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumMax;
+      case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumMax;
+      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMax;
+      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumMax;
       default:break;
       }
 
@@ -2216,33 +2216,33 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(BOOL *hasCounts, INT32 *wantedOutputT
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumNanMax;
       case NPY_DOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumNanMax;
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumNanMax;
-      case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<INT8, INT8, V>::AccumMax;
-      case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<INT8, INT8, V>::AccumNanMax;
-      case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<INT16, INT16, V>::AccumNanMax;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<INT32, INT32, V>::AccumNanMax;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<INT64, INT64, V>::AccumNanMax;
-      case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<UINT8, UINT8, V>::AccumNanMax;
-      case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<UINT16, UINT16, V>::AccumNanMax;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<UINT32, UINT32, V>::AccumNanMax;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<UINT64, UINT64, V>::AccumNanMax;
+      case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMax;
+      case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumNanMax;
+      case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumNanMax;
+      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMax;
+      CASE_NPY_INT64:  *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanMax;
+      case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumNanMax;
+      case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumNanMax;
+      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMax;
+      CASE_NPY_UINT64: *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanMax;
       default:break;
       }
 
    case GB_MEAN:
       *hasCounts = TRUE;
       switch (inputType) {
-      case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < INT8,   double, V > ::AccumMean;
+      case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < int8_t,   double, V > ::AccumMean;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float,   float, V>::AccumMeanFloat;
       case NPY_DOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumMean;
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumMean;
-      case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT8,     double, V>::AccumMean;
-      case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT16,   double, V>::AccumMean;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT32,   double, V>::AccumMean;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT64,   double, V>::AccumMean;
-      case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT8,   double, V>::AccumMean;
-      case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT16, double, V>::AccumMean;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT32, double, V>::AccumMean;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT64, double, V>::AccumMean;
+      case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t,     double, V>::AccumMean;
+      case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t,   double, V>::AccumMean;
+      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t,   double, V>::AccumMean;
+      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t,   double, V>::AccumMean;
+      case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t,   double, V>::AccumMean;
+      case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumMean;
+      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumMean;
+      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumMean;
       default:break;
       }
 
@@ -2250,18 +2250,18 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(BOOL *hasCounts, INT32 *wantedOutputT
    case GB_NANMEAN:
       *hasCounts = TRUE;
       switch (inputType) {
-      case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < INT8, double, V > ::AccumNanMean;
+      case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < int8_t, double, V > ::AccumNanMean;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumNanMeanFloat;
       case NPY_DOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumNanMean;
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanMean;
-      case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT8, double, V>::AccumNanMean;
-      case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT16, double, V>::AccumNanMean;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT32, double, V>::AccumNanMean;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT64, double, V>::AccumNanMean;
-      case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT8, double, V>::AccumNanMean;
-      case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT16, double, V>::AccumNanMean;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT32, double, V>::AccumNanMean;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT64, double, V>::AccumNanMean;
+      case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanMean;
+      case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanMean;
+      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanMean;
+      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanMean;
+      case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanMean;
+      case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanMean;
+      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanMean;
+      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanMean;
       default:break;
       }
 
@@ -2269,18 +2269,18 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(BOOL *hasCounts, INT32 *wantedOutputT
    case GB_VAR:
       *hasCounts = TRUE;
       switch (inputType) {
-      case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < INT8, double, V > ::AccumVar;
+      case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < int8_t, double, V > ::AccumVar;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumVar;
       case NPY_DOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumVar;
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumVar;
-      case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT8, double, V>::AccumVar;
-      case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT16, double, V>::AccumVar;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT32, double, V>::AccumVar;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT64, double, V>::AccumVar;
-      case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT8, double, V>::AccumVar;
-      case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT16, double, V>::AccumVar;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT32, double, V>::AccumVar;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT64, double, V>::AccumVar;
+      case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumVar;
+      case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumVar;
+      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumVar;
+      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumVar;
+      case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumVar;
+      case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumVar;
+      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumVar;
+      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumVar;
       default:break;
       }
 
@@ -2288,36 +2288,36 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(BOOL *hasCounts, INT32 *wantedOutputT
    case GB_NANVAR:
       *hasCounts = TRUE;
       switch (inputType) {
-      case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < INT8, double, V > ::AccumNanVar;
+      case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < int8_t, double, V > ::AccumNanVar;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumNanVar;
       case NPY_DOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumNanVar;
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanVar;
-      case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT8, double, V>::AccumNanVar;
-      case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT16, double, V>::AccumNanVar;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT32, double, V>::AccumNanVar;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT64, double, V>::AccumNanVar;
-      case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT8, double, V>::AccumNanVar;
-      case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT16, double, V>::AccumNanVar;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT32, double, V>::AccumNanVar;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT64, double, V>::AccumNanVar;
+      case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanVar;
+      case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanVar;
+      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanVar;
+      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanVar;
+      case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanVar;
+      case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanVar;
+      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanVar;
+      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanVar;
       default:break;
       }
 
    case GB_STD:
       *hasCounts = TRUE;
       switch (inputType) {
-      case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < INT8, double, V > ::AccumStd;
+      case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < int8_t, double, V > ::AccumStd;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumStd;
       case NPY_DOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumStd;
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumStd;
-      case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT8, double, V>::AccumStd;
-      case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT16, double, V>::AccumStd;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT32, double, V>::AccumStd;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT64, double, V>::AccumStd;
-      case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT8, double, V>::AccumStd;
-      case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT16, double, V>::AccumStd;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT32, double, V>::AccumStd;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT64, double, V>::AccumStd;
+      case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumStd;
+      case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumStd;
+      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumStd;
+      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumStd;
+      case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumStd;
+      case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumStd;
+      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumStd;
+      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumStd;
       default:break;
       }
 
@@ -2325,18 +2325,18 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(BOOL *hasCounts, INT32 *wantedOutputT
    case GB_NANSTD:
       *hasCounts = TRUE;
       switch (inputType) {
-      case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < INT8, double, V > ::AccumNanStd;
+      case NPY_BOOL:   *wantedOutputType = NPY_DOUBLE; return GroupByBase < int8_t, double, V > ::AccumNanStd;
       case NPY_FLOAT:  *wantedOutputType = NPY_FLOAT; return GroupByBase<float, float, V>::AccumNanStd;
       case NPY_DOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<double, double, V>::AccumNanStd;
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanStd;
-      case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT8, double, V>::AccumNanStd;
-      case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT16, double, V>::AccumNanStd;
-      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT32, double, V>::AccumNanStd;
-      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<INT64, double, V>::AccumNanStd;
-      case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT8, double, V>::AccumNanStd;
-      case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT16, double, V>::AccumNanStd;
-      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT32, double, V>::AccumNanStd;
-      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<UINT64, double, V>::AccumNanStd;
+      case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanStd;
+      case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanStd;
+      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanStd;
+      CASE_NPY_INT64:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanStd;
+      case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanStd;
+      case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanStd;
+      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanStd;
+      CASE_NPY_UINT64: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanStd;
       default:break;
       }
 
@@ -2353,16 +2353,16 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(BOOL *hasCounts, INT32 *wantedOutputT
 //      //   case NPY_BOOL:   return GroupByBase<T, bool>::GetFunc(func);
 //   case NPY_FLOAT:  return GroupByBase<T, float>::GetXFunc(func);
 //   case NPY_DOUBLE: return GroupByBase<T, double>::GetXFunc(func);
-//      //   case NPY_BYTE:   return GroupByBase<T, INT8>::GetFunc(func);
-//      //   case NPY_INT16:  return GroupByBase<T, INT16>::GetFunc(func);
-//   case NPY_INT:    return GroupByBase<T, INT32>::GetXFunc(func);
-//   case NPY_INT32:  return GroupByBase<T, INT32>::GetXFunc(func);
-//   case NPY_INT64:  return GroupByBase<T, INT64>::GetXFunc(func);
-//      //   case NPY_UBYTE:  return GroupByBase<T, UINT8>::GetFunc(func);
-//      //   case NPY_UINT16: return GroupByBase<T, UINT16>::GetFunc(func);
-//   case NPY_UINT:   return GroupByBase<T, UINT32>::GetXFunc(func);
-//   case NPY_UINT32: return GroupByBase<T, UINT32>::GetXFunc(func);
-//   case NPY_UINT64: return GroupByBase<T, UINT64>::GetXFunc(func);
+//      //   case NPY_BYTE:   return GroupByBase<T, int8_t>::GetFunc(func);
+//      //   case NPY_INT16:  return GroupByBase<T, int16_t>::GetFunc(func);
+//   case NPY_INT:    return GroupByBase<T, int32_t>::GetXFunc(func);
+//   case NPY_INT32:  return GroupByBase<T, int32_t>::GetXFunc(func);
+//   case NPY_INT64:  return GroupByBase<T, int64_t>::GetXFunc(func);
+//      //   case NPY_UBYTE:  return GroupByBase<T, uint8_t>::GetFunc(func);
+//      //   case NPY_UINT16: return GroupByBase<T, uint16_t>::GetFunc(func);
+//   case NPY_UINT:   return GroupByBase<T, uint32_t>::GetXFunc(func);
+//   case NPY_UINT32: return GroupByBase<T, uint32_t>::GetXFunc(func);
+//   case NPY_UINT64: return GroupByBase<T, uint64_t>::GetXFunc(func);
 //   }
 //   return NULL;
 //
@@ -2378,23 +2378,23 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_FLOAT:  return GroupByBase<float, float, V>::AccumTrimMeanBR;
       case NPY_DOUBLE: return GroupByBase<double, double, V>::AccumTrimMeanBR;
       case NPY_LONGDOUBLE: return GroupByBase<long double, double, V>::AccumTrimMeanBR;
-      case NPY_INT8:   return GroupByBase<INT8, double, V>::AccumTrimMeanBR;
-      case NPY_INT16:  return GroupByBase<INT16, double, V>::AccumTrimMeanBR;
-      CASE_NPY_INT32:  return GroupByBase<INT32, double, V>::AccumTrimMeanBR;
-      CASE_NPY_INT64:  return GroupByBase<INT64, double, V>::AccumTrimMeanBR;
-      case NPY_UINT8:  return GroupByBase<UINT8, double, V>::AccumTrimMeanBR;
-      case NPY_UINT16: return GroupByBase<UINT16, double, V>::AccumTrimMeanBR;
-      CASE_NPY_UINT32: return GroupByBase<UINT32, double, V>::AccumTrimMeanBR;
-      CASE_NPY_UINT64: return GroupByBase<UINT64, double, V>::AccumTrimMeanBR;
+      case NPY_INT8:   return GroupByBase<int8_t, double, V>::AccumTrimMeanBR;
+      case NPY_INT16:  return GroupByBase<int16_t, double, V>::AccumTrimMeanBR;
+      CASE_NPY_INT32:  return GroupByBase<int32_t, double, V>::AccumTrimMeanBR;
+      CASE_NPY_INT64:  return GroupByBase<int64_t, double, V>::AccumTrimMeanBR;
+      case NPY_UINT8:  return GroupByBase<uint8_t, double, V>::AccumTrimMeanBR;
+      case NPY_UINT16: return GroupByBase<uint16_t, double, V>::AccumTrimMeanBR;
+      CASE_NPY_UINT32: return GroupByBase<uint32_t, double, V>::AccumTrimMeanBR;
+      CASE_NPY_UINT64: return GroupByBase<uint64_t, double, V>::AccumTrimMeanBR;
       }
       return NULL;
    } else
    if (func == GB_ROLLING_COUNT) {
       switch (inputType) {
-      case NPY_INT8:   return GroupByBase<INT8, INT32, V>::GetXFunc2(func);
-      case NPY_INT16:  return GroupByBase<INT16, INT32, V>::GetXFunc2(func);
-      CASE_NPY_INT32:  return GroupByBase<INT32, INT32, V>::GetXFunc2(func);
-      CASE_NPY_INT64:  return GroupByBase<INT64, INT32, V>::GetXFunc2(func);
+      case NPY_INT8:   return GroupByBase<int8_t, int32_t, V>::GetXFunc2(func);
+      case NPY_INT16:  return GroupByBase<int16_t, int32_t, V>::GetXFunc2(func);
+      CASE_NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
+      CASE_NPY_INT64:  return GroupByBase<int64_t, int32_t, V>::GetXFunc2(func);
       }
       return NULL;
    } else
@@ -2402,18 +2402,18 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       LOGGING("Rolling+diff called with type %d\n", inputType);
       switch (inputType) {
          // really need to change output type for accumsum/rolling
-         //case NPY_BOOL:   return GroupByBase<bool, INT64, V>::GetXFunc2(func);
+         //case NPY_BOOL:   return GroupByBase<bool, int64_t, V>::GetXFunc2(func);
       case NPY_FLOAT:  return GroupByBase<float, float, V>::GetXFunc2(func);
       case NPY_DOUBLE: return GroupByBase<double, double, V>::GetXFunc2(func);
       case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc2(func);
-      case NPY_INT8:   return GroupByBase<INT8, INT8, V>::GetXFunc2(func);
-      case NPY_INT16:  return GroupByBase<INT16, INT16, V>::GetXFunc2(func);
-      CASE_NPY_INT32:  return GroupByBase<INT32, INT32, V>::GetXFunc2(func);
-      CASE_NPY_INT64:  return GroupByBase<INT64, INT64, V>::GetXFunc2(func);
-      case NPY_UINT8:  return GroupByBase<UINT8, UINT8, V>::GetXFunc2(func);
-      case NPY_UINT16: return GroupByBase<UINT16, UINT16, V>::GetXFunc2(func);
-      CASE_NPY_UINT32: return GroupByBase<UINT32, UINT32, V>::GetXFunc2(func);
-      CASE_NPY_UINT64: return GroupByBase<UINT64, UINT64, V>::GetXFunc2(func);
+      case NPY_INT8:   return GroupByBase<int8_t, int8_t, V>::GetXFunc2(func);
+      case NPY_INT16:  return GroupByBase<int16_t, int16_t, V>::GetXFunc2(func);
+      CASE_NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
+      CASE_NPY_INT64:  return GroupByBase<int64_t, int64_t, V>::GetXFunc2(func);
+      case NPY_UINT8:  return GroupByBase<uint8_t, uint8_t, V>::GetXFunc2(func);
+      case NPY_UINT16: return GroupByBase<uint16_t, uint16_t, V>::GetXFunc2(func);
+      CASE_NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc2(func);
+      CASE_NPY_UINT64: return GroupByBase<uint64_t, uint64_t, V>::GetXFunc2(func);
       }
       return NULL;
    }
@@ -2426,35 +2426,35 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
          case NPY_FLOAT:  return GroupByBase<float, double, V>::GetXFunc2(func);
          case NPY_DOUBLE: return GroupByBase<double, double, V>::GetXFunc2(func);
          case NPY_LONGDOUBLE: return GroupByBase<long double, double, V>::GetXFunc2(func);
-         case NPY_INT8:   return GroupByBase<INT8, double, V>::GetXFunc2(func);
-         case NPY_INT16:  return GroupByBase<INT16, double, V>::GetXFunc2(func);
-         CASE_NPY_INT32:  return GroupByBase<INT32, double, V>::GetXFunc2(func);
-         CASE_NPY_INT64:  return GroupByBase<INT64, double, V>::GetXFunc2(func); 
-         case NPY_UINT8:  return GroupByBase<UINT8, double, V>::GetXFunc2(func);
-         case NPY_UINT16: return GroupByBase<UINT16, double, V>::GetXFunc2(func);
-         CASE_NPY_UINT32: return GroupByBase<UINT32, double, V>::GetXFunc2(func);
-         CASE_NPY_UINT64: return GroupByBase<UINT64, double, V>::GetXFunc2(func);
+         case NPY_INT8:   return GroupByBase<int8_t, double, V>::GetXFunc2(func);
+         case NPY_INT16:  return GroupByBase<int16_t, double, V>::GetXFunc2(func);
+         CASE_NPY_INT32:  return GroupByBase<int32_t, double, V>::GetXFunc2(func);
+         CASE_NPY_INT64:  return GroupByBase<int64_t, double, V>::GetXFunc2(func); 
+         case NPY_UINT8:  return GroupByBase<uint8_t, double, V>::GetXFunc2(func);
+         case NPY_UINT16: return GroupByBase<uint16_t, double, V>::GetXFunc2(func);
+         CASE_NPY_UINT32: return GroupByBase<uint32_t, double, V>::GetXFunc2(func);
+         CASE_NPY_UINT64: return GroupByBase<uint64_t, double, V>::GetXFunc2(func);
          }
          return NULL;
       }
       else
 
-      // due to overflow, all ints become INT64
+      // due to overflow, all ints become int64_t
        LOGGING("Rolling+sum called with type %d\n", inputType);
        switch (inputType) {
           // really need to change output type for accumsum/rolling
-       case NPY_BOOL:   return GroupByBase<INT8, INT64, V>::GetXFunc2(func);
+       case NPY_BOOL:   return GroupByBase<int8_t, int64_t, V>::GetXFunc2(func);
        case NPY_FLOAT:  return GroupByBase<float, float, V>::GetXFunc2(func);
        case NPY_DOUBLE: return GroupByBase<double, double, V>::GetXFunc2(func);
        case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc2(func);
-       case NPY_INT8:   return GroupByBase<INT8, INT64, V>::GetXFunc2(func);
-       case NPY_INT16:  return GroupByBase<INT16, INT64, V>::GetXFunc2(func);
-       CASE_NPY_INT32:  return GroupByBase<INT32, INT64, V>::GetXFunc2(func);
-       CASE_NPY_INT64:  return GroupByBase<INT64, INT64, V>::GetXFunc2(func);
-       case NPY_UINT8:  return GroupByBase<UINT8, INT64, V>::GetXFunc2(func);
-       case NPY_UINT16: return GroupByBase<UINT16, INT64, V>::GetXFunc2(func);
-       CASE_NPY_UINT32: return GroupByBase<UINT32, INT64, V>::GetXFunc2(func);
-       CASE_NPY_UINT64: return GroupByBase<UINT64, INT64, V>::GetXFunc2(func);
+       case NPY_INT8:   return GroupByBase<int8_t, int64_t, V>::GetXFunc2(func);
+       case NPY_INT16:  return GroupByBase<int16_t, int64_t, V>::GetXFunc2(func);
+       CASE_NPY_INT32:  return GroupByBase<int32_t, int64_t, V>::GetXFunc2(func);
+       CASE_NPY_INT64:  return GroupByBase<int64_t, int64_t, V>::GetXFunc2(func);
+       case NPY_UINT8:  return GroupByBase<uint8_t, int64_t, V>::GetXFunc2(func);
+       case NPY_UINT16: return GroupByBase<uint16_t, int64_t, V>::GetXFunc2(func);
+       CASE_NPY_UINT32: return GroupByBase<uint32_t, int64_t, V>::GetXFunc2(func);
+       CASE_NPY_UINT64: return GroupByBase<uint64_t, int64_t, V>::GetXFunc2(func);
        }
     }
     else {
@@ -2465,14 +2465,14 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_FLOAT:  return GroupByBase<float, float, V>::GetXFunc(func);
       case NPY_DOUBLE: return GroupByBase<double, double, V>::GetXFunc(func);
       case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc(func);
-      case NPY_INT8:   return GroupByBase<INT8, INT8, V>::GetXFunc(func);
-      case NPY_INT16:  return GroupByBase<INT16, INT16, V>::GetXFunc(func);
-      CASE_NPY_INT32:  return GroupByBase<INT32, INT32, V>::GetXFunc(func);
-      CASE_NPY_INT64:  return GroupByBase<INT64, INT64, V>::GetXFunc(func);
-      case NPY_UINT8:  return GroupByBase<UINT8, UINT8, V>::GetXFunc(func);
-      case NPY_UINT16: return GroupByBase<UINT16, UINT16, V>::GetXFunc(func);
-      CASE_NPY_UINT32: return GroupByBase<UINT32, UINT32, V>::GetXFunc(func);
-      CASE_NPY_UINT64: return GroupByBase<UINT64, UINT64, V>::GetXFunc(func);
+      case NPY_INT8:   return GroupByBase<int8_t, int8_t, V>::GetXFunc(func);
+      case NPY_INT16:  return GroupByBase<int16_t, int16_t, V>::GetXFunc(func);
+      CASE_NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc(func);
+      CASE_NPY_INT64:  return GroupByBase<int64_t, int64_t, V>::GetXFunc(func);
+      case NPY_UINT8:  return GroupByBase<uint8_t, uint8_t, V>::GetXFunc(func);
+      case NPY_UINT16: return GroupByBase<uint16_t, uint16_t, V>::GetXFunc(func);
+      CASE_NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc(func);
+      CASE_NPY_UINT64: return GroupByBase<uint64_t, uint64_t, V>::GetXFunc(func);
       case NPY_STRING:
          return GroupByBase<char, char, V>::GetXFuncString(func);
       case NPY_UNICODE:
@@ -2486,14 +2486,14 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL BandedGroupByCall(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
+static bool BandedGroupByCall(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
    // -1 is the first core
    core = core + 1;
-   BOOL didSomeWork = FALSE;
+   bool didSomeWork = FALSE;
    stGroupBy32* pGroupBy32 = (stGroupBy32*)pstWorkerItem->WorkCallbackArg;
 
-   INT64 index;
-   INT64 workBlock;
+   int64_t index;
+   int64_t workBlock;
 
    // As long as there is work to do
    while ((index = pstWorkerItem->GetNextWorkIndex(&workBlock)) > 0) {
@@ -2503,10 +2503,10 @@ static BOOL BandedGroupByCall(struct stMATH_WORKER_ITEM* pstWorkerItem, int core
 
       // Data in was passed
       char* pDataIn = (char*)(aInfo[0].pData);
-      INT64 len = aInfo[0].ArrayLength;
-      INT64 totalRows = pGroupBy32->totalInputRows;
+      int64_t len = aInfo[0].ArrayLength;
+      int64_t totalRows = pGroupBy32->totalInputRows;
 
-      INT32* pCountOut = pGroupBy32->returnObjects[0].pCountOut;
+      int32_t* pCountOut = pGroupBy32->returnObjects[0].pCountOut;
       GROUPBY_X_FUNC32  pFunctionX = pGroupBy32->returnObjects[0].pFunctionX32;
       void* pDataOut = pGroupBy32->returnObjects[0].pOutArray;
 
@@ -2514,14 +2514,14 @@ static BOOL BandedGroupByCall(struct stMATH_WORKER_ITEM* pstWorkerItem, int core
       index--;
 
       LOGGING("|%d %d %lld %p %p %p", core, (int)workBlock, index, pDataIn, pCountOut, pDataOut);
-      INT64 binLow = pGroupBy32->returnObjects[index].binLow;
-      INT64 binHigh = pGroupBy32->returnObjects[index].binHigh;
+      int64_t binLow = pGroupBy32->returnObjects[index].binLow;
+      int64_t binHigh = pGroupBy32->returnObjects[index].binHigh;
 
       pFunctionX(
          (void*)pDataIn,
          (void*)pGroupBy32->pGroup,
-         (INT32*)pGroupBy32->pFirst,
-         (INT32*)pGroupBy32->pCount,
+         (int32_t*)pGroupBy32->pFirst,
+         (int32_t*)pGroupBy32->pCount,
          (char*)pDataOut,
          binLow,
          binHigh,
@@ -2543,41 +2543,41 @@ static BOOL BandedGroupByCall(struct stMATH_WORKER_ITEM* pstWorkerItem, int core
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL ScatterGroupByCall(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
+static bool ScatterGroupByCall(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
    // -1 is the first core
    core = core + 1;
 
-   BOOL didSomeWork = FALSE;
+   bool didSomeWork = FALSE;
    stGroupBy32* pGroupBy32 = (stGroupBy32*)pstWorkerItem->WorkCallbackArg;
    ArrayInfo* aInfo = pGroupBy32->aInfo;
 
    // Data in was passed
    char* pDataIn = (char*)(aInfo[0].pData);
-   INT64 len = aInfo[0].ArrayLength;
+   int64_t len = aInfo[0].ArrayLength;
 
    // iKey
    char* pDataIn2 = (char*)(pGroupBy32->pDataIn2);
 
-   INT64 binLow = pGroupBy32->returnObjects[core].binLow;
-   INT64 binHigh = pGroupBy32->returnObjects[core].binHigh;
-   INT32* pCountOut = pGroupBy32->returnObjects[core].pCountOut;
+   int64_t binLow = pGroupBy32->returnObjects[core].binLow;
+   int64_t binHigh = pGroupBy32->returnObjects[core].binHigh;
+   int32_t* pCountOut = pGroupBy32->returnObjects[core].pCountOut;
    GROUPBY_TWO_FUNC  pFunction = pGroupBy32->returnObjects[core].pFunction;
    void* pDataOut = pGroupBy32->returnObjects[core].pOutArray;
 
-   INT64 lenX;
-   INT64 workBlock;
-   INT64 pass = 0;
+   int64_t lenX;
+   int64_t workBlock;
+   int64_t pass = 0;
 
-   INT64 itemSize1 = aInfo[0].ItemSize;
-   INT64 itemSize2 = pGroupBy32->itemSize2;
+   int64_t itemSize1 = aInfo[0].ItemSize;
+   int64_t itemSize2 = pGroupBy32->itemSize2;
 
    //printf("Scatter working core %d  %lld\n", core, len);
    // As long as there is work to do
    while ((lenX = pstWorkerItem->GetNextWorkBlock(&workBlock)) > 0) {
       //printf("|%d %d %lld %p %p %p %p", core, (int)workBlock, lenX, pDataIn, pDataIn2, pCountOut, pDataOut);
 
-      INT64 inputAdj1 = pstWorkerItem->BlockSize * workBlock * itemSize1;
-      INT64 inputAdj2 = pstWorkerItem->BlockSize * workBlock * itemSize2;
+      int64_t inputAdj1 = pstWorkerItem->BlockSize * workBlock * itemSize1;
+      int64_t inputAdj2 = pstWorkerItem->BlockSize * workBlock * itemSize2;
 
       // shift pDataIn by T
       // shift pDataIn2 by U
@@ -2600,7 +2600,7 @@ static BOOL ScatterGroupByCall(struct stMATH_WORKER_ITEM* pstWorkerItem, int cor
 // BOTH groupby versions call this routine
 // ** THIS ROUTINE IS CALLED FROM MULTIPLE CONCURRENT THREADS!
 // i is the column number
-void GroupByCall(void* pGroupBy, INT64 i) {
+void GroupByCall(void* pGroupBy, int64_t i) {
    
    stGroupBy32* pGroupBy32 = (stGroupBy32* )pGroupBy;
    ArrayInfo* aInfo = pGroupBy32->aInfo;
@@ -2608,18 +2608,18 @@ void GroupByCall(void* pGroupBy, INT64 i) {
    // iKey
    void* pDataIn2 = pGroupBy32->pDataIn2;
 
-   INT64 uniqueRows = pGroupBy32->uniqueRows;
-   INT64 binLow = pGroupBy32->returnObjects[i].binLow;
-   INT64 binHigh = pGroupBy32->returnObjects[i].binHigh;
+   int64_t uniqueRows = pGroupBy32->uniqueRows;
+   int64_t binLow = pGroupBy32->returnObjects[i].binLow;
+   int64_t binHigh = pGroupBy32->returnObjects[i].binHigh;
 
    // Data in was passed
    void* pDataIn = aInfo[i].pData;
-   INT64 len = aInfo[i].ArrayLength;
+   int64_t len = aInfo[i].ArrayLength;
 
    PyArrayObject* outArray = pGroupBy32->returnObjects[i].outArray;
-   INT32* pCountOut = pGroupBy32->returnObjects[i].pCountOut;
+   int32_t* pCountOut = pGroupBy32->returnObjects[i].pCountOut;
    GROUPBY_TWO_FUNC  pFunction = pGroupBy32->returnObjects[i].pFunction;
-   INT32 numpyOutType = pGroupBy32->returnObjects[i].numpyOutType;
+   int32_t numpyOutType = pGroupBy32->returnObjects[i].numpyOutType;
    TYPE_OF_FUNCTION_CALL typeCall = pGroupBy32->typeOfFunctionCall;
 
    if (outArray && pFunction) {
@@ -2642,17 +2642,17 @@ void GroupByCall(void* pGroupBy, INT64 i) {
          // Accum the calculation
          GROUPBY_X_FUNC32  pFunctionX = pGroupBy32->returnObjects[i].pFunctionX32;
 
-         INT32 funcNum = pGroupBy32->returnObjects[i].funcNum;
+         int32_t funcNum = pGroupBy32->returnObjects[i].funcNum;
 
-         //static void AccumLast(void* pColumn, void* pGroupT, INT32* pFirst, INT32* pCount, void* pAccumBin, INT64 numUnique, INT64 totalInputRows, INT64 itemSize, INT64 funcParam) {
+         //static void AccumLast(void* pColumn, void* pGroupT, int32_t* pFirst, int32_t* pCount, void* pAccumBin, int64_t numUnique, int64_t totalInputRows, int64_t itemSize, int64_t funcParam) {
          if (funcNum < GB_FIRST) printf("!!! internal bug in GroupByCall -- %d\n", funcNum);
 
          if (pFunctionX) {
             pFunctionX(
                (void*)pDataIn,
-               (INT32*)pGroupBy32->pGroup /*USE GROUP wihch must be int32*/,
-               (INT32*)pGroupBy32->pFirst,
-               (INT32*)pGroupBy32->pCount,
+               (int32_t*)pGroupBy32->pGroup /*USE GROUP wihch must be int32*/,
+               (int32_t*)pGroupBy32->pFirst,
+               (int32_t*)pGroupBy32->pCount,
                (char*)pDataOut,
                binLow,
                binHigh,
@@ -2685,7 +2685,7 @@ void GroupByCall(void* pGroupBy, INT64 i) {
 
 //---------------------------------------------------------------
 // Arg1 = LIST of numpy arrays which has the values to accumulate (often all the columns in a dataset)
-// Arg2 = numpy array (INT32) which has the index to the unique keys (ikey from MultiKeyGroupBy32)
+// Arg2 = numpy array (int32_t) which has the index to the unique keys (ikey from MultiKeyGroupBy32)
 // Arg3 = integer unique rows
 // Arg4 = integer (function number to execute for sum,mean,min, max)
 // Example: GroupByOp2(array, ikey, 3, np.float32)
@@ -2696,8 +2696,8 @@ GroupByAll64(PyObject *self, PyObject *args)
    PyObject *inList1 = NULL;
    PyArrayObject *inArr2 = NULL;
 
-   INT64 unique_rows = 0;
-   INT64 funcNum = 0;
+   int64_t unique_rows = 0;
+   int64_t funcNum = 0;
 
    if (!PyArg_ParseTuple(
       args, "OO!LL",
@@ -2714,21 +2714,21 @@ GroupByAll64(PyObject *self, PyObject *args)
 }
 
 //---------------------------------------------------------------
-GROUPBY_TWO_FUNC GetGroupByFunctionStep1(INT32 iKeyType, BOOL* hasCounts, INT32* numpyOutType, INT32 numpyInType, GB_FUNCTIONS funcNum) {
+GROUPBY_TWO_FUNC GetGroupByFunctionStep1(int32_t iKeyType, bool* hasCounts, int32_t* numpyOutType, int32_t numpyInType, GB_FUNCTIONS funcNum) {
    GROUPBY_TWO_FUNC  pFunction = NULL;
 
    switch (iKeyType) {
    case NPY_INT8:
-      pFunction = GetGroupByFunction<INT8>(hasCounts, numpyOutType, numpyInType, funcNum);
+      pFunction = GetGroupByFunction<int8_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
    case NPY_INT16:
-      pFunction = GetGroupByFunction<INT16>(hasCounts, numpyOutType, numpyInType, funcNum);
+      pFunction = GetGroupByFunction<int16_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
    CASE_NPY_INT32:
-      pFunction = GetGroupByFunction<INT32>(hasCounts, numpyOutType, numpyInType, funcNum);
+      pFunction = GetGroupByFunction<int32_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
    CASE_NPY_INT64:
-      pFunction = GetGroupByFunction<INT64>(hasCounts, numpyOutType, numpyInType, funcNum);
+      pFunction = GetGroupByFunction<int64_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
    }
 
@@ -2748,16 +2748,16 @@ GroupBySingleOpMultiBands(
    PyArrayObject *iGroup,
    PyArrayObject *nCount,
    GB_FUNCTIONS firstFuncNum,
-   INT64 unique_rows,
-   INT64 tupleSize,
-   INT64 binLow,
-   INT64 binHigh)
+   int64_t unique_rows,
+   int64_t tupleSize,
+   int64_t binLow,
+   int64_t binHigh)
 {
    PyObject* returnTuple = NULL;
-   INT32 iKeyType = PyArray_TYPE(iKey);
+   int32_t iKeyType = PyArray_TYPE(iKey);
 
-   INT32 numpyOutType = aInfo[0].NumpyDType;
-   BOOL hasCounts = FALSE;
+   int32_t numpyOutType = aInfo[0].NumpyDType;
+   bool hasCounts = FALSE;
 
    LOGGING("In banded groupby %d\n", (int)firstFuncNum);
 
@@ -2765,26 +2765,26 @@ GroupBySingleOpMultiBands(
 
    switch (iKeyType) {
    case NPY_INT8:
-      pFunction = GetGroupByXFunction32<INT8>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
+      pFunction = GetGroupByXFunction32<int8_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
    case NPY_INT16:
-      pFunction = GetGroupByXFunction32<INT16>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
+      pFunction = GetGroupByXFunction32<int16_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
    CASE_NPY_INT32:
-      pFunction = GetGroupByXFunction32<INT32>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
+      pFunction = GetGroupByXFunction32<int32_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
    CASE_NPY_INT64:
-      pFunction = GetGroupByXFunction32<INT64>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
+      pFunction = GetGroupByXFunction32<int64_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
    }
 
    if (pFunction) {
       void* pDataIn2 = PyArray_BYTES(iKey);
-      INT64 arraySizeKey = ArrayLength(iKey);
+      int64_t arraySizeKey = ArrayLength(iKey);
 
       INT numCores = g_cMathWorker->WorkerThreadCount + 1;
-      INT64 bins = binHigh - binLow;
-      INT64 cores = numCores;
+      int64_t bins = binHigh - binLow;
+      int64_t cores = numCores;
       if (bins < cores) cores = bins;
 
       LOGGING("Banded cores %lld\n", cores);
@@ -2813,8 +2813,8 @@ GroupBySingleOpMultiBands(
             return NULL;
          }
 
-         INT64 itemSize = PyArray_ITEMSIZE(outArray);
-         INT32* pCountOut = NULL;
+         int64_t itemSize = PyArray_ITEMSIZE(outArray);
+         int32_t* pCountOut = NULL;
 
          //// Allocate room for all the threads to participate, this will be gathered later
          //char* pWorkspace = (char*)WORKSPACE_ALLOC(unique_rows * itemSize * numCores);
@@ -2826,8 +2826,8 @@ GroupBySingleOpMultiBands(
 
          if (hasCounts) {
             // Zero out for them
-            INT64 allocSize = sizeof(INT32)* unique_rows;
-            pCountOut = (INT32*)WORKSPACE_ALLOC(allocSize);
+            int64_t allocSize = sizeof(int32_t)* unique_rows;
+            pCountOut = (int32_t*)WORKSPACE_ALLOC(allocSize);
             if (pCountOut == NULL) {
                return NULL;
             }
@@ -2851,13 +2851,13 @@ GroupBySingleOpMultiBands(
 
          LOGGING("groupby dtypes:  key:%d  ifirst:%d  igroup:%d  count:%d\n", PyArray_TYPE(iKey), PyArray_TYPE(iFirst), PyArray_TYPE(iGroup), PyArray_TYPE(nCount));
 
-         INT64 dividend = unique_rows / cores;
-         INT64 remainder = unique_rows % cores;
+         int64_t dividend = unique_rows / cores;
+         int64_t remainder = unique_rows % cores;
 
-         INT64 low = 0;
-         INT64 high = 0;
+         int64_t low = 0;
+         int64_t high = 0;
 
-         for (INT64 i = 0; i < cores; i++) {
+         for (int64_t i = 0; i < cores; i++) {
 
             // Calculate band range
             high = low + dividend;
@@ -2874,7 +2874,7 @@ GroupBySingleOpMultiBands(
             // next low bin is the previous high bin
             low = high;
 
-            pstGroupBy32->returnObjects[i].funcNum = (INT32)firstFuncNum;
+            pstGroupBy32->returnObjects[i].funcNum = (int32_t)firstFuncNum;
             pstGroupBy32->returnObjects[i].didWork = 0;
 
             // Assign working memory per call
@@ -2922,18 +2922,18 @@ GroupBySingleOpMultithreaded(
    ArrayInfo* aInfo,
    PyArrayObject *iKey,
    GB_FUNCTIONS firstFuncNum, 
-   INT64 unique_rows, 
-   INT64 tupleSize,
-   INT64 binLow,
-   INT64 binHigh)
+   int64_t unique_rows, 
+   int64_t tupleSize,
+   int64_t binLow,
+   int64_t binHigh)
 {
    // Parallel one way
    // Divide up by memory
    PyObject* returnTuple = NULL;
-   INT32 iKeyType = PyArray_TYPE(iKey);
+   int32_t iKeyType = PyArray_TYPE(iKey);
 
-   INT32 numpyOutType = -1;
-   BOOL hasCounts = FALSE;
+   int32_t numpyOutType = -1;
+   bool hasCounts = FALSE;
 
    GROUPBY_TWO_FUNC  pFunction =
       GetGroupByFunctionStep1(iKeyType, &hasCounts, &numpyOutType, aInfo[0].NumpyDType, (GB_FUNCTIONS)firstFuncNum);
@@ -2943,7 +2943,7 @@ GroupBySingleOpMultithreaded(
    if (pFunction && numpyOutType != -1) {
 
       void* pDataIn2 = PyArray_BYTES(iKey);
-      INT64 arraySizeKey = ArrayLength(iKey);
+      int64_t arraySizeKey = ArrayLength(iKey);
 
       stMATH_WORKER_ITEM* pWorkItem = g_cMathWorker->GetWorkItem(arraySizeKey);
 
@@ -2961,8 +2961,8 @@ GroupBySingleOpMultithreaded(
             return NULL;
          }
 
-         INT64 itemSize = PyArray_ITEMSIZE(outArray);
-         INT32* pCountOut = NULL;
+         int64_t itemSize = PyArray_ITEMSIZE(outArray);
+         int32_t* pCountOut = NULL;
 
          // Allocate room for all the threads to participate, this will be gathered later
          char* pWorkspace = (char*)WORKSPACE_ALLOC(unique_rows * itemSize * numCores);
@@ -2975,8 +2975,8 @@ GroupBySingleOpMultithreaded(
 
          if (hasCounts) {
             // Zero out for them
-            INT64 allocSize = sizeof(INT32)* unique_rows * numCores;
-            pCountOut = (INT32*)WORKSPACE_ALLOC(allocSize);
+            int64_t allocSize = sizeof(int32_t)* unique_rows * numCores;
+            pCountOut = (int32_t*)WORKSPACE_ALLOC(allocSize);
             if (pCountOut == NULL) {
                return NULL;
             }
@@ -3003,7 +3003,7 @@ GroupBySingleOpMultithreaded(
          pstGroupBy32->typeOfFunctionCall = TYPE_OF_FUNCTION_CALL::ANY_GROUPBY_FUNC;
 
          for (int i = 0; i < numCores; i++) {
-            pstGroupBy32->returnObjects[i].funcNum = (INT32)firstFuncNum;
+            pstGroupBy32->returnObjects[i].funcNum = (int32_t)firstFuncNum;
             pstGroupBy32->returnObjects[i].binLow = binLow;
             pstGroupBy32->returnObjects[i].binHigh = binHigh;
 
@@ -3058,7 +3058,7 @@ GroupBySingleOpMultithreaded(
 
 //---------------------------------------------------------------
 // Arg1 = LIST of numpy arrays which has the values to accumulate (often all the columns in a dataset)
-// Arg2 = iKey = numpy array (INT32) which has the index to the unique keys (ikey from MultiKeyGroupBy32)
+// Arg2 = iKey = numpy array (int32_t) which has the index to the unique keys (ikey from MultiKeyGroupBy32)
 // Arg3 = integer unique rows
 // Arg4 = LIST of integer (function number to execute for sum,mean,min, max)
 // Arg5 = LIST of integers (binLow -- invalid bin)
@@ -3073,7 +3073,7 @@ GroupByAll32(PyObject *self, PyObject *args)
    PyArrayObject *iKey = NULL;
    PyObject* param = NULL;
 
-   INT64 unique_rows = 0;
+   int64_t unique_rows = 0;
    PyListObject* listFuncNum = NULL;
    PyListObject* listBinLow = NULL;
    PyListObject* listBinHigh = NULL;
@@ -3091,14 +3091,14 @@ GroupByAll32(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   INT32 ndim = PyArray_NDIM(iKey);
+   int32_t ndim = PyArray_NDIM(iKey);
 
    if (ndim != 1) {
       PyErr_Format(PyExc_ValueError, "GroupByAll32 ndim must be 1 not %d", ndim);
       return NULL;
    }
 
-   INT32 iKeyType = PyArray_TYPE(iKey);
+   int32_t iKeyType = PyArray_TYPE(iKey);
 
    // Valid types we can index by
    switch (iKeyType) {
@@ -3115,24 +3115,24 @@ GroupByAll32(PyObject *self, PyObject *args)
    // Add 1 for zero bin
    unique_rows += GB_BASE_INDEX;
 
-   INT32 numpyInType2 = ObjectToDtype(iKey);
+   int32_t numpyInType2 = ObjectToDtype(iKey);
 
-   INT64 totalItemSize = 0;
-   INT64 tupleSize = 0;
+   int64_t totalItemSize = 0;
+   int64_t tupleSize = 0;
    ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize,  &totalItemSize);
 
    if (!aInfo) {
       return NULL;
    }
 
-   INT64 funcTupleSize = PyList_GET_SIZE(listFuncNum);
+   int64_t funcTupleSize = PyList_GET_SIZE(listFuncNum);
 
    if (tupleSize != funcTupleSize) {
       PyErr_Format(PyExc_ValueError, "GroupByAll32 func numbers do not match array columns %lld %lld", tupleSize, funcTupleSize);
       return NULL;
    }
 
-   INT64 binTupleSize = PyList_GET_SIZE(listBinLow);
+   int64_t binTupleSize = PyList_GET_SIZE(listBinLow);
 
    if (tupleSize != binTupleSize) {
       PyErr_Format(PyExc_ValueError, "GroupByAll32 bin numbers do not match array columns %lld %lld", tupleSize, binTupleSize);
@@ -3141,7 +3141,7 @@ GroupByAll32(PyObject *self, PyObject *args)
 
    // Since this is the 32 bit function, the array indexes are 32 bit
    void* pDataIn2 = PyArray_BYTES(iKey);
-   INT64 arraySizeKey = ArrayLength(iKey);
+   int64_t arraySizeKey = ArrayLength(iKey);
 
    if (aInfo->ArrayLength != arraySizeKey) {
       PyErr_Format(PyExc_ValueError, "GroupByAll32 iKey length does not match value length %lld %lld", aInfo->ArrayLength, arraySizeKey);
@@ -3149,14 +3149,14 @@ GroupByAll32(PyObject *self, PyObject *args)
    }
 
    int overflow = 0;
-   INT64 firstFuncNum = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listFuncNum, 0), &overflow);
+   int64_t firstFuncNum = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listFuncNum, 0), &overflow);
    PyObject* returnTuple = NULL;
 
    // NOTE: what if bin size 10x larger?
    if (TRUE && ((unique_rows * 10) < arraySizeKey) && tupleSize == 1) {
 
-      INT64 binLow = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinLow, 0), &overflow);
-      INT64 binHigh = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinHigh, 0), &overflow);
+      int64_t binLow = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinLow, 0), &overflow);
+      int64_t binHigh = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinHigh, 0), &overflow);
 
       if ((firstFuncNum >= GB_SUM && firstFuncNum <= GB_MAX) ||
          (firstFuncNum >= GB_NANSUM && firstFuncNum <= GB_NANMAX))
@@ -3199,24 +3199,24 @@ GroupByAll32(PyObject *self, PyObject *args)
       for (int i = 0; i < tupleSize; i++) {
 
          // TODO: determine based on function
-         INT32 numpyOutType = -1;
-         BOOL hasCounts = FALSE;
+         int32_t numpyOutType = -1;
+         bool hasCounts = FALSE;
 
          int overflow = 0;
-         INT64 funcNum = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listFuncNum, i), &overflow);
-         pstGroupBy32->returnObjects[i].funcNum = (INT32)funcNum;
+         int64_t funcNum = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listFuncNum, i), &overflow);
+         pstGroupBy32->returnObjects[i].funcNum = (int32_t)funcNum;
 
-         INT64 binLow = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinLow, i), &overflow);
+         int64_t binLow = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinLow, i), &overflow);
          pstGroupBy32->returnObjects[i].binLow = binLow;
 
-         INT64 binHigh = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinHigh, i), &overflow);
+         int64_t binHigh = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinHigh, i), &overflow);
          pstGroupBy32->returnObjects[i].binHigh = binHigh;
 
          GROUPBY_TWO_FUNC  pFunction = 
             GetGroupByFunctionStep1(iKeyType, &hasCounts, &numpyOutType, aInfo[i].NumpyDType, (GB_FUNCTIONS)funcNum);
 
          PyArrayObject* outArray = NULL;
-         INT32* pCountOut = NULL;
+         int32_t* pCountOut = NULL;
          void* pOutArray=NULL;
 
          if (pFunction && numpyOutType != -1) {
@@ -3229,15 +3229,15 @@ GroupByAll32(PyObject *self, PyObject *args)
             }
 
             pOutArray = PyArray_BYTES(outArray);
-            INT64 itemSize = PyArray_ITEMSIZE(outArray);
+            int64_t itemSize = PyArray_ITEMSIZE(outArray);
 
             if (hasCounts) {
                // Zero out for them
-               pCountOut = (INT32*)WORKSPACE_ALLOC(sizeof(INT32)* unique_rows);
+               pCountOut = (int32_t*)WORKSPACE_ALLOC(sizeof(int32_t)* unique_rows);
                if (pCountOut == NULL) {
                   return NULL;
                }
-               memset(pCountOut, 0, sizeof(INT32) * unique_rows);
+               memset(pCountOut, 0, sizeof(int32_t) * unique_rows);
             }
          }
          else {
@@ -3271,7 +3271,7 @@ GroupByAll32(PyObject *self, PyObject *args)
          //printf("ref %d  %llu\n", i, item->ob_refcnt);
          PyTuple_SET_ITEM(returnTuple, i, item);
 
-         INT32* pCountOut = pstGroupBy32->returnObjects[i].pCountOut;
+         int32_t* pCountOut = pstGroupBy32->returnObjects[i].pCountOut;
 
          if (pCountOut) {
             WORKSPACE_FREE(pCountOut);
@@ -3294,10 +3294,10 @@ GroupByAll32(PyObject *self, PyObject *args)
 
 //---------------------------------------------------------------
 // Arg1 = LIST of numpy arrays which has the values to accumulate (often all the columns in a dataset)
-// Arg2 =iKey = numpy array (INT32) which has the index to the unique keys (ikey from MultiKeyGroupBy32)
-// Arg3 =iGroup: (INT32) array size is same as multikey, unique keys are grouped together
-// Arg4 =iFirst: (INT32) array size is number of unique keys, indexes into iGroup
-// Arg5 =nCount: (INT32) array size is number of unique keys for the group, is how many member of the group (paired with iFirst)
+// Arg2 =iKey = numpy array (int32_t) which has the index to the unique keys (ikey from MultiKeyGroupBy32)
+// Arg3 =iGroup: (int32_t) array size is same as multikey, unique keys are grouped together
+// Arg4 =iFirst: (int32_t) array size is number of unique keys, indexes into iGroup
+// Arg5 =nCount: (int32_t) array size is number of unique keys for the group, is how many member of the group (paired with iFirst)
 // Arg6 = integer unique rows
 // Arg7 = LIST of integers (function number to execute for sum,mean,min, max)
 // Arg8 = LIST of integers (binLow -- invalid bin)
@@ -3318,11 +3318,11 @@ GroupByAllPack32(PyObject *self, PyObject *args)
    PyArrayObject* nCount;
 
 
-   INT64 unique_rows = 0;
+   int64_t unique_rows = 0;
    PyListObject* listFuncNum = 0;
    PyListObject* listBinLow = 0;
    PyListObject* listBinHigh = 0;
-   INT64 funcParam = 0;
+   int64_t funcParam = 0;
 
    if (!PyArg_ParseTuple(
       args, "OO!O!O!O!LO!O!O!L",
@@ -3343,7 +3343,7 @@ GroupByAllPack32(PyObject *self, PyObject *args)
 
    LOGGING("GroupByAllPack32 types: key:%d  group:%d  first:%d  count:%d\n", PyArray_TYPE(iKey), PyArray_TYPE(iGroup), PyArray_TYPE(iFirst), PyArray_TYPE(nCount));
 
-   INT32 iKeyType = PyArray_TYPE(iKey);
+   int32_t iKeyType = PyArray_TYPE(iKey);
 
    // Valid types we can index by
    switch (iKeyType) {
@@ -3360,8 +3360,8 @@ GroupByAllPack32(PyObject *self, PyObject *args)
    // Add 1 for zero bin
    unique_rows += GB_BASE_INDEX;
 
-   INT64 totalItemSize = 0;
-   INT64 tupleSize = 0;
+   int64_t totalItemSize = 0;
+   int64_t tupleSize = 0;
    ArrayInfo* aInfo = BuildArrayInfo(inList1, &tupleSize, &totalItemSize);
 
    if (!aInfo) {
@@ -3370,15 +3370,15 @@ GroupByAllPack32(PyObject *self, PyObject *args)
 
    // New reference
    PyObject* returnTuple = NULL;
-   INT64 arraySizeKey = ArrayLength(iKey);
+   int64_t arraySizeKey = ArrayLength(iKey);
 
    if (tupleSize == 1 && arraySizeKey > 65536) {
 
       int overflow = 0;
-      INT64 binLow = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinLow, 0), &overflow);
-      INT64 binHigh = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinHigh, 0), &overflow);
+      int64_t binLow = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinLow, 0), &overflow);
+      int64_t binHigh = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinHigh, 0), &overflow);
 
-      INT64 firstFuncNum = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listFuncNum, 0), &overflow);
+      int64_t firstFuncNum = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listFuncNum, 0), &overflow);
 
       LOGGING("Checking banded %lld\n", firstFuncNum);
 
@@ -3401,13 +3401,13 @@ GroupByAllPack32(PyObject *self, PyObject *args)
 
    if (returnTuple == NULL) {
 
-      INT64 funcTupleSize = PyList_GET_SIZE(listFuncNum);
+      int64_t funcTupleSize = PyList_GET_SIZE(listFuncNum);
 
       if (tupleSize != funcTupleSize) {
          PyErr_Format(PyExc_ValueError, "GroupByAll32 func numbers do not match array columns %lld %lld", tupleSize, funcTupleSize);
       }
 
-      INT64 binTupleSize = PyList_GET_SIZE(listBinLow);
+      int64_t binTupleSize = PyList_GET_SIZE(listBinLow);
 
       if (tupleSize != binTupleSize) {
          PyErr_Format(PyExc_ValueError, "GroupByAll32 bin numbers do not match array columns %lld %lld", tupleSize, binTupleSize);
@@ -3415,14 +3415,14 @@ GroupByAllPack32(PyObject *self, PyObject *args)
       }
 
       // TODO: determine based on function
-      INT32 numpyOutType = NPY_FLOAT64;
-      INT32 numpyInType2 = ObjectToDtype(iKey);
+      int32_t numpyOutType = NPY_FLOAT64;
+      int32_t numpyInType2 = ObjectToDtype(iKey);
 
       // Since this is the 32 bit function, the array indexes are 32 bit
       void* pDataIn2 = PyArray_BYTES(iKey);
 
       // Allocate the struct + ROOM at the end of struct for all the tuple objects being produced
-      INT64 allocSize = (sizeof(stGroupBy32) + 8 + sizeof(stGroupByReturn))*tupleSize;
+      int64_t allocSize = (sizeof(stGroupBy32) + 8 + sizeof(stGroupByReturn))*tupleSize;
       LOGGING("in groupby32 allocating %lld\n", allocSize);
 
       stGroupBy32* pstGroupBy32 = (stGroupBy32*)WORKSPACE_ALLOC(allocSize);
@@ -3448,13 +3448,13 @@ GroupByAllPack32(PyObject *self, PyObject *args)
       // Allocate all the memory and output arrays up front since Python is single threaded
       for (int i = 0; i < tupleSize; i++) {
          int overflow = 0;
-         INT64 funcNum = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listFuncNum, i), &overflow);
-         pstGroupBy32->returnObjects[i].funcNum = (INT32)funcNum;
+         int64_t funcNum = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listFuncNum, i), &overflow);
+         pstGroupBy32->returnObjects[i].funcNum = (int32_t)funcNum;
 
-         INT64 binLow = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinLow, i), &overflow);
+         int64_t binLow = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinLow, i), &overflow);
          pstGroupBy32->returnObjects[i].binLow = binLow;
 
-         INT64 binHigh = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinHigh, i), &overflow);
+         int64_t binHigh = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinHigh, i), &overflow);
          pstGroupBy32->returnObjects[i].binHigh = binHigh;
 
          numpyOutType = aInfo[i].NumpyDType;
@@ -3463,16 +3463,16 @@ GroupByAllPack32(PyObject *self, PyObject *args)
 
          switch (iKeyType) {
          case NPY_INT8:
-            pFunction = GetGroupByXFunction32<INT8>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
+            pFunction = GetGroupByXFunction32<int8_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
          case NPY_INT16:
-            pFunction = GetGroupByXFunction32<INT16>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
+            pFunction = GetGroupByXFunction32<int16_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
          CASE_NPY_INT32:
-            pFunction = GetGroupByXFunction32<INT32>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
+            pFunction = GetGroupByXFunction32<int32_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
          CASE_NPY_INT64:
-            pFunction = GetGroupByXFunction32<INT64>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
+            pFunction = GetGroupByXFunction32<int64_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
          }
 
@@ -3585,7 +3585,7 @@ GroupByAllPack32(PyObject *self, PyObject *args)
 
       //   if (pFunction) {
       //      // Perform op
-      //      pFunction((INT32*)pGroup, (INT32*)pFirst, (INT32*)pCount, (char*)pAccumBin, (char*)aInfo[i].pData, unique_rows, aInfo[i].ItemSize, funcParam);
+      //      pFunction((int32_t*)pGroup, (int32_t*)pFirst, (int32_t*)pCount, (char*)pAccumBin, (char*)aInfo[i].pData, unique_rows, aInfo[i].ItemSize, funcParam);
       //      PyTuple_SET_ITEM(returnTuple, i, (PyObject*)pstGroupBy32->returnObjects[i].outArray);
       //   }
       //   else {

--- a/src/GroupBy.cpp
+++ b/src/GroupBy.cpp
@@ -2042,12 +2042,12 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: return GatherSum<long double>;
       case NPY_INT8:  return GatherSum<int64_t>;
       case NPY_INT16: return GatherSum<int64_t>;
-      case NPY_INT32: return GatherSum<int64_t>;
+      case NPY_INT: return GatherSum<int64_t>;
       case NPY_INT64:
       case NPY_LONGLONG: return GatherSum<int64_t>;
       case NPY_UINT8: return GatherSum<uint64_t>;
       case NPY_UINT16:return GatherSum<uint64_t>;
-      case NPY_UINT32:return GatherSum<uint64_t>;
+      case NPY_UINT:return GatherSum<uint64_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GatherSum<uint64_t>;
@@ -2064,12 +2064,12 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: 
       case NPY_INT8:  
       case NPY_INT16: 
-      case NPY_INT32: 
+      case NPY_INT: 
       case NPY_INT64:
       case NPY_LONGLONG:
       case NPY_UINT8: 
       case NPY_UINT16:
-      case NPY_UINT32:
+      case NPY_UINT:
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GatherMean<double>;
@@ -2085,13 +2085,13 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: return GatherMaxFloat<long double>;
       case NPY_INT8:  return GatherMax<int8_t>;
       case NPY_INT16: return GatherMax<int16_t>;
-      case NPY_INT32: return GatherMax<int32_t>;
+      case NPY_INT: return GatherMax<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return GatherMax<int64_t>;
       case NPY_UINT8: return GatherMax<uint8_t>;
       case NPY_UINT16:return GatherMax<uint16_t>;
-      case NPY_UINT32:return GatherMax<uint32_t>;
+      case NPY_UINT:return GatherMax<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GatherMax<uint64_t>;
@@ -2107,13 +2107,13 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: return GatherMinFloat<long double>;
       case NPY_INT8:  return GatherMin<int8_t>;
       case NPY_INT16: return GatherMin<int16_t>;
-      case NPY_INT32: return GatherMin<int32_t>;
+      case NPY_INT: return GatherMin<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return GatherMin<int64_t>;
       case NPY_UINT8: return GatherMin<uint8_t>;
       case NPY_UINT16:return GatherMin<uint16_t>;
-      case NPY_UINT32:return GatherMin<uint32_t>;
+      case NPY_UINT:return GatherMin<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GatherMin<uint64_t>;
@@ -2143,13 +2143,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumSum;
       case NPY_INT8:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t,    int64_t,  V>::AccumSum;
       case NPY_INT16:  *wantedOutputType = NPY_INT64; return GroupByBase<int16_t,   int64_t,  V>::AccumSum;
-      case NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t,   int64_t,  V>::AccumSum;
+      case NPY_INT:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t,   int64_t,  V>::AccumSum;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t,   int64_t,  V>::AccumSum;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT64; return GroupByBase<uint8_t,  uint64_t, V>::AccumSum;
       case NPY_UINT16: *wantedOutputType = NPY_UINT64; return GroupByBase<uint16_t, uint64_t, V>::AccumSum;
-      case NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumSum;
+      case NPY_UINT: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumSum;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumSum;
@@ -2165,13 +2165,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_BOOL:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t, int64_t, V>::AccumSum;
       case NPY_INT8:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t, int64_t, V>::AccumNanSum;
       case NPY_INT16:  *wantedOutputType = NPY_INT64; return GroupByBase<int16_t, int64_t, V>::AccumNanSum;
-      case NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t, int64_t, V>::AccumNanSum;
+      case NPY_INT:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t, int64_t, V>::AccumNanSum;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanSum;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT64; return GroupByBase<uint8_t, uint64_t, V>::AccumNanSum;
       case NPY_UINT16: *wantedOutputType = NPY_UINT64; return GroupByBase<uint16_t, uint64_t, V>::AccumNanSum;
-      case NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumNanSum;
+      case NPY_UINT: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumNanSum;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanSum;
@@ -2187,13 +2187,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumMin;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t,     int8_t, V>::AccumMin;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t,   int16_t, V>::AccumMin;
-      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t,   int32_t, V>::AccumMin;
+      case NPY_INT:  *wantedOutputType = NPY_INT; return GroupByBase<int32_t,   int32_t, V>::AccumMin;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t,   int64_t, V>::AccumMin;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t,   uint8_t, V>::AccumMin;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumMin;
-      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMin;
+      case NPY_UINT: *wantedOutputType = NPY_UINT; return GroupByBase<uint32_t, uint32_t, V>::AccumMin;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumMin;
@@ -2209,13 +2209,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMin;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumNanMin;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumNanMin;
-      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMin;
+      case NPY_INT:  *wantedOutputType = NPY_INT; return GroupByBase<int32_t, int32_t, V>::AccumNanMin;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanMin;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumNanMin;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumNanMin;
-      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMin;
+      case NPY_UINT: *wantedOutputType = NPY_UINT; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMin;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanMin;
@@ -2231,13 +2231,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumMax;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumMax;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumMax;
-      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumMax;
+      case NPY_INT:  *wantedOutputType = NPY_INT; return GroupByBase<int32_t, int32_t, V>::AccumMax;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumMax;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumMax;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumMax;
-      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMax;
+      case NPY_UINT: *wantedOutputType = NPY_UINT; return GroupByBase<uint32_t, uint32_t, V>::AccumMax;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumMax;
@@ -2254,13 +2254,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMax;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumNanMax;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumNanMax;
-      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMax;
+      case NPY_INT:  *wantedOutputType = NPY_INT; return GroupByBase<int32_t, int32_t, V>::AccumNanMax;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanMax;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumNanMax;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumNanMax;
-      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMax;
+      case NPY_UINT: *wantedOutputType = NPY_UINT; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMax;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanMax;
@@ -2276,13 +2276,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumMean;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t,     double, V>::AccumMean;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t,   double, V>::AccumMean;
-      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t,   double, V>::AccumMean;
+      case NPY_INT:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t,   double, V>::AccumMean;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t,   double, V>::AccumMean;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t,   double, V>::AccumMean;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumMean;
-      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumMean;
+      case NPY_UINT: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumMean;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumMean;
@@ -2299,13 +2299,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanMean;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanMean;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanMean;
-      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanMean;
+      case NPY_INT:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanMean;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanMean;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanMean;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanMean;
-      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanMean;
+      case NPY_UINT: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanMean;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanMean;
@@ -2322,13 +2322,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumVar;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumVar;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumVar;
-      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumVar;
+      case NPY_INT:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumVar;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumVar;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumVar;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumVar;
-      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumVar;
+      case NPY_UINT: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumVar;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumVar;
@@ -2345,13 +2345,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanVar;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanVar;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanVar;
-      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanVar;
+      case NPY_INT:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanVar;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanVar;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanVar;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanVar;
-      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanVar;
+      case NPY_UINT: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanVar;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanVar;
@@ -2367,13 +2367,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumStd;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumStd;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumStd;
-      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumStd;
+      case NPY_INT:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumStd;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumStd;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumStd;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumStd;
-      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumStd;
+      case NPY_UINT: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumStd;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumStd;
@@ -2390,13 +2390,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanStd;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanStd;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanStd;
-      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanStd;
+      case NPY_INT:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanStd;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanStd;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanStd;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanStd;
-      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanStd;
+      case NPY_UINT: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanStd;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanStd;
@@ -2419,12 +2419,12 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
 //      //   case NPY_BYTE:   return GroupByBase<T, int8_t>::GetFunc(func);
 //      //   case NPY_INT16:  return GroupByBase<T, int16_t>::GetFunc(func);
 //   case NPY_INT:    return GroupByBase<T, int32_t>::GetXFunc(func);
-//   case NPY_INT32:  return GroupByBase<T, int32_t>::GetXFunc(func);
+//   case NPY_INT:  return GroupByBase<T, int32_t>::GetXFunc(func);
 //   case NPY_INT64:  return GroupByBase<T, int64_t>::GetXFunc(func);
 //      //   case NPY_UBYTE:  return GroupByBase<T, uint8_t>::GetFunc(func);
 //      //   case NPY_UINT16: return GroupByBase<T, uint16_t>::GetFunc(func);
 //   case NPY_UINT:   return GroupByBase<T, uint32_t>::GetXFunc(func);
-//   case NPY_UINT32: return GroupByBase<T, uint32_t>::GetXFunc(func);
+//   case NPY_UINT: return GroupByBase<T, uint32_t>::GetXFunc(func);
 //   case NPY_UINT64: return GroupByBase<T, uint64_t>::GetXFunc(func);
 //   }
 //   return NULL;
@@ -2443,13 +2443,13 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_LONGDOUBLE: return GroupByBase<long double, double, V>::AccumTrimMeanBR;
       case NPY_INT8:   return GroupByBase<int8_t, double, V>::AccumTrimMeanBR;
       case NPY_INT16:  return GroupByBase<int16_t, double, V>::AccumTrimMeanBR;
-      case NPY_INT32:  return GroupByBase<int32_t, double, V>::AccumTrimMeanBR;
+      case NPY_INT:  return GroupByBase<int32_t, double, V>::AccumTrimMeanBR;
       case NPY_INT64:
       case NPY_LONGLONG:
          return GroupByBase<int64_t, double, V>::AccumTrimMeanBR;
       case NPY_UINT8:  return GroupByBase<uint8_t, double, V>::AccumTrimMeanBR;
       case NPY_UINT16: return GroupByBase<uint16_t, double, V>::AccumTrimMeanBR;
-      case NPY_UINT32: return GroupByBase<uint32_t, double, V>::AccumTrimMeanBR;
+      case NPY_UINT: return GroupByBase<uint32_t, double, V>::AccumTrimMeanBR;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GroupByBase<uint64_t, double, V>::AccumTrimMeanBR;
@@ -2460,7 +2460,7 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       switch (inputType) {
       case NPY_INT8:   return GroupByBase<int8_t, int32_t, V>::GetXFunc2(func);
       case NPY_INT16:  return GroupByBase<int16_t, int32_t, V>::GetXFunc2(func);
-      case NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
+      case NPY_INT:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
       case NPY_INT64:
       case NPY_LONGLONG:
          return GroupByBase<int64_t, int32_t, V>::GetXFunc2(func);
@@ -2477,13 +2477,13 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc2(func);
       case NPY_INT8:   return GroupByBase<int8_t, int8_t, V>::GetXFunc2(func);
       case NPY_INT16:  return GroupByBase<int16_t, int16_t, V>::GetXFunc2(func);
-      case NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
+      case NPY_INT:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
       case NPY_INT64:
       case NPY_LONGLONG:
          return GroupByBase<int64_t, int64_t, V>::GetXFunc2(func);
       case NPY_UINT8:  return GroupByBase<uint8_t, uint8_t, V>::GetXFunc2(func);
       case NPY_UINT16: return GroupByBase<uint16_t, uint16_t, V>::GetXFunc2(func);
-      case NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc2(func);
+      case NPY_UINT: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc2(func);
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GroupByBase<uint64_t, uint64_t, V>::GetXFunc2(func);
@@ -2501,13 +2501,13 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
          case NPY_LONGDOUBLE: return GroupByBase<long double, double, V>::GetXFunc2(func);
          case NPY_INT8:   return GroupByBase<int8_t, double, V>::GetXFunc2(func);
          case NPY_INT16:  return GroupByBase<int16_t, double, V>::GetXFunc2(func);
-         case NPY_INT32:  return GroupByBase<int32_t, double, V>::GetXFunc2(func);
+         case NPY_INT:  return GroupByBase<int32_t, double, V>::GetXFunc2(func);
          case NPY_INT64:
          case NPY_LONGLONG:
             return GroupByBase<int64_t, double, V>::GetXFunc2(func); 
          case NPY_UINT8:  return GroupByBase<uint8_t, double, V>::GetXFunc2(func);
          case NPY_UINT16: return GroupByBase<uint16_t, double, V>::GetXFunc2(func);
-         case NPY_UINT32: return GroupByBase<uint32_t, double, V>::GetXFunc2(func);
+         case NPY_UINT: return GroupByBase<uint32_t, double, V>::GetXFunc2(func);
          case NPY_UINT64:
          case NPY_ULONGLONG:
             return GroupByBase<uint64_t, double, V>::GetXFunc2(func);
@@ -2526,13 +2526,13 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
          case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc2(func);
          case NPY_INT8:   return GroupByBase<int8_t, int64_t, V>::GetXFunc2(func);
          case NPY_INT16:  return GroupByBase<int16_t, int64_t, V>::GetXFunc2(func);
-         case NPY_INT32:  return GroupByBase<int32_t, int64_t, V>::GetXFunc2(func);
+         case NPY_INT:  return GroupByBase<int32_t, int64_t, V>::GetXFunc2(func);
          case NPY_INT64:
          case NPY_LONGLONG:
             return GroupByBase<int64_t, int64_t, V>::GetXFunc2(func);
          case NPY_UINT8:  return GroupByBase<uint8_t, int64_t, V>::GetXFunc2(func);
          case NPY_UINT16: return GroupByBase<uint16_t, int64_t, V>::GetXFunc2(func);
-         case NPY_UINT32: return GroupByBase<uint32_t, int64_t, V>::GetXFunc2(func);
+         case NPY_UINT: return GroupByBase<uint32_t, int64_t, V>::GetXFunc2(func);
          case NPY_UINT64:
          case NPY_ULONGLONG:
             return GroupByBase<uint64_t, int64_t, V>::GetXFunc2(func);
@@ -2549,13 +2549,13 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc(func);
       case NPY_INT8:   return GroupByBase<int8_t, int8_t, V>::GetXFunc(func);
       case NPY_INT16:  return GroupByBase<int16_t, int16_t, V>::GetXFunc(func);
-      case NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc(func);
+      case NPY_INT:  return GroupByBase<int32_t, int32_t, V>::GetXFunc(func);
       case NPY_INT64:
       case NPY_LONGLONG:
          return GroupByBase<int64_t, int64_t, V>::GetXFunc(func);
       case NPY_UINT8:  return GroupByBase<uint8_t, uint8_t, V>::GetXFunc(func);
       case NPY_UINT16: return GroupByBase<uint16_t, uint16_t, V>::GetXFunc(func);
-      case NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc(func);
+      case NPY_UINT: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc(func);
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GroupByBase<uint64_t, uint64_t, V>::GetXFunc(func);
@@ -2810,7 +2810,7 @@ GROUPBY_TWO_FUNC GetGroupByFunctionStep1(int32_t iKeyType, bool* hasCounts, int3
    case NPY_INT16:
       pFunction = GetGroupByFunction<int16_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
-   case NPY_INT32:
+   case NPY_INT:
       pFunction = GetGroupByFunction<int32_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
    case NPY_INT64:
@@ -2857,7 +2857,7 @@ GroupBySingleOpMultiBands(
    case NPY_INT16:
       pFunction = GetGroupByXFunction32<int16_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
-   case NPY_INT32:
+   case NPY_INT:
       pFunction = GetGroupByXFunction32<int32_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
    case NPY_INT64:
@@ -3192,7 +3192,7 @@ GroupByAll32(PyObject *self, PyObject *args)
    switch (iKeyType) {
    case NPY_INT8:
    case NPY_INT16:
-   case NPY_INT32:
+   case NPY_INT:
    case NPY_INT64:
    case NPY_LONGLONG:
       break;
@@ -3438,7 +3438,7 @@ GroupByAllPack32(PyObject *self, PyObject *args)
    switch (iKeyType) {
    case NPY_INT8:
    case NPY_INT16:
-   case NPY_INT32:
+   case NPY_INT:
    case NPY_INT64:
    case NPY_LONGLONG:
       break;
@@ -3558,7 +3558,7 @@ GroupByAllPack32(PyObject *self, PyObject *args)
          case NPY_INT16:
             pFunction = GetGroupByXFunction32<int16_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
-         case NPY_INT32:
+         case NPY_INT:
             pFunction = GetGroupByXFunction32<int32_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
          case NPY_INT64:
@@ -3594,7 +3594,7 @@ GroupByAllPack32(PyObject *self, PyObject *args)
                      numpyOutType = NPY_INT64;
 
                      if (funcNum == GB_ROLLING_COUNT) {
-                        numpyOutType = NPY_INT32;
+                        numpyOutType = NPY_INT;
                      }
                      else {
 

--- a/src/GroupBy.cpp
+++ b/src/GroupBy.cpp
@@ -2042,12 +2042,12 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: return GatherSum<long double>;
       case NPY_INT8:  return GatherSum<int64_t>;
       case NPY_INT16: return GatherSum<int64_t>;
-      case NPY_INT: return GatherSum<int64_t>;
+      case NPY_INT32: return GatherSum<int64_t>;
       case NPY_INT64:
       case NPY_LONGLONG: return GatherSum<int64_t>;
       case NPY_UINT8: return GatherSum<uint64_t>;
       case NPY_UINT16:return GatherSum<uint64_t>;
-      case NPY_UINT:return GatherSum<uint64_t>;
+      case NPY_UINT32:return GatherSum<uint64_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GatherSum<uint64_t>;
@@ -2064,12 +2064,12 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: 
       case NPY_INT8:  
       case NPY_INT16: 
-      case NPY_INT: 
+      case NPY_INT32: 
       case NPY_INT64:
       case NPY_LONGLONG:
       case NPY_UINT8: 
       case NPY_UINT16:
-      case NPY_UINT:
+      case NPY_UINT32:
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GatherMean<double>;
@@ -2085,13 +2085,13 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: return GatherMaxFloat<long double>;
       case NPY_INT8:  return GatherMax<int8_t>;
       case NPY_INT16: return GatherMax<int16_t>;
-      case NPY_INT: return GatherMax<int32_t>;
+      case NPY_INT32: return GatherMax<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return GatherMax<int64_t>;
       case NPY_UINT8: return GatherMax<uint8_t>;
       case NPY_UINT16:return GatherMax<uint16_t>;
-      case NPY_UINT:return GatherMax<uint32_t>;
+      case NPY_UINT32:return GatherMax<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GatherMax<uint64_t>;
@@ -2107,13 +2107,13 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: return GatherMinFloat<long double>;
       case NPY_INT8:  return GatherMin<int8_t>;
       case NPY_INT16: return GatherMin<int16_t>;
-      case NPY_INT: return GatherMin<int32_t>;
+      case NPY_INT32: return GatherMin<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return GatherMin<int64_t>;
       case NPY_UINT8: return GatherMin<uint8_t>;
       case NPY_UINT16:return GatherMin<uint16_t>;
-      case NPY_UINT:return GatherMin<uint32_t>;
+      case NPY_UINT32:return GatherMin<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GatherMin<uint64_t>;
@@ -2143,13 +2143,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumSum;
       case NPY_INT8:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t,    int64_t,  V>::AccumSum;
       case NPY_INT16:  *wantedOutputType = NPY_INT64; return GroupByBase<int16_t,   int64_t,  V>::AccumSum;
-      case NPY_INT:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t,   int64_t,  V>::AccumSum;
+      case NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t,   int64_t,  V>::AccumSum;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t,   int64_t,  V>::AccumSum;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT64; return GroupByBase<uint8_t,  uint64_t, V>::AccumSum;
       case NPY_UINT16: *wantedOutputType = NPY_UINT64; return GroupByBase<uint16_t, uint64_t, V>::AccumSum;
-      case NPY_UINT: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumSum;
+      case NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumSum;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumSum;
@@ -2165,13 +2165,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_BOOL:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t, int64_t, V>::AccumSum;
       case NPY_INT8:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t, int64_t, V>::AccumNanSum;
       case NPY_INT16:  *wantedOutputType = NPY_INT64; return GroupByBase<int16_t, int64_t, V>::AccumNanSum;
-      case NPY_INT:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t, int64_t, V>::AccumNanSum;
+      case NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t, int64_t, V>::AccumNanSum;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanSum;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT64; return GroupByBase<uint8_t, uint64_t, V>::AccumNanSum;
       case NPY_UINT16: *wantedOutputType = NPY_UINT64; return GroupByBase<uint16_t, uint64_t, V>::AccumNanSum;
-      case NPY_UINT: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumNanSum;
+      case NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumNanSum;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanSum;
@@ -2187,13 +2187,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumMin;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t,     int8_t, V>::AccumMin;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t,   int16_t, V>::AccumMin;
-      case NPY_INT:  *wantedOutputType = NPY_INT; return GroupByBase<int32_t,   int32_t, V>::AccumMin;
+      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t,   int32_t, V>::AccumMin;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t,   int64_t, V>::AccumMin;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t,   uint8_t, V>::AccumMin;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumMin;
-      case NPY_UINT: *wantedOutputType = NPY_UINT; return GroupByBase<uint32_t, uint32_t, V>::AccumMin;
+      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMin;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumMin;
@@ -2209,13 +2209,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMin;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumNanMin;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumNanMin;
-      case NPY_INT:  *wantedOutputType = NPY_INT; return GroupByBase<int32_t, int32_t, V>::AccumNanMin;
+      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMin;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanMin;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumNanMin;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumNanMin;
-      case NPY_UINT: *wantedOutputType = NPY_UINT; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMin;
+      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMin;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanMin;
@@ -2231,13 +2231,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumMax;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumMax;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumMax;
-      case NPY_INT:  *wantedOutputType = NPY_INT; return GroupByBase<int32_t, int32_t, V>::AccumMax;
+      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumMax;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumMax;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumMax;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumMax;
-      case NPY_UINT: *wantedOutputType = NPY_UINT; return GroupByBase<uint32_t, uint32_t, V>::AccumMax;
+      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMax;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumMax;
@@ -2254,13 +2254,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMax;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumNanMax;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumNanMax;
-      case NPY_INT:  *wantedOutputType = NPY_INT; return GroupByBase<int32_t, int32_t, V>::AccumNanMax;
+      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMax;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanMax;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumNanMax;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumNanMax;
-      case NPY_UINT: *wantedOutputType = NPY_UINT; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMax;
+      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMax;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanMax;
@@ -2276,13 +2276,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumMean;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t,     double, V>::AccumMean;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t,   double, V>::AccumMean;
-      case NPY_INT:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t,   double, V>::AccumMean;
+      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t,   double, V>::AccumMean;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t,   double, V>::AccumMean;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t,   double, V>::AccumMean;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumMean;
-      case NPY_UINT: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumMean;
+      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumMean;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumMean;
@@ -2299,13 +2299,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanMean;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanMean;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanMean;
-      case NPY_INT:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanMean;
+      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanMean;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanMean;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanMean;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanMean;
-      case NPY_UINT: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanMean;
+      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanMean;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanMean;
@@ -2322,13 +2322,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumVar;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumVar;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumVar;
-      case NPY_INT:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumVar;
+      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumVar;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumVar;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumVar;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumVar;
-      case NPY_UINT: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumVar;
+      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumVar;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumVar;
@@ -2345,13 +2345,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanVar;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanVar;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanVar;
-      case NPY_INT:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanVar;
+      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanVar;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanVar;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanVar;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanVar;
-      case NPY_UINT: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanVar;
+      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanVar;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanVar;
@@ -2367,13 +2367,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumStd;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumStd;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumStd;
-      case NPY_INT:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumStd;
+      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumStd;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumStd;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumStd;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumStd;
-      case NPY_UINT: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumStd;
+      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumStd;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumStd;
@@ -2390,13 +2390,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanStd;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanStd;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanStd;
-      case NPY_INT:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanStd;
+      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanStd;
       case NPY_INT64:
       case NPY_LONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanStd;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanStd;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanStd;
-      case NPY_UINT: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanStd;
+      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanStd;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanStd;
@@ -2419,12 +2419,12 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
 //      //   case NPY_BYTE:   return GroupByBase<T, int8_t>::GetFunc(func);
 //      //   case NPY_INT16:  return GroupByBase<T, int16_t>::GetFunc(func);
 //   case NPY_INT:    return GroupByBase<T, int32_t>::GetXFunc(func);
-//   case NPY_INT:  return GroupByBase<T, int32_t>::GetXFunc(func);
+//   case NPY_INT32:  return GroupByBase<T, int32_t>::GetXFunc(func);
 //   case NPY_INT64:  return GroupByBase<T, int64_t>::GetXFunc(func);
 //      //   case NPY_UBYTE:  return GroupByBase<T, uint8_t>::GetFunc(func);
 //      //   case NPY_UINT16: return GroupByBase<T, uint16_t>::GetFunc(func);
 //   case NPY_UINT:   return GroupByBase<T, uint32_t>::GetXFunc(func);
-//   case NPY_UINT: return GroupByBase<T, uint32_t>::GetXFunc(func);
+//   case NPY_UINT32: return GroupByBase<T, uint32_t>::GetXFunc(func);
 //   case NPY_UINT64: return GroupByBase<T, uint64_t>::GetXFunc(func);
 //   }
 //   return NULL;
@@ -2443,13 +2443,13 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_LONGDOUBLE: return GroupByBase<long double, double, V>::AccumTrimMeanBR;
       case NPY_INT8:   return GroupByBase<int8_t, double, V>::AccumTrimMeanBR;
       case NPY_INT16:  return GroupByBase<int16_t, double, V>::AccumTrimMeanBR;
-      case NPY_INT:  return GroupByBase<int32_t, double, V>::AccumTrimMeanBR;
+      case NPY_INT32:  return GroupByBase<int32_t, double, V>::AccumTrimMeanBR;
       case NPY_INT64:
       case NPY_LONGLONG:
          return GroupByBase<int64_t, double, V>::AccumTrimMeanBR;
       case NPY_UINT8:  return GroupByBase<uint8_t, double, V>::AccumTrimMeanBR;
       case NPY_UINT16: return GroupByBase<uint16_t, double, V>::AccumTrimMeanBR;
-      case NPY_UINT: return GroupByBase<uint32_t, double, V>::AccumTrimMeanBR;
+      case NPY_UINT32: return GroupByBase<uint32_t, double, V>::AccumTrimMeanBR;
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GroupByBase<uint64_t, double, V>::AccumTrimMeanBR;
@@ -2460,7 +2460,7 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       switch (inputType) {
       case NPY_INT8:   return GroupByBase<int8_t, int32_t, V>::GetXFunc2(func);
       case NPY_INT16:  return GroupByBase<int16_t, int32_t, V>::GetXFunc2(func);
-      case NPY_INT:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
+      case NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
       case NPY_INT64:
       case NPY_LONGLONG:
          return GroupByBase<int64_t, int32_t, V>::GetXFunc2(func);
@@ -2477,13 +2477,13 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc2(func);
       case NPY_INT8:   return GroupByBase<int8_t, int8_t, V>::GetXFunc2(func);
       case NPY_INT16:  return GroupByBase<int16_t, int16_t, V>::GetXFunc2(func);
-      case NPY_INT:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
+      case NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
       case NPY_INT64:
       case NPY_LONGLONG:
          return GroupByBase<int64_t, int64_t, V>::GetXFunc2(func);
       case NPY_UINT8:  return GroupByBase<uint8_t, uint8_t, V>::GetXFunc2(func);
       case NPY_UINT16: return GroupByBase<uint16_t, uint16_t, V>::GetXFunc2(func);
-      case NPY_UINT: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc2(func);
+      case NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc2(func);
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GroupByBase<uint64_t, uint64_t, V>::GetXFunc2(func);
@@ -2501,13 +2501,13 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
          case NPY_LONGDOUBLE: return GroupByBase<long double, double, V>::GetXFunc2(func);
          case NPY_INT8:   return GroupByBase<int8_t, double, V>::GetXFunc2(func);
          case NPY_INT16:  return GroupByBase<int16_t, double, V>::GetXFunc2(func);
-         case NPY_INT:  return GroupByBase<int32_t, double, V>::GetXFunc2(func);
+         case NPY_INT32:  return GroupByBase<int32_t, double, V>::GetXFunc2(func);
          case NPY_INT64:
          case NPY_LONGLONG:
             return GroupByBase<int64_t, double, V>::GetXFunc2(func); 
          case NPY_UINT8:  return GroupByBase<uint8_t, double, V>::GetXFunc2(func);
          case NPY_UINT16: return GroupByBase<uint16_t, double, V>::GetXFunc2(func);
-         case NPY_UINT: return GroupByBase<uint32_t, double, V>::GetXFunc2(func);
+         case NPY_UINT32: return GroupByBase<uint32_t, double, V>::GetXFunc2(func);
          case NPY_UINT64:
          case NPY_ULONGLONG:
             return GroupByBase<uint64_t, double, V>::GetXFunc2(func);
@@ -2526,13 +2526,13 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
          case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc2(func);
          case NPY_INT8:   return GroupByBase<int8_t, int64_t, V>::GetXFunc2(func);
          case NPY_INT16:  return GroupByBase<int16_t, int64_t, V>::GetXFunc2(func);
-         case NPY_INT:  return GroupByBase<int32_t, int64_t, V>::GetXFunc2(func);
+         case NPY_INT32:  return GroupByBase<int32_t, int64_t, V>::GetXFunc2(func);
          case NPY_INT64:
          case NPY_LONGLONG:
             return GroupByBase<int64_t, int64_t, V>::GetXFunc2(func);
          case NPY_UINT8:  return GroupByBase<uint8_t, int64_t, V>::GetXFunc2(func);
          case NPY_UINT16: return GroupByBase<uint16_t, int64_t, V>::GetXFunc2(func);
-         case NPY_UINT: return GroupByBase<uint32_t, int64_t, V>::GetXFunc2(func);
+         case NPY_UINT32: return GroupByBase<uint32_t, int64_t, V>::GetXFunc2(func);
          case NPY_UINT64:
          case NPY_ULONGLONG:
             return GroupByBase<uint64_t, int64_t, V>::GetXFunc2(func);
@@ -2549,13 +2549,13 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc(func);
       case NPY_INT8:   return GroupByBase<int8_t, int8_t, V>::GetXFunc(func);
       case NPY_INT16:  return GroupByBase<int16_t, int16_t, V>::GetXFunc(func);
-      case NPY_INT:  return GroupByBase<int32_t, int32_t, V>::GetXFunc(func);
+      case NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc(func);
       case NPY_INT64:
       case NPY_LONGLONG:
          return GroupByBase<int64_t, int64_t, V>::GetXFunc(func);
       case NPY_UINT8:  return GroupByBase<uint8_t, uint8_t, V>::GetXFunc(func);
       case NPY_UINT16: return GroupByBase<uint16_t, uint16_t, V>::GetXFunc(func);
-      case NPY_UINT: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc(func);
+      case NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc(func);
       case NPY_UINT64:
       case NPY_ULONGLONG:
          return GroupByBase<uint64_t, uint64_t, V>::GetXFunc(func);
@@ -2810,7 +2810,7 @@ GROUPBY_TWO_FUNC GetGroupByFunctionStep1(int32_t iKeyType, bool* hasCounts, int3
    case NPY_INT16:
       pFunction = GetGroupByFunction<int16_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
-   case NPY_INT:
+   case NPY_INT32:
       pFunction = GetGroupByFunction<int32_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
    case NPY_INT64:
@@ -2857,7 +2857,7 @@ GroupBySingleOpMultiBands(
    case NPY_INT16:
       pFunction = GetGroupByXFunction32<int16_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
-   case NPY_INT:
+   case NPY_INT32:
       pFunction = GetGroupByXFunction32<int32_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
    case NPY_INT64:
@@ -3192,7 +3192,7 @@ GroupByAll32(PyObject *self, PyObject *args)
    switch (iKeyType) {
    case NPY_INT8:
    case NPY_INT16:
-   case NPY_INT:
+   case NPY_INT32:
    case NPY_INT64:
    case NPY_LONGLONG:
       break;
@@ -3438,7 +3438,7 @@ GroupByAllPack32(PyObject *self, PyObject *args)
    switch (iKeyType) {
    case NPY_INT8:
    case NPY_INT16:
-   case NPY_INT:
+   case NPY_INT32:
    case NPY_INT64:
    case NPY_LONGLONG:
       break;
@@ -3558,7 +3558,7 @@ GroupByAllPack32(PyObject *self, PyObject *args)
          case NPY_INT16:
             pFunction = GetGroupByXFunction32<int16_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
-         case NPY_INT:
+         case NPY_INT32:
             pFunction = GetGroupByXFunction32<int32_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
          case NPY_INT64:
@@ -3594,7 +3594,7 @@ GroupByAllPack32(PyObject *self, PyObject *args)
                      numpyOutType = NPY_INT64;
 
                      if (funcNum == GB_ROLLING_COUNT) {
-                        numpyOutType = NPY_INT;
+                        numpyOutType = NPY_INT32;
                      }
                      else {
 

--- a/src/GroupBy.cpp
+++ b/src/GroupBy.cpp
@@ -2042,14 +2042,14 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: return GatherSum<long double>;
       case NPY_INT8:  return GatherSum<int64_t>;
       case NPY_INT16: return GatherSum<int64_t>;
-      case NPY_INT32: return GatherSum<int64_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG: return GatherSum<int64_t>;
+      CASE_NPY_INT32: return GatherSum<int64_t>;
+      CASE_NPY_INT64:
+       return GatherSum<int64_t>;
       case NPY_UINT8: return GatherSum<uint64_t>;
       case NPY_UINT16:return GatherSum<uint64_t>;
-      case NPY_UINT32:return GatherSum<uint64_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32:return GatherSum<uint64_t>;
+      CASE_NPY_UINT64:
+      
          return GatherSum<uint64_t>;
       }
       break;
@@ -2064,14 +2064,14 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: 
       case NPY_INT8:  
       case NPY_INT16: 
-      case NPY_INT32: 
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32: 
+      CASE_NPY_INT64:
+      
       case NPY_UINT8: 
       case NPY_UINT16:
-      case NPY_UINT32:
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32:
+      CASE_NPY_UINT64:
+      
          return GatherMean<double>;
       }
       break;
@@ -2085,15 +2085,15 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: return GatherMaxFloat<long double>;
       case NPY_INT8:  return GatherMax<int8_t>;
       case NPY_INT16: return GatherMax<int16_t>;
-      case NPY_INT32: return GatherMax<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32: return GatherMax<int32_t>;
+      CASE_NPY_INT64:
+      
          return GatherMax<int64_t>;
       case NPY_UINT8: return GatherMax<uint8_t>;
       case NPY_UINT16:return GatherMax<uint16_t>;
-      case NPY_UINT32:return GatherMax<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32:return GatherMax<uint32_t>;
+      CASE_NPY_UINT64:
+      
          return GatherMax<uint64_t>;
       }
       break;
@@ -2107,15 +2107,15 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
       case NPY_LONGDOUBLE: return GatherMinFloat<long double>;
       case NPY_INT8:  return GatherMin<int8_t>;
       case NPY_INT16: return GatherMin<int16_t>;
-      case NPY_INT32: return GatherMin<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32: return GatherMin<int32_t>;
+      CASE_NPY_INT64:
+      
          return GatherMin<int64_t>;
       case NPY_UINT8: return GatherMin<uint8_t>;
       case NPY_UINT16:return GatherMin<uint16_t>;
-      case NPY_UINT32:return GatherMin<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32:return GatherMin<uint32_t>;
+      CASE_NPY_UINT64:
+      
          return GatherMin<uint64_t>;
       }
       break;
@@ -2143,15 +2143,15 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumSum;
       case NPY_INT8:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t,    int64_t,  V>::AccumSum;
       case NPY_INT16:  *wantedOutputType = NPY_INT64; return GroupByBase<int16_t,   int64_t,  V>::AccumSum;
-      case NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t,   int64_t,  V>::AccumSum;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t,   int64_t,  V>::AccumSum;
+      CASE_NPY_INT64:
+      
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t,   int64_t,  V>::AccumSum;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT64; return GroupByBase<uint8_t,  uint64_t, V>::AccumSum;
       case NPY_UINT16: *wantedOutputType = NPY_UINT64; return GroupByBase<uint16_t, uint64_t, V>::AccumSum;
-      case NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumSum;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumSum;
+      CASE_NPY_UINT64:
+      
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumSum;
       default:break;
       }
@@ -2165,15 +2165,15 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_BOOL:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t, int64_t, V>::AccumSum;
       case NPY_INT8:   *wantedOutputType = NPY_INT64; return GroupByBase<int8_t, int64_t, V>::AccumNanSum;
       case NPY_INT16:  *wantedOutputType = NPY_INT64; return GroupByBase<int16_t, int64_t, V>::AccumNanSum;
-      case NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t, int64_t, V>::AccumNanSum;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *wantedOutputType = NPY_INT64; return GroupByBase<int32_t, int64_t, V>::AccumNanSum;
+      CASE_NPY_INT64:
+      
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanSum;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT64; return GroupByBase<uint8_t, uint64_t, V>::AccumNanSum;
       case NPY_UINT16: *wantedOutputType = NPY_UINT64; return GroupByBase<uint16_t, uint64_t, V>::AccumNanSum;
-      case NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumNanSum;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT64; return GroupByBase<uint32_t, uint64_t, V>::AccumNanSum;
+      CASE_NPY_UINT64:
+      
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanSum;
       default:break;
       }
@@ -2187,15 +2187,15 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumMin;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t,     int8_t, V>::AccumMin;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t,   int16_t, V>::AccumMin;
-      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t,   int32_t, V>::AccumMin;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t,   int32_t, V>::AccumMin;
+      CASE_NPY_INT64:
+      
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t,   int64_t, V>::AccumMin;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t,   uint8_t, V>::AccumMin;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumMin;
-      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMin;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMin;
+      CASE_NPY_UINT64:
+      
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumMin;
       default:break;
       }
@@ -2209,15 +2209,15 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMin;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumNanMin;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumNanMin;
-      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMin;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMin;
+      CASE_NPY_INT64:
+      
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanMin;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumNanMin;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumNanMin;
-      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMin;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMin;
+      CASE_NPY_UINT64:
+      
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanMin;
       default:break;
       }
@@ -2231,15 +2231,15 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_LONGDOUBLE; return GroupByBase<long double, long double, V>::AccumMax;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumMax;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumMax;
-      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumMax;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumMax;
+      CASE_NPY_INT64:
+      
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumMax;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumMax;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumMax;
-      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMax;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumMax;
+      CASE_NPY_UINT64:
+      
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumMax;
       default:break;
       }
@@ -2254,15 +2254,15 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_BOOL:   *wantedOutputType = NPY_BOOL; return GroupByBase<int8_t, int8_t, V>::AccumMax;
       case NPY_INT8:   *wantedOutputType = NPY_INT8; return GroupByBase<int8_t, int8_t, V>::AccumNanMax;
       case NPY_INT16:  *wantedOutputType = NPY_INT16; return GroupByBase<int16_t, int16_t, V>::AccumNanMax;
-      case NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMax;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *wantedOutputType = NPY_INT32; return GroupByBase<int32_t, int32_t, V>::AccumNanMax;
+      CASE_NPY_INT64:
+      
          *wantedOutputType = NPY_INT64; return GroupByBase<int64_t, int64_t, V>::AccumNanMax;
       case NPY_UINT8:  *wantedOutputType = NPY_UINT8; return GroupByBase<uint8_t, uint8_t, V>::AccumNanMax;
       case NPY_UINT16: *wantedOutputType = NPY_UINT16; return GroupByBase<uint16_t, uint16_t, V>::AccumNanMax;
-      case NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMax;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *wantedOutputType = NPY_UINT32; return GroupByBase<uint32_t, uint32_t, V>::AccumNanMax;
+      CASE_NPY_UINT64:
+      
          *wantedOutputType = NPY_UINT64; return GroupByBase<uint64_t, uint64_t, V>::AccumNanMax;
       default:break;
       }
@@ -2276,15 +2276,15 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumMean;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t,     double, V>::AccumMean;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t,   double, V>::AccumMean;
-      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t,   double, V>::AccumMean;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t,   double, V>::AccumMean;
+      CASE_NPY_INT64:
+      
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t,   double, V>::AccumMean;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t,   double, V>::AccumMean;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumMean;
-      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumMean;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumMean;
+      CASE_NPY_UINT64:
+      
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumMean;
       default:break;
       }
@@ -2299,15 +2299,15 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanMean;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanMean;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanMean;
-      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanMean;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanMean;
+      CASE_NPY_INT64:
+      
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanMean;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanMean;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanMean;
-      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanMean;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanMean;
+      CASE_NPY_UINT64:
+      
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanMean;
       default:break;
       }
@@ -2322,15 +2322,15 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumVar;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumVar;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumVar;
-      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumVar;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumVar;
+      CASE_NPY_INT64:
+      
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumVar;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumVar;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumVar;
-      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumVar;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumVar;
+      CASE_NPY_UINT64:
+      
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumVar;
       default:break;
       }
@@ -2345,15 +2345,15 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanVar;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanVar;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanVar;
-      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanVar;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanVar;
+      CASE_NPY_INT64:
+      
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanVar;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanVar;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanVar;
-      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanVar;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanVar;
+      CASE_NPY_UINT64:
+      
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanVar;
       default:break;
       }
@@ -2367,15 +2367,15 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumStd;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumStd;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumStd;
-      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumStd;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumStd;
+      CASE_NPY_INT64:
+      
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumStd;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumStd;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumStd;
-      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumStd;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumStd;
+      CASE_NPY_UINT64:
+      
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumStd;
       default:break;
       }
@@ -2390,15 +2390,15 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
       case NPY_LONGDOUBLE: *wantedOutputType = NPY_DOUBLE; return GroupByBase<long double, double, V>::AccumNanStd;
       case NPY_INT8:   *wantedOutputType = NPY_DOUBLE; return GroupByBase<int8_t, double, V>::AccumNanStd;
       case NPY_INT16:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int16_t, double, V>::AccumNanStd;
-      case NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanStd;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<int32_t, double, V>::AccumNanStd;
+      CASE_NPY_INT64:
+      
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<int64_t, double, V>::AccumNanStd;
       case NPY_UINT8:  *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint8_t, double, V>::AccumNanStd;
       case NPY_UINT16: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint16_t, double, V>::AccumNanStd;
-      case NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanStd;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint32_t, double, V>::AccumNanStd;
+      CASE_NPY_UINT64:
+      
          *wantedOutputType = NPY_DOUBLE; return GroupByBase<uint64_t, double, V>::AccumNanStd;
       default:break;
       }
@@ -2419,13 +2419,13 @@ static GROUPBY_TWO_FUNC GetGroupByFunction(bool *hasCounts, int32_t *wantedOutpu
 //      //   case NPY_BYTE:   return GroupByBase<T, int8_t>::GetFunc(func);
 //      //   case NPY_INT16:  return GroupByBase<T, int16_t>::GetFunc(func);
 //   case NPY_INT:    return GroupByBase<T, int32_t>::GetXFunc(func);
-//   case NPY_INT32:  return GroupByBase<T, int32_t>::GetXFunc(func);
-//   case NPY_INT64:  return GroupByBase<T, int64_t>::GetXFunc(func);
+//   CASE_NPY_INT32:  return GroupByBase<T, int32_t>::GetXFunc(func);
+//   CASE_NPY_INT64:  return GroupByBase<T, int64_t>::GetXFunc(func);
 //      //   case NPY_UBYTE:  return GroupByBase<T, uint8_t>::GetFunc(func);
 //      //   case NPY_UINT16: return GroupByBase<T, uint16_t>::GetFunc(func);
 //   case NPY_UINT:   return GroupByBase<T, uint32_t>::GetXFunc(func);
-//   case NPY_UINT32: return GroupByBase<T, uint32_t>::GetXFunc(func);
-//   case NPY_UINT64: return GroupByBase<T, uint64_t>::GetXFunc(func);
+//   CASE_NPY_UINT32: return GroupByBase<T, uint32_t>::GetXFunc(func);
+//   CASE_NPY_UINT64: return GroupByBase<T, uint64_t>::GetXFunc(func);
 //   }
 //   return NULL;
 //
@@ -2443,15 +2443,15 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_LONGDOUBLE: return GroupByBase<long double, double, V>::AccumTrimMeanBR;
       case NPY_INT8:   return GroupByBase<int8_t, double, V>::AccumTrimMeanBR;
       case NPY_INT16:  return GroupByBase<int16_t, double, V>::AccumTrimMeanBR;
-      case NPY_INT32:  return GroupByBase<int32_t, double, V>::AccumTrimMeanBR;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return GroupByBase<int32_t, double, V>::AccumTrimMeanBR;
+      CASE_NPY_INT64:
+      
          return GroupByBase<int64_t, double, V>::AccumTrimMeanBR;
       case NPY_UINT8:  return GroupByBase<uint8_t, double, V>::AccumTrimMeanBR;
       case NPY_UINT16: return GroupByBase<uint16_t, double, V>::AccumTrimMeanBR;
-      case NPY_UINT32: return GroupByBase<uint32_t, double, V>::AccumTrimMeanBR;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return GroupByBase<uint32_t, double, V>::AccumTrimMeanBR;
+      CASE_NPY_UINT64:
+      
          return GroupByBase<uint64_t, double, V>::AccumTrimMeanBR;
       }
       return NULL;
@@ -2460,9 +2460,9 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       switch (inputType) {
       case NPY_INT8:   return GroupByBase<int8_t, int32_t, V>::GetXFunc2(func);
       case NPY_INT16:  return GroupByBase<int16_t, int32_t, V>::GetXFunc2(func);
-      case NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
+      CASE_NPY_INT64:
+      
          return GroupByBase<int64_t, int32_t, V>::GetXFunc2(func);
       }
       return NULL;
@@ -2477,15 +2477,15 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc2(func);
       case NPY_INT8:   return GroupByBase<int8_t, int8_t, V>::GetXFunc2(func);
       case NPY_INT16:  return GroupByBase<int16_t, int16_t, V>::GetXFunc2(func);
-      case NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc2(func);
+      CASE_NPY_INT64:
+      
          return GroupByBase<int64_t, int64_t, V>::GetXFunc2(func);
       case NPY_UINT8:  return GroupByBase<uint8_t, uint8_t, V>::GetXFunc2(func);
       case NPY_UINT16: return GroupByBase<uint16_t, uint16_t, V>::GetXFunc2(func);
-      case NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc2(func);
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc2(func);
+      CASE_NPY_UINT64:
+      
          return GroupByBase<uint64_t, uint64_t, V>::GetXFunc2(func);
       }
       return NULL;
@@ -2501,15 +2501,15 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
          case NPY_LONGDOUBLE: return GroupByBase<long double, double, V>::GetXFunc2(func);
          case NPY_INT8:   return GroupByBase<int8_t, double, V>::GetXFunc2(func);
          case NPY_INT16:  return GroupByBase<int16_t, double, V>::GetXFunc2(func);
-         case NPY_INT32:  return GroupByBase<int32_t, double, V>::GetXFunc2(func);
-         case NPY_INT64:
-         case NPY_LONGLONG:
+         CASE_NPY_INT32:  return GroupByBase<int32_t, double, V>::GetXFunc2(func);
+         CASE_NPY_INT64:
+         
             return GroupByBase<int64_t, double, V>::GetXFunc2(func); 
          case NPY_UINT8:  return GroupByBase<uint8_t, double, V>::GetXFunc2(func);
          case NPY_UINT16: return GroupByBase<uint16_t, double, V>::GetXFunc2(func);
-         case NPY_UINT32: return GroupByBase<uint32_t, double, V>::GetXFunc2(func);
-         case NPY_UINT64:
-         case NPY_ULONGLONG:
+         CASE_NPY_UINT32: return GroupByBase<uint32_t, double, V>::GetXFunc2(func);
+         CASE_NPY_UINT64:
+         
             return GroupByBase<uint64_t, double, V>::GetXFunc2(func);
          }
          return NULL;
@@ -2526,15 +2526,15 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
          case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc2(func);
          case NPY_INT8:   return GroupByBase<int8_t, int64_t, V>::GetXFunc2(func);
          case NPY_INT16:  return GroupByBase<int16_t, int64_t, V>::GetXFunc2(func);
-         case NPY_INT32:  return GroupByBase<int32_t, int64_t, V>::GetXFunc2(func);
-         case NPY_INT64:
-         case NPY_LONGLONG:
+         CASE_NPY_INT32:  return GroupByBase<int32_t, int64_t, V>::GetXFunc2(func);
+         CASE_NPY_INT64:
+         
             return GroupByBase<int64_t, int64_t, V>::GetXFunc2(func);
          case NPY_UINT8:  return GroupByBase<uint8_t, int64_t, V>::GetXFunc2(func);
          case NPY_UINT16: return GroupByBase<uint16_t, int64_t, V>::GetXFunc2(func);
-         case NPY_UINT32: return GroupByBase<uint32_t, int64_t, V>::GetXFunc2(func);
-         case NPY_UINT64:
-         case NPY_ULONGLONG:
+         CASE_NPY_UINT32: return GroupByBase<uint32_t, int64_t, V>::GetXFunc2(func);
+         CASE_NPY_UINT64:
+         
             return GroupByBase<uint64_t, int64_t, V>::GetXFunc2(func);
          }
       }
@@ -2549,15 +2549,15 @@ static GROUPBY_X_FUNC32 GetGroupByXFunction32(int inputType, int outputType, GB_
       case NPY_LONGDOUBLE: return GroupByBase<long double, long double, V>::GetXFunc(func);
       case NPY_INT8:   return GroupByBase<int8_t, int8_t, V>::GetXFunc(func);
       case NPY_INT16:  return GroupByBase<int16_t, int16_t, V>::GetXFunc(func);
-      case NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc(func);
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return GroupByBase<int32_t, int32_t, V>::GetXFunc(func);
+      CASE_NPY_INT64:
+      
          return GroupByBase<int64_t, int64_t, V>::GetXFunc(func);
       case NPY_UINT8:  return GroupByBase<uint8_t, uint8_t, V>::GetXFunc(func);
       case NPY_UINT16: return GroupByBase<uint16_t, uint16_t, V>::GetXFunc(func);
-      case NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc(func);
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return GroupByBase<uint32_t, uint32_t, V>::GetXFunc(func);
+      CASE_NPY_UINT64:
+      
          return GroupByBase<uint64_t, uint64_t, V>::GetXFunc(func);
       case NPY_STRING:
          return GroupByBase<char, char, V>::GetXFuncString(func);
@@ -2810,11 +2810,11 @@ GROUPBY_TWO_FUNC GetGroupByFunctionStep1(int32_t iKeyType, bool* hasCounts, int3
    case NPY_INT16:
       pFunction = GetGroupByFunction<int16_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
-   case NPY_INT32:
+   CASE_NPY_INT32:
       pFunction = GetGroupByFunction<int32_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       pFunction = GetGroupByFunction<int64_t>(hasCounts, numpyOutType, numpyInType, funcNum);
       break;
    }
@@ -2857,11 +2857,11 @@ GroupBySingleOpMultiBands(
    case NPY_INT16:
       pFunction = GetGroupByXFunction32<int16_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
-   case NPY_INT32:
+   CASE_NPY_INT32:
       pFunction = GetGroupByXFunction32<int32_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       pFunction = GetGroupByXFunction32<int64_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)firstFuncNum);
       break;
    }
@@ -3192,9 +3192,9 @@ GroupByAll32(PyObject *self, PyObject *args)
    switch (iKeyType) {
    case NPY_INT8:
    case NPY_INT16:
-   case NPY_INT32:
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:
+   CASE_NPY_INT64:
+   
       break;
    default:
       PyErr_Format(PyExc_ValueError, "GroupByAll32 key param must be int8, int16, int32, int64 not type %d", iKeyType);
@@ -3438,9 +3438,9 @@ GroupByAllPack32(PyObject *self, PyObject *args)
    switch (iKeyType) {
    case NPY_INT8:
    case NPY_INT16:
-   case NPY_INT32:
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:
+   CASE_NPY_INT64:
+   
       break;
    default:
       PyErr_Format(PyExc_ValueError, "GroupByAllPack32 key param must int8, int16, int32, int64");
@@ -3558,11 +3558,11 @@ GroupByAllPack32(PyObject *self, PyObject *args)
          case NPY_INT16:
             pFunction = GetGroupByXFunction32<int16_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
-         case NPY_INT32:
+         CASE_NPY_INT32:
             pFunction = GetGroupByXFunction32<int32_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
-         case NPY_INT64:
-         case NPY_LONGLONG:
+         CASE_NPY_INT64:
+         
             pFunction = GetGroupByXFunction32<int64_t>(numpyOutType, numpyOutType, (GB_FUNCTIONS)funcNum);
             break;
          }
@@ -3606,8 +3606,8 @@ GroupByAllPack32(PyObject *self, PyObject *args)
                         case NPY_LONGDOUBLE:
                            numpyOutType = NPY_FLOAT64;
                            break;
-                        case NPY_UINT64:
-                        case NPY_ULONGLONG:
+                        CASE_NPY_UINT64:
+                        
                            numpyOutType = NPY_UINT64;
                            break;
                         }

--- a/src/GroupBy.h
+++ b/src/GroupBy.h
@@ -20,19 +20,19 @@ struct stGroupByReturn {
 
    union {
       PyArrayObject*    outArray;
-      INT64             didWork;
+      int64_t             didWork;
    };
 
    // for multithreaded sum this is set
    void*             pOutArray;
 
-   INT32*            pCountOut;
+   int32_t*            pCountOut;
 
-   INT32             numpyOutType;
-   INT32             funcNum;
+   int32_t             numpyOutType;
+   int32_t             funcNum;
 
-   INT64             binLow;
-   INT64             binHigh;
+   int64_t             binLow;
+   int64_t             binHigh;
 
    union {
       GROUPBY_TWO_FUNC  pFunction;
@@ -47,18 +47,18 @@ struct stGroupByReturn {
 struct stGroupBy32 {
 
    ArrayInfo* aInfo;
-   INT64    tupleSize;
- /*  INT32    numpyOutType;
-   INT32    reserved;
+   int64_t    tupleSize;
+ /*  int32_t    numpyOutType;
+   int32_t    reserved;
  */  
    void*    pDataIn2;
-   INT64    itemSize2;
+   int64_t    itemSize2;
 
-   INT64    uniqueRows;
-   INT64    totalInputRows;
+   int64_t    uniqueRows;
+   int64_t    totalInputRows;
 
    TYPE_OF_FUNCTION_CALL   typeOfFunctionCall;
-   INT64    funcParam;
+   int64_t    funcParam;
    void*    pKey;
    void*    pGroup;
    void*    pFirst;

--- a/src/HashFunctions.cpp
+++ b/src/HashFunctions.cpp
@@ -155,11 +155,11 @@ IsMemberCategorical(PyObject *self, PyObject *args)
    LOGGING("IsMember32 %s vs %s   size: %d  %d\n", NpyToString(arrayType1), NpyToString(arrayType2), sizeType1, sizeType2);
 
    switch (arrayType1) {
-   case NPY_INT:
-      arrayType1 = NPY_INT;
+   case NPY_INT32:
+      arrayType1 = NPY_INT32;
       break;
-   case NPY_UINT:
-      arrayType1 = NPY_UINT;
+   case NPY_UINT32:
+      arrayType1 = NPY_UINT32;
       break;
    case NPY_INT64:
    case NPY_LONGLONG:
@@ -172,11 +172,11 @@ IsMemberCategorical(PyObject *self, PyObject *args)
    }
 
    switch (arrayType2) {
-   case NPY_INT:
-      arrayType2 = NPY_INT;
+   case NPY_INT32:
+      arrayType2 = NPY_INT32;
       break;
-   case NPY_UINT:
-      arrayType2 = NPY_UINT;
+   case NPY_UINT32:
+      arrayType2 = NPY_UINT32;
       break;
    case NPY_INT64:
    case NPY_LONGLONG:
@@ -227,7 +227,7 @@ IsMemberCategorical(PyObject *self, PyObject *args)
 
       LOGGING("Calling float!\n");
       if (arraySize1 < 2100000000) {
-         indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT);
+         indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
          int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(indexArray);
          missed = IsMemberHashCategorical(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1 + 100, HASH_MODE(hashMode), hintSize);
       }
@@ -241,7 +241,7 @@ IsMemberCategorical(PyObject *self, PyObject *args)
    else {
       LOGGING("Calling hash!\n");
       if (arraySize1 < 2100000000) {
-         indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT);
+         indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
          int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(indexArray);
          missed = IsMemberHashCategorical(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1, HASH_MODE(hashMode), hintSize);
       }
@@ -279,7 +279,7 @@ void FindFirstOccurence(T* pArray2, int32_t* pUnique1, int32_t* pReIndex, int32_
    T baseOffset2 = (T)baseOffset2T;
 
    // Put invalid as default
-   const int32_t invalid = *(int32_t*)GetDefaultForType(NPY_INT);
+   const int32_t invalid = *(int32_t*)GetDefaultForType(NPY_INT32);
    for (int32_t i = 0; i < unique1Length; i++) {
       pReIndex[i] = invalid;
    }
@@ -351,7 +351,7 @@ void FindFirstOccurence(T* pArray2, int32_t* pUnique1, int32_t* pReIndex, int32_
 template<typename T>
 void FinalMatch(T* pArray1, int32_t* pOutput, int8_t* pBoolOutput, int32_t* pReIndex, int32_t array1Length, int32_t baseoffset) {
 
-   const int32_t invalid = *(int32_t*)GetDefaultForType(NPY_INT);
+   const int32_t invalid = *(int32_t*)GetDefaultForType(NPY_INT32);
 
    // TODO: Multithreadable
    // Find first occurence of values in pUnique
@@ -414,7 +414,7 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
    int32_t array1Type = PyArray_TYPE(inArr1);
 
    switch (uniqueType) {
-   case NPY_INT:
+   case NPY_INT32:
       break;
    default:
       PyErr_Format(PyExc_ValueError, "IsMemberCategoricalFixup third argument must be type int32_t not %s", NpyToString(uniqueType));
@@ -427,7 +427,7 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
    int32_t* reIndexArray = (int32_t*)WORKSPACE_ALLOC(arraySizeUnique * sizeof(int32_t));
    int32_t* reverseMapArray = (int32_t*)WORKSPACE_ALLOC(unique2Length * sizeof(int32_t));
 
-   PyArrayObject* indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT);
+   PyArrayObject* indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
    PyArrayObject* boolArray = AllocateLikeNumpyArray(inArr1, NPY_BOOL);
 
    if (reIndexArray && indexArray && boolArray) {
@@ -442,7 +442,7 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
       case NPY_INT16:
          FindFirstOccurence<int16_t>((int16_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
-      case NPY_INT:
+      case NPY_INT32:
          FindFirstOccurence<int32_t>((int32_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
       case NPY_INT64:
@@ -465,7 +465,7 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
       case NPY_INT16:
          FinalMatch<int16_t>((int16_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
-      case NPY_INT:
+      case NPY_INT32:
          FinalMatch<int32_t>((int32_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
       case NPY_INT64:

--- a/src/HashFunctions.cpp
+++ b/src/HashFunctions.cpp
@@ -155,31 +155,35 @@ IsMemberCategorical(PyObject *self, PyObject *args)
    LOGGING("IsMember32 %s vs %s   size: %d  %d\n", NpyToString(arrayType1), NpyToString(arrayType2), sizeType1, sizeType2);
 
    switch (arrayType1) {
-   CASE_NPY_INT32:
+   case NPY_INT32:
       arrayType1 = NPY_INT32;
       break;
-   CASE_NPY_UINT32:
+   case NPY_UINT32:
       arrayType1 = NPY_UINT32;
       break;
-   CASE_NPY_INT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       arrayType1 = NPY_INT64;
       break;
-   CASE_NPY_UINT64:
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
       arrayType1 = NPY_UINT64;
       break;
    }
 
    switch (arrayType2) {
-   CASE_NPY_INT32:
+   case NPY_INT32:
       arrayType2 = NPY_INT32;
       break;
-   CASE_NPY_UINT32:
+   case NPY_UINT32:
       arrayType2 = NPY_UINT32;
       break;
-   CASE_NPY_INT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       arrayType2 = NPY_INT64;
       break;
-   CASE_NPY_UINT64:
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
       arrayType2 = NPY_UINT64;
       break;
    }
@@ -410,7 +414,7 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
    int32_t array1Type = PyArray_TYPE(inArr1);
 
    switch (uniqueType) {
-   CASE_NPY_INT32:
+   case NPY_INT32:
       break;
    default:
       PyErr_Format(PyExc_ValueError, "IsMemberCategoricalFixup third argument must be type int32_t not %s", NpyToString(uniqueType));
@@ -438,10 +442,11 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
       case NPY_INT16:
          FindFirstOccurence<int16_t>((int16_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
-      CASE_NPY_INT32:
+      case NPY_INT32:
          FindFirstOccurence<int32_t>((int32_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
-      CASE_NPY_INT64:
+      case NPY_INT64:
+      case NPY_LONGLONG:
          FindFirstOccurence<int64_t>((int64_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
       default:
@@ -460,10 +465,11 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
       case NPY_INT16:
          FinalMatch<int16_t>((int16_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
-      CASE_NPY_INT32:
+      case NPY_INT32:
          FinalMatch<int32_t>((int32_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
-      CASE_NPY_INT64:
+      case NPY_INT64:
+      case NPY_LONGLONG:
          FinalMatch<int64_t>((int64_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
       default:

--- a/src/HashFunctions.cpp
+++ b/src/HashFunctions.cpp
@@ -35,19 +35,19 @@
 //    First arg: existing  numpy array
 //    Second arg: existing  numpy array
 //    Third arg: hashmode (1 or 2)
-//    Returns: boolean array and optional INT64 location array
+//    Returns: boolean array and optional int64_t location array
 PyObject *
 IsMember64(PyObject *self, PyObject *args)
 {
    PyArrayObject *inArr1 = NULL;
    PyArrayObject *inArr2 = NULL;
    int hashMode;
-   INT64 hintSize = 0;
+   int64_t hintSize = 0;
 
    if (!PyArg_ParseTuple(args, "O!O!i", &PyArray_Type, &inArr1, &PyArray_Type, &inArr2, &hashMode)) return NULL;
 
-   INT32 arrayType1 = PyArray_TYPE(inArr1);
-   INT32 arrayType2 = PyArray_TYPE(inArr2);
+   int32_t arrayType1 = PyArray_TYPE(inArr1);
+   int32_t arrayType2 = PyArray_TYPE(inArr2);
 
    int sizeType1 = (int)NpyItemSize((PyObject*)inArr1);
    int sizeType2 = (int)NpyItemSize((PyObject*)inArr2);
@@ -77,8 +77,8 @@ IsMember64(PyObject *self, PyObject *args)
    int ndim2 = PyArray_NDIM(inArr2);
    npy_intp* dims2 = PyArray_DIMS(inArr2);
 
-   INT64 arraySize1 = CalcArrayLength(ndim, dims);
-   INT64 arraySize2 = CalcArrayLength(ndim2, dims2);
+   int64_t arraySize1 = CalcArrayLength(ndim, dims);
+   int64_t arraySize2 = CalcArrayLength(ndim2, dims2);
 
    PyArrayObject* boolArray = AllocateNumpyArray(ndim, dims, NPY_BOOL);
    CHECK_MEMORY_ERROR(boolArray);
@@ -89,8 +89,8 @@ IsMember64(PyObject *self, PyObject *args)
    if (boolArray && indexArray) {
       void* pDataIn1 = PyArray_BYTES(inArr1);
       void* pDataIn2 = PyArray_BYTES(inArr2);
-      INT8* pDataOut1 = (INT8*)PyArray_BYTES(boolArray);
-      INT64* pDataOut2 = (INT64*)PyArray_BYTES(indexArray);
+      int8_t* pDataOut1 = (int8_t*)PyArray_BYTES(boolArray);
+      int64_t* pDataOut2 = (int64_t*)PyArray_BYTES(indexArray);
 
       //printf("Size array1: %llu   array2: %llu\n", arraySize1, arraySize2);
 
@@ -137,7 +137,7 @@ IsMemberCategorical(PyObject *self, PyObject *args)
    PyArrayObject *inArr1 = NULL;
    PyArrayObject *inArr2 = NULL;
    int hashMode=HASH_MODE_MASK;
-   INT64 hintSize=0;
+   int64_t hintSize=0;
 
    if (PyTuple_GET_SIZE(args) == 3) {
       if (!PyArg_ParseTuple(args, "O!O!i", &PyArray_Type, &inArr1, &PyArray_Type, &inArr2, &hashMode)) return NULL;
@@ -146,8 +146,8 @@ IsMemberCategorical(PyObject *self, PyObject *args)
       if (!PyArg_ParseTuple(args, "O!O!iL", &PyArray_Type, &inArr1, &PyArray_Type, &inArr2, &hashMode, &hintSize)) return NULL;
 
    }
-   INT32 arrayType1 = PyArray_TYPE(inArr1);
-   INT32 arrayType2 = PyArray_TYPE(inArr2);
+   int32_t arrayType1 = PyArray_TYPE(inArr1);
+   int32_t arrayType2 = PyArray_TYPE(inArr2);
 
    int sizeType1 = (int)NpyItemSize((PyObject*)inArr1);
    int sizeType2 = (int)NpyItemSize((PyObject*)inArr2);
@@ -202,8 +202,8 @@ IsMemberCategorical(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   INT64 arraySize1 = ArrayLength(inArr1);
-   INT64 arraySize2 = ArrayLength(inArr2);
+   int64_t arraySize1 = ArrayLength(inArr1);
+   int64_t arraySize2 = ArrayLength(inArr2);
 
    void* pDataIn1 = PyArray_BYTES(inArr1);
    void* pDataIn2 = PyArray_BYTES(inArr2);
@@ -212,7 +212,7 @@ IsMemberCategorical(PyObject *self, PyObject *args)
 
    LOGGING("Size array1: %llu   array2: %llu\n", arraySize1, arraySize2);
 
-   INT64 missed = 0;
+   int64_t missed = 0;
 
    if (arrayType1 >= NPY_STRING) {
       LOGGING("Calling string/uni/void!\n");
@@ -224,13 +224,13 @@ IsMemberCategorical(PyObject *self, PyObject *args)
       LOGGING("Calling float!\n");
       if (arraySize1 < 2100000000) {
          indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
-         INT32* pDataOut2 = (INT32*)PyArray_BYTES(indexArray);
+         int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(indexArray);
          missed = IsMemberHashCategorical(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1 + 100, HASH_MODE(hashMode), hintSize);
       }
       else {
 
          indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT64);
-         INT64* pDataOut2 = (INT64*)PyArray_BYTES(indexArray);
+         int64_t* pDataOut2 = (int64_t*)PyArray_BYTES(indexArray);
          missed = IsMemberHashCategorical64(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1 + 100, HASH_MODE(hashMode), hintSize);
       }
    }
@@ -238,12 +238,12 @@ IsMemberCategorical(PyObject *self, PyObject *args)
       LOGGING("Calling hash!\n");
       if (arraySize1 < 2100000000) {
          indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
-         INT32* pDataOut2 = (INT32*)PyArray_BYTES(indexArray);
+         int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(indexArray);
          missed = IsMemberHashCategorical(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1, HASH_MODE(hashMode), hintSize);
       }
       else {
          indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT64);
-         INT64* pDataOut2 = (INT64*)PyArray_BYTES(indexArray);
+         int64_t* pDataOut2 = (int64_t*)PyArray_BYTES(indexArray);
          missed = IsMemberHashCategorical64(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1, HASH_MODE(hashMode), hintSize);
       }
    }
@@ -270,24 +270,24 @@ IsMemberCategorical(PyObject *self, PyObject *args)
 //
 // final result 6 0 6 2 0 4 6 4 0
 template<typename T>
-void FindFirstOccurence(T* pArray2, INT32* pUnique1, INT32* pReIndex, INT32* pReverseMap, INT32 array2Length, INT32 unique1Length, INT32 unique2Length, INT32 baseOffset2T) {
+void FindFirstOccurence(T* pArray2, int32_t* pUnique1, int32_t* pReIndex, int32_t* pReverseMap, int32_t array2Length, int32_t unique1Length, int32_t unique2Length, int32_t baseOffset2T) {
 
    T baseOffset2 = (T)baseOffset2T;
 
    // Put invalid as default
-   const INT32 invalid = *(INT32*)GetDefaultForType(NPY_INT32);
-   for (INT32 i = 0; i < unique1Length; i++) {
+   const int32_t invalid = *(int32_t*)GetDefaultForType(NPY_INT32);
+   for (int32_t i = 0; i < unique1Length; i++) {
       pReIndex[i] = invalid;
    }
 
-   for (INT32 i = 0; i < unique2Length; i++) {
+   for (int32_t i = 0; i < unique2Length; i++) {
       pReverseMap[i] = -1;
    }
 
    // Make reverse map
-   INT32 matchedUniqueLength(0);
-   for (INT32 i = 0; i < unique1Length; i++) {
-      INT32 val = pUnique1[i];
+   int32_t matchedUniqueLength(0);
+   for (int32_t i = 0; i < unique1Length; i++) {
+      int32_t val = pUnique1[i];
       if (val >= 0 && val < unique2Length) {
          pReverseMap[val] = i;
          ++matchedUniqueLength;
@@ -295,14 +295,14 @@ void FindFirstOccurence(T* pArray2, INT32* pUnique1, INT32* pReIndex, INT32* pRe
    }
 
    // leave for debugging
-   //for (INT32 i = 0; i < unique2Length; i++) {
+   //for (int32_t i = 0; i < unique2Length; i++) {
    //   printf("rmap [%d] %d\n", i, pReverseMap[i]);
    //}
 
    // Find first occurence of values in pUnique
    // TODO: early stopping possible
    if (matchedUniqueLength > 0) {
-      for (INT32 i = 0; i < array2Length; i++) {
+      for (int32_t i = 0; i < array2Length; i++) {
          // N.B. The value can be the minimum integer, need to be checked first before offsetting by baseOffset2.
          T val = pArray2[i];
 
@@ -311,7 +311,7 @@ void FindFirstOccurence(T* pArray2, INT32* pUnique1, INT32* pReIndex, INT32* pRe
             val -= baseOffset2;
 
             // Check if the value in the second array is found in the first array
-            INT32 lookup = pReverseMap[val];
+            int32_t lookup = pReverseMap[val];
 
             if (lookup >= 0) {
                // Is this the first occurence?
@@ -329,7 +329,7 @@ void FindFirstOccurence(T* pArray2, INT32* pUnique1, INT32* pReIndex, INT32* pRe
    }
 
    // Leave for debugging
-   //for (INT32 i = 0; i < unique1Length; i++) {
+   //for (int32_t i = 0; i < unique1Length; i++) {
    //   printf("ridx [%d] %d\n", i, pReIndex[i]);
    //}
 
@@ -345,20 +345,20 @@ void FindFirstOccurence(T* pArray2, INT32* pUnique1, INT32* pReIndex, INT32* pRe
 // Returns: pOutput and pBoolOutput
 // TODO: this routine needs to output INT8/16/32/64 instead of just INT32
 template<typename T>
-void FinalMatch(T* pArray1, INT32* pOutput, INT8* pBoolOutput, INT32* pReIndex, INT32 array1Length, INT32 baseoffset) {
+void FinalMatch(T* pArray1, int32_t* pOutput, int8_t* pBoolOutput, int32_t* pReIndex, int32_t array1Length, int32_t baseoffset) {
 
-   const INT32 invalid = *(INT32*)GetDefaultForType(NPY_INT32);
+   const int32_t invalid = *(int32_t*)GetDefaultForType(NPY_INT32);
 
    // TODO: Multithreadable
    // Find first occurence of values in pUnique
-   for (INT64 i = 0; i < array1Length; i++) {
+   for (int64_t i = 0; i < array1Length; i++) {
       // N.B. The value can be the minimum integer, need to be checked first before offsetting by baseoffset.
       T val = pArray1[i];
 
       // Find first occurence
       if (val >= baseoffset) {
          val -= baseoffset;
-         const INT32 firstoccurence = pReIndex[val];
+         const int32_t firstoccurence = pReIndex[val];
          pOutput[i] = firstoccurence;
          pBoolOutput[i] = firstoccurence != invalid;
       }
@@ -389,9 +389,9 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
    PyArrayObject *inArr1 = NULL;
    PyArrayObject *inArr2 = NULL;
    PyArrayObject *isMemberUnique = NULL;
-   INT32 unique2Length;
-   INT32 baseoffset1;
-   INT32 baseoffset2;
+   int32_t unique2Length;
+   int32_t baseoffset1;
+   int32_t baseoffset2;
 
    if (!PyArg_ParseTuple(args, "O!O!O!iii",
       &PyArray_Type, &inArr1, 
@@ -401,48 +401,48 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
       &baseoffset1,
       &baseoffset2)) return NULL;
 
-   INT32 arraySize1 = (INT32)ArrayLength(inArr1);
-   INT32 arraySize2 = (INT32)ArrayLength(inArr2);
-   INT32 arraySizeUnique = (INT32)ArrayLength(isMemberUnique);
+   int32_t arraySize1 = (int32_t)ArrayLength(inArr1);
+   int32_t arraySize2 = (int32_t)ArrayLength(inArr2);
+   int32_t arraySizeUnique = (int32_t)ArrayLength(isMemberUnique);
 
-   INT32 uniqueType = PyArray_TYPE(isMemberUnique);
-   INT32 array2Type = PyArray_TYPE(inArr2);
-   INT32 array1Type = PyArray_TYPE(inArr1);
+   int32_t uniqueType = PyArray_TYPE(isMemberUnique);
+   int32_t array2Type = PyArray_TYPE(inArr2);
+   int32_t array1Type = PyArray_TYPE(inArr1);
 
    switch (uniqueType) {
    CASE_NPY_INT32:
       break;
    default:
-      PyErr_Format(PyExc_ValueError, "IsMemberCategoricalFixup third argument must be type INT32 not %s", NpyToString(uniqueType));
+      PyErr_Format(PyExc_ValueError, "IsMemberCategoricalFixup third argument must be type int32_t not %s", NpyToString(uniqueType));
       return NULL;
    }
 
    LOGGING("IsMemberCategoricalFixup uniqlength:%d   baseoffset1:%d   baseoffset2:%d\n", unique2Length, baseoffset1, baseoffset2);
 
    // need to reindex this array...
-   INT32* reIndexArray = (INT32*)WORKSPACE_ALLOC(arraySizeUnique * sizeof(INT32));
-   INT32* reverseMapArray = (INT32*)WORKSPACE_ALLOC(unique2Length * sizeof(INT32));
+   int32_t* reIndexArray = (int32_t*)WORKSPACE_ALLOC(arraySizeUnique * sizeof(int32_t));
+   int32_t* reverseMapArray = (int32_t*)WORKSPACE_ALLOC(unique2Length * sizeof(int32_t));
 
    PyArrayObject* indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
    PyArrayObject* boolArray = AllocateLikeNumpyArray(inArr1, NPY_BOOL);
 
    if (reIndexArray && indexArray && boolArray) {
 
-      INT32* pUnique = (INT32*)PyArray_BYTES(isMemberUnique);
+      int32_t* pUnique = (int32_t*)PyArray_BYTES(isMemberUnique);
       void*  pArray2 = PyArray_BYTES(inArr2);
 
       switch (array2Type) {
       case NPY_INT8:
-         FindFirstOccurence<INT8>((INT8*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
+         FindFirstOccurence<int8_t>((int8_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
       case NPY_INT16:
-         FindFirstOccurence<INT16>((INT16*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
+         FindFirstOccurence<int16_t>((int16_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
       CASE_NPY_INT32:
-         FindFirstOccurence<INT32>((INT32*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
+         FindFirstOccurence<int32_t>((int32_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
       CASE_NPY_INT64:
-         FindFirstOccurence<INT64>((INT64*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
+         FindFirstOccurence<int64_t>((int64_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
       default:
          PyErr_Format(PyExc_ValueError, "IsMemberCategoricalFixup second argument is not INT8/16/32/64");
@@ -450,21 +450,21 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
       }
 
       void*  pArray1 = PyArray_BYTES(inArr1);
-      INT32* pIndexOut = (INT32*)PyArray_BYTES(indexArray);
-      INT8* pBoolOut = (INT8*)PyArray_BYTES(boolArray);
+      int32_t* pIndexOut = (int32_t*)PyArray_BYTES(indexArray);
+      int8_t* pBoolOut = (int8_t*)PyArray_BYTES(boolArray);
 
       switch (array1Type) {
       case NPY_INT8:
-         FinalMatch<INT8>((INT8*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
+         FinalMatch<int8_t>((int8_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
       case NPY_INT16:
-         FinalMatch<INT16>((INT16*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
+         FinalMatch<int16_t>((int16_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
       CASE_NPY_INT32:
-         FinalMatch<INT32>((INT32*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
+         FinalMatch<int32_t>((int32_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
       CASE_NPY_INT64:
-         FinalMatch<INT64>((INT64*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
+         FinalMatch<int64_t>((int64_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
       default:
          PyErr_Format(PyExc_ValueError, "IsMemberCategoricalFixup first argument is not INT8/16/32/64");

--- a/src/HashFunctions.cpp
+++ b/src/HashFunctions.cpp
@@ -155,11 +155,11 @@ IsMemberCategorical(PyObject *self, PyObject *args)
    LOGGING("IsMember32 %s vs %s   size: %d  %d\n", NpyToString(arrayType1), NpyToString(arrayType2), sizeType1, sizeType2);
 
    switch (arrayType1) {
-   case NPY_INT32:
-      arrayType1 = NPY_INT32;
+   case NPY_INT:
+      arrayType1 = NPY_INT;
       break;
-   case NPY_UINT32:
-      arrayType1 = NPY_UINT32;
+   case NPY_UINT:
+      arrayType1 = NPY_UINT;
       break;
    case NPY_INT64:
    case NPY_LONGLONG:
@@ -172,11 +172,11 @@ IsMemberCategorical(PyObject *self, PyObject *args)
    }
 
    switch (arrayType2) {
-   case NPY_INT32:
-      arrayType2 = NPY_INT32;
+   case NPY_INT:
+      arrayType2 = NPY_INT;
       break;
-   case NPY_UINT32:
-      arrayType2 = NPY_UINT32;
+   case NPY_UINT:
+      arrayType2 = NPY_UINT;
       break;
    case NPY_INT64:
    case NPY_LONGLONG:
@@ -227,7 +227,7 @@ IsMemberCategorical(PyObject *self, PyObject *args)
 
       LOGGING("Calling float!\n");
       if (arraySize1 < 2100000000) {
-         indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
+         indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT);
          int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(indexArray);
          missed = IsMemberHashCategorical(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1 + 100, HASH_MODE(hashMode), hintSize);
       }
@@ -241,7 +241,7 @@ IsMemberCategorical(PyObject *self, PyObject *args)
    else {
       LOGGING("Calling hash!\n");
       if (arraySize1 < 2100000000) {
-         indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
+         indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT);
          int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(indexArray);
          missed = IsMemberHashCategorical(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1, HASH_MODE(hashMode), hintSize);
       }
@@ -279,7 +279,7 @@ void FindFirstOccurence(T* pArray2, int32_t* pUnique1, int32_t* pReIndex, int32_
    T baseOffset2 = (T)baseOffset2T;
 
    // Put invalid as default
-   const int32_t invalid = *(int32_t*)GetDefaultForType(NPY_INT32);
+   const int32_t invalid = *(int32_t*)GetDefaultForType(NPY_INT);
    for (int32_t i = 0; i < unique1Length; i++) {
       pReIndex[i] = invalid;
    }
@@ -351,7 +351,7 @@ void FindFirstOccurence(T* pArray2, int32_t* pUnique1, int32_t* pReIndex, int32_
 template<typename T>
 void FinalMatch(T* pArray1, int32_t* pOutput, int8_t* pBoolOutput, int32_t* pReIndex, int32_t array1Length, int32_t baseoffset) {
 
-   const int32_t invalid = *(int32_t*)GetDefaultForType(NPY_INT32);
+   const int32_t invalid = *(int32_t*)GetDefaultForType(NPY_INT);
 
    // TODO: Multithreadable
    // Find first occurence of values in pUnique
@@ -414,7 +414,7 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
    int32_t array1Type = PyArray_TYPE(inArr1);
 
    switch (uniqueType) {
-   case NPY_INT32:
+   case NPY_INT:
       break;
    default:
       PyErr_Format(PyExc_ValueError, "IsMemberCategoricalFixup third argument must be type int32_t not %s", NpyToString(uniqueType));
@@ -427,7 +427,7 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
    int32_t* reIndexArray = (int32_t*)WORKSPACE_ALLOC(arraySizeUnique * sizeof(int32_t));
    int32_t* reverseMapArray = (int32_t*)WORKSPACE_ALLOC(unique2Length * sizeof(int32_t));
 
-   PyArrayObject* indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
+   PyArrayObject* indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT);
    PyArrayObject* boolArray = AllocateLikeNumpyArray(inArr1, NPY_BOOL);
 
    if (reIndexArray && indexArray && boolArray) {
@@ -442,7 +442,7 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
       case NPY_INT16:
          FindFirstOccurence<int16_t>((int16_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
-      case NPY_INT32:
+      case NPY_INT:
          FindFirstOccurence<int32_t>((int32_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
       case NPY_INT64:
@@ -465,7 +465,7 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
       case NPY_INT16:
          FinalMatch<int16_t>((int16_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
-      case NPY_INT32:
+      case NPY_INT:
          FinalMatch<int32_t>((int32_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
       case NPY_INT64:

--- a/src/HashFunctions.cpp
+++ b/src/HashFunctions.cpp
@@ -155,35 +155,35 @@ IsMemberCategorical(PyObject *self, PyObject *args)
    LOGGING("IsMember32 %s vs %s   size: %d  %d\n", NpyToString(arrayType1), NpyToString(arrayType2), sizeType1, sizeType2);
 
    switch (arrayType1) {
-   case NPY_INT32:
+   CASE_NPY_INT32:
       arrayType1 = NPY_INT32;
       break;
-   case NPY_UINT32:
+   CASE_NPY_UINT32:
       arrayType1 = NPY_UINT32;
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       arrayType1 = NPY_INT64;
       break;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT64:
+   
       arrayType1 = NPY_UINT64;
       break;
    }
 
    switch (arrayType2) {
-   case NPY_INT32:
+   CASE_NPY_INT32:
       arrayType2 = NPY_INT32;
       break;
-   case NPY_UINT32:
+   CASE_NPY_UINT32:
       arrayType2 = NPY_UINT32;
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       arrayType2 = NPY_INT64;
       break;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT64:
+   
       arrayType2 = NPY_UINT64;
       break;
    }
@@ -414,7 +414,7 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
    int32_t array1Type = PyArray_TYPE(inArr1);
 
    switch (uniqueType) {
-   case NPY_INT32:
+   CASE_NPY_INT32:
       break;
    default:
       PyErr_Format(PyExc_ValueError, "IsMemberCategoricalFixup third argument must be type int32_t not %s", NpyToString(uniqueType));
@@ -442,11 +442,11 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
       case NPY_INT16:
          FindFirstOccurence<int16_t>((int16_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          FindFirstOccurence<int32_t>((int32_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          FindFirstOccurence<int64_t>((int64_t*)pArray2, pUnique, reIndexArray, reverseMapArray, arraySize2, arraySizeUnique, unique2Length, baseoffset2);
          break;
       default:
@@ -465,11 +465,11 @@ IsMemberCategoricalFixup(PyObject *self, PyObject *args)
       case NPY_INT16:
          FinalMatch<int16_t>((int16_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          FinalMatch<int32_t>((int32_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          FinalMatch<int64_t>((int64_t*)pArray1, pIndexOut, pBoolOut, reIndexArray, arraySize1, baseoffset1);
          break;
       default:

--- a/src/HashLinear.cpp
+++ b/src/HashLinear.cpp
@@ -28,7 +28,7 @@
 //static constexpr int numpy_type_code = -1;   // -1 is an invalid code, because if something uses this specialization we want it to break.
 //
 //template<>
-//static constexpr int numpy_type_code<int32_t> = NPY_INT;
+//static constexpr int numpy_type_code<int32_t> = NPY_INT32;
 //
 //template<>
 //static constexpr int numpy_type_code<int64_t> = NPY_INT64;
@@ -44,7 +44,7 @@ struct numpy_type_code
 template<>
 struct numpy_type_code<int32_t>
 {
-   static constexpr int value = NPY_INT;
+   static constexpr int value = NPY_INT32;
 };
 
 template<>
@@ -1981,7 +1981,7 @@ PyArrayObject* CopyToSmallerArray(void* pFirstArrayIndex, int64_t numUnique, int
          firstArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT16);
          break;
       case 4:
-         firstArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT);
+         firstArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT32);
          break;
       case 8:
          firstArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT64);
@@ -4265,7 +4265,7 @@ bool MergePreBinned(
    case NPY_LONGLONG:
       FindLastMatchCategorical<KEY_TYPE, int64_t>(size1, size2, pKey1, pKey2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalUniqueSize);
       break;
-   case NPY_INT:
+   case NPY_INT32:
       FindLastMatchCategorical<KEY_TYPE, int32_t>(size1, size2, pKey1, pKey2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalUniqueSize);
       break;
    case NPY_FLOAT64:
@@ -4317,7 +4317,7 @@ bool AlignHashMK32(
          pHashLinear->FindLastMatchMK<int64_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
       break;
-   case NPY_INT:
+   case NPY_INT32:
       if (isForward) {
          pHashLinear->FindNextMatchMK<int32_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
@@ -4381,7 +4381,7 @@ bool AlignHashMK64(
       }
 
       break;
-   case NPY_INT:
+   case NPY_INT32:
       if (isForward) {
          pHashLinear->FindNextMatchMK<int32_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
@@ -4831,7 +4831,7 @@ void IsMemberHashString32Pre(
 
    }
    else if (size < 2000000000) {
-      *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT);
+      *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
       int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(*indexArray);
       IsMemberHashString32<int32_t>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, pBoolOutput, HASH_MODE(hashMode), hintSize, isUnicode);
 
@@ -4877,7 +4877,7 @@ int64_t IsMemberCategoricalHashStringPre(
 
    }
    else if (size2 < 2000000000) {
-      *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT);
+      *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
       int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(*indexArray);
       missed = IsMemberHashStringCategorical<int32_t>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, HASH_MODE(hashMode), hintSize, isUnicode);
 
@@ -5052,7 +5052,7 @@ void IsMemberHashMKPre(
       }
    }
    else if (size < 2000000000) {
-      *indexArray = AllocateNumpyArray(1, (npy_intp*)&size1, NPY_INT);
+      *indexArray = AllocateNumpyArray(1, (npy_intp*)&size1, NPY_INT32);
       if (*indexArray) {
          int32_t* pOutput = (int32_t*)PyArray_BYTES(*indexArray);
          IsMemberHashMK<int32_t>(size1, pInput1, size2, pInput2, pBoolOutput, pOutput, totalItemSize, hintSize, hashMode);
@@ -5171,11 +5171,11 @@ IsMember32(PyObject *self, PyObject *args)
    LOGGING("IsMember32 %s vs %s   size: %d  %d\n", NpyToString(arrayType1), NpyToString(arrayType2), sizeType1, sizeType2);
 
    switch (arrayType1) {
-   case NPY_INT:
-      arrayType1 = NPY_INT;
+   case NPY_INT32:
+      arrayType1 = NPY_INT32;
       break;
-   case NPY_UINT:
-      arrayType1 = NPY_UINT;
+   case NPY_UINT32:
+      arrayType1 = NPY_UINT32;
       break;
    case NPY_INT64:
    case NPY_LONGLONG:
@@ -5188,11 +5188,11 @@ IsMember32(PyObject *self, PyObject *args)
    }
 
    switch (arrayType2) {
-   case NPY_INT:
-      arrayType2 = NPY_INT;
+   case NPY_INT32:
+      arrayType2 = NPY_INT32;
       break;
-   case NPY_UINT:
-      arrayType2 = NPY_UINT;
+   case NPY_UINT32:
+      arrayType2 = NPY_UINT32;
       break;
    case NPY_INT64:
    case NPY_LONGLONG:
@@ -5260,7 +5260,7 @@ IsMember32(PyObject *self, PyObject *args)
             dtype = NPY_INT16;
          } else
          if (arraySize2 < 2000000000) {
-            dtype = NPY_INT;
+            dtype = NPY_INT32;
          }
          else {
             dtype = NPY_INT64;
@@ -5278,7 +5278,7 @@ IsMember32(PyObject *self, PyObject *args)
             case NPY_INT16:
                IsMemberHash32<int16_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int16_t*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
                break;
-            case NPY_INT:
+            case NPY_INT32:
                IsMemberHash32<int32_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int32_t*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
                break;
             case NPY_INT64:
@@ -5628,7 +5628,7 @@ PyObject *MergeBinnedAndSorted(PyObject *self, PyObject *args)
       case NPY_INT16:
          success = MergePreBinned<int16_t>(ArrayLength(key1), (int16_t*)pKey1, pVal1, ArrayLength(key2), (int16_t*)pKey2, pVal2, (int16_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
-      case NPY_INT:
+      case NPY_INT32:
          success = MergePreBinned<int32_t>(ArrayLength(key1), (int32_t*)pKey1, pVal1, ArrayLength(key2), (int32_t*)pKey2, pVal2, (int32_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
       case NPY_INT64:

--- a/src/HashLinear.cpp
+++ b/src/HashLinear.cpp
@@ -4261,11 +4261,11 @@ bool MergePreBinned(
    LOGGING("AlignCategorical32 dtype: %d  size1: %lld  size2: %lld\n", dtype, size1, size2);
 
    switch (dtype) {
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       FindLastMatchCategorical<KEY_TYPE, int64_t>(size1, size2, pKey1, pKey2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalUniqueSize);
       break;
-   case NPY_INT32:
+   CASE_NPY_INT32:
       FindLastMatchCategorical<KEY_TYPE, int32_t>(size1, size2, pKey1, pKey2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalUniqueSize);
       break;
    case NPY_FLOAT64:
@@ -4308,8 +4308,8 @@ bool AlignHashMK32(
    CHashLinear<char, int32_t>* pHashLinear = new CHashLinear<char, int32_t>(hashMode);
 
    switch (dtype) {
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       if (isForward) {
          pHashLinear->FindNextMatchMK<int64_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
@@ -4317,7 +4317,7 @@ bool AlignHashMK32(
          pHashLinear->FindLastMatchMK<int64_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
       break;
-   case NPY_INT32:
+   CASE_NPY_INT32:
       if (isForward) {
          pHashLinear->FindNextMatchMK<int32_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
@@ -4371,8 +4371,8 @@ bool AlignHashMK64(
    CHashLinear<char, int64_t>* pHashLinear = new CHashLinear<char, int64_t>(hashMode);
 
    switch (dtype) {
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       if (isForward) {
          pHashLinear->FindNextMatchMK<int64_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
@@ -4381,7 +4381,7 @@ bool AlignHashMK64(
       }
 
       break;
-   case NPY_INT32:
+   CASE_NPY_INT32:
       if (isForward) {
          pHashLinear->FindNextMatchMK<int32_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
@@ -5171,35 +5171,35 @@ IsMember32(PyObject *self, PyObject *args)
    LOGGING("IsMember32 %s vs %s   size: %d  %d\n", NpyToString(arrayType1), NpyToString(arrayType2), sizeType1, sizeType2);
 
    switch (arrayType1) {
-   case NPY_INT32:
+   CASE_NPY_INT32:
       arrayType1 = NPY_INT32;
       break;
-   case NPY_UINT32:
+   CASE_NPY_UINT32:
       arrayType1 = NPY_UINT32;
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       arrayType1 = NPY_INT64;
       break;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT64:
+   
       arrayType1 = NPY_UINT64;
       break;
    }
 
    switch (arrayType2) {
-   case NPY_INT32:
+   CASE_NPY_INT32:
       arrayType2 = NPY_INT32;
       break;
-   case NPY_UINT32:
+   CASE_NPY_UINT32:
       arrayType2 = NPY_UINT32;
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       arrayType2 = NPY_INT64;
       break;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT64:
+   
       arrayType2 = NPY_UINT64;
       break;
    }
@@ -5278,10 +5278,10 @@ IsMember32(PyObject *self, PyObject *args)
             case NPY_INT16:
                IsMemberHash32<int16_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int16_t*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
                break;
-            case NPY_INT32:
+            CASE_NPY_INT32:
                IsMemberHash32<int32_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int32_t*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
                break;
-            case NPY_INT64:
+            CASE_NPY_INT64:
                IsMemberHash32<int64_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int64_t*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
                break;
             }
@@ -5628,11 +5628,11 @@ PyObject *MergeBinnedAndSorted(PyObject *self, PyObject *args)
       case NPY_INT16:
          success = MergePreBinned<int16_t>(ArrayLength(key1), (int16_t*)pKey1, pVal1, ArrayLength(key2), (int16_t*)pKey2, pVal2, (int16_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          success = MergePreBinned<int32_t>(ArrayLength(key1), (int32_t*)pKey1, pVal1, ArrayLength(key2), (int32_t*)pKey2, pVal2, (int32_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          success = MergePreBinned<int64_t>(ArrayLength(key1), (int64_t*)pKey1, pVal1, ArrayLength(key2), (int64_t*)pKey2, pVal2, (int64_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
       }

--- a/src/HashLinear.cpp
+++ b/src/HashLinear.cpp
@@ -28,10 +28,10 @@
 //static constexpr int numpy_type_code = -1;   // -1 is an invalid code, because if something uses this specialization we want it to break.
 //
 //template<>
-//static constexpr int numpy_type_code<INT32> = NPY_INT32;
+//static constexpr int numpy_type_code<int32_t> = NPY_INT32;
 //
 //template<>
-//static constexpr int numpy_type_code<INT64> = NPY_INT64;
+//static constexpr int numpy_type_code<int64_t> = NPY_INT64;
 
 /* Template-based, compile-time mapping between C++ types and numpy type codes (e.g. NPY_FLOAT64). */
 
@@ -42,13 +42,13 @@ struct numpy_type_code
 };
 
 template<>
-struct numpy_type_code<INT32>
+struct numpy_type_code<int32_t>
 {
    static constexpr int value = NPY_INT32;
 };
 
 template<>
-struct numpy_type_code<INT64>
+struct numpy_type_code<int64_t>
 {
    static constexpr int value = NPY_INT64;
 };
@@ -56,7 +56,7 @@ struct numpy_type_code<INT64>
 
 
 // Use this table to find a suitable hash size
-INT64 PRIME_NUMBERS[] = {
+int64_t PRIME_NUMBERS[] = {
    53,
    97,
    193,
@@ -93,18 +93,18 @@ INT64 PRIME_NUMBERS[] = {
 };
 
 #define MEMCMP_NEW(ARG1, ARG2, ARG3, ARG4) \
-{ ARG1 = 0; const char* pSrc1 = ARG2; const char* pSrc2 = ARG3; INT64 length = ARG4; \
+{ ARG1 = 0; const char* pSrc1 = ARG2; const char* pSrc2 = ARG3; int64_t length = ARG4; \
    while (length >= 8) { \
-      UINT64* p1 = (UINT64*)pSrc1; \
-      UINT64* p2 = (UINT64*)pSrc2;\
+      uint64_t* p1 = (uint64_t*)pSrc1; \
+      uint64_t* p2 = (uint64_t*)pSrc2;\
       if (*p1 != *p2) {ARG1=1; length=0; break;}\
       length -= 8;\
       pSrc1 += 8;\
       pSrc2 += 8;\
    }\
    if (length >= 4) { \
-      UINT32* p1 = (UINT32*)pSrc1; \
-      UINT32* p2 = (UINT32*)pSrc2; \
+      uint32_t* p1 = (uint32_t*)pSrc1; \
+      uint32_t* p2 = (uint32_t*)pSrc2; \
       if (*p1 != *p2) { \
          ARG1 = 1; length = 0; \
       } \
@@ -123,35 +123,35 @@ INT64 PRIME_NUMBERS[] = {
 }
 
 
-//static inline UINT32  sse42_crc32(const uint8_t *bytes, size_t len)
+//static inline uint32_t  sse42_crc32(const uint8_t *bytes, size_t len)
 //{
-//   UINT32 hash = 0;
-//   INT64 i = 0;
+//   uint32_t hash = 0;
+//   int64_t i = 0;
 //   for (i = 0; i<len; i++) {
 //      hash = _mm_crc32_u8(hash, bytes[i]);
 //   }
 //   return hash;
 //}
 
-static FORCEINLINE UINT64 crchash64(const char *buf, size_t count) {
-   UINT64 h = 0;
+static FORCEINLINE uint64_t crchash64(const char *buf, size_t count) {
+   uint64_t h = 0;
 
    while (count >= 8) {
-      h = _mm_crc32_u64(h, *(UINT64*)buf);
+      h = _mm_crc32_u64(h, *(uint64_t*)buf);
       count -= 8;
       buf += 8;
    }
 
-   UINT64 t = 0;
+   uint64_t t = 0;
 
    switch (count) {
-   case 7: t ^= (UINT64)buf[6] << 48;
-   case 6: t ^= (UINT64)buf[5] << 40;
-   case 5: t ^= (UINT64)buf[4] << 32;
-   case 4: t ^= (UINT64)buf[3] << 24;
-   case 3: t ^= (UINT64)buf[2] << 16;
-   case 2: t ^= (UINT64)buf[1] << 8;
-   case 1: t ^= (UINT64)buf[0];
+   case 7: t ^= (uint64_t)buf[6] << 48;
+   case 6: t ^= (uint64_t)buf[5] << 40;
+   case 5: t ^= (uint64_t)buf[4] << 32;
+   case 4: t ^= (uint64_t)buf[3] << 24;
+   case 3: t ^= (uint64_t)buf[2] << 16;
+   case 2: t ^= (uint64_t)buf[1] << 8;
+   case 1: t ^= (uint64_t)buf[0];
       return _mm_crc32_u64(h, t);
    }
    return h;
@@ -168,14 +168,14 @@ static FORCEINLINE UINT64 crchash64(const char *buf, size_t count) {
 // This function is generated using the framework provided.
 #define mix(h) h ^= h >> 23; h *= 0x2127599bf4325c37ULL;	 h ^= h >> 47;
 
-static FORCEINLINE UINT64 fasthash64(const void *buf, size_t len)
+static FORCEINLINE uint64_t fasthash64(const void *buf, size_t len)
 {
-   UINT64 seed = 0;
-   const UINT64    m = 0x880355f21e6d1965ULL;
-   const UINT64 *pos = (const UINT64 *)buf;
+   uint64_t seed = 0;
+   const uint64_t    m = 0x880355f21e6d1965ULL;
+   const uint64_t *pos = (const uint64_t *)buf;
    const unsigned char *pos2;
-   UINT64 h = seed ^ (len * m);
-   UINT64 v;
+   uint64_t h = seed ^ (len * m);
+   uint64_t v;
 
    while (len >=8) {
       v = *pos++;
@@ -188,13 +188,13 @@ static FORCEINLINE UINT64 fasthash64(const void *buf, size_t len)
    v = 0;
 
    switch (len) {
-   case 7: v ^= (UINT64)pos2[6] << 48;
-   case 6: v ^= (UINT64)pos2[5] << 40;
-   case 5: v ^= (UINT64)pos2[4] << 32;
-   case 4: v ^= (UINT64)pos2[3] << 24;
-   case 3: v ^= (UINT64)pos2[2] << 16;
-   case 2: v ^= (UINT64)pos2[1] << 8;
-   case 1: v ^= (UINT64)pos2[0];
+   case 7: v ^= (uint64_t)pos2[6] << 48;
+   case 6: v ^= (uint64_t)pos2[5] << 40;
+   case 5: v ^= (uint64_t)pos2[4] << 32;
+   case 4: v ^= (uint64_t)pos2[3] << 24;
+   case 3: v ^= (uint64_t)pos2[2] << 16;
+   case 2: v ^= (uint64_t)pos2[1] << 8;
+   case 1: v ^= (uint64_t)pos2[0];
       h ^= mix(v);
       h *= m;
    }
@@ -205,11 +205,11 @@ static FORCEINLINE UINT64 fasthash64(const void *buf, size_t len)
 
 // --------------------------------------------
 // Used when we know 8byte hash
-FORCEINLINE UINT64 fasthash64_8(UINT64 v)
+FORCEINLINE uint64_t fasthash64_8(uint64_t v)
 {
-   UINT64 seed = 0;
-   const UINT64    m = 0x880355f21e6d1965ULL;
-   UINT64 h = seed ^  m;
+   uint64_t seed = 0;
+   const uint64_t    m = 0x880355f21e6d1965ULL;
+   uint64_t h = seed ^  m;
 
    h ^= mix(v);
    h *= m;
@@ -219,11 +219,11 @@ FORCEINLINE UINT64 fasthash64_8(UINT64 v)
 
 // --------------------------------------------
 // Used when we know 8byte hash
-FORCEINLINE UINT64 fasthash64_16(UINT64* v)
+FORCEINLINE uint64_t fasthash64_16(uint64_t* v)
 {
-   UINT64 seed = 0;
-   const UINT64    m = 0x880355f21e6d1965ULL;
-   UINT64 h = seed ^ m;
+   uint64_t seed = 0;
+   const uint64_t    m = 0x880355f21e6d1965ULL;
+   uint64_t h = seed ^ m;
 
    h ^= mix(v[0]);
    h *= m;
@@ -250,15 +250,15 @@ const char* strStart = (pHashList+(i*strWidth)); \
 const char* str = strStart; \
 const char* strEnd = str + strWidth; \
 while (*str !=0) if (++str >= strEnd) break;         \
-UINT64 hash = fasthash64(strStart, str - strStart);
+uint64_t hash = fasthash64(strStart, str - strStart);
 
 
 #define HASH_UNICODE()          \
 const char* strStart = (pHashList+(i*strWidth)); \
-const UINT32* str = (UINT32*)strStart; \
-const UINT32* strEnd = str + strWidth/4; \
-UINT32 hash = 0;                  \
-UINT32  c;                            \
+const uint32_t* str = (uint32_t*)strStart; \
+const uint32_t* strEnd = str + strWidth/4; \
+uint32_t hash = 0;                  \
+uint32_t  c;                            \
 while ((c = *str) !=0) { \
    str++;                            \
    hash = _mm_crc32_u32(hash, c);    \
@@ -267,10 +267,10 @@ while ((c = *str) !=0) { \
 
 
 FORCE_INLINE
-BOOLEAN
-UNICODE_MATCH(const char* str1T, const char* str2T, INT64 strWidth1) {
-   const UINT32* str1 = (const UINT32*)str1T;
-   const UINT32* str2 = (const UINT32*)str2T;
+bool
+UNICODE_MATCH(const char* str1T, const char* str2T, int64_t strWidth1) {
+   const uint32_t* str1 = (const uint32_t*)str1T;
+   const uint32_t* str2 = (const uint32_t*)str2T;
    strWidth1 /= 4;
    while (strWidth1 > 0) {
       if (*str1 != *str2) return FALSE;
@@ -282,8 +282,8 @@ UNICODE_MATCH(const char* str1T, const char* str2T, INT64 strWidth1) {
 }
 
 FORCE_INLINE
-BOOLEAN
-STRING_MATCH(const char* str1, const char* str2, INT64 strWidth1) {
+bool
+STRING_MATCH(const char* str1, const char* str2, int64_t strWidth1) {
    while (strWidth1 > 0) {
       if (*str1 != *str2) return FALSE;
       ++str1;
@@ -295,10 +295,10 @@ STRING_MATCH(const char* str1, const char* str2, INT64 strWidth1) {
 
 
 FORCE_INLINE
-BOOLEAN
-UNICODE_MATCH2(const char* str1T, const char* str2T, INT64 strWidth1, INT64 strWidth2) {
-   const UINT32* str1 = (const UINT32*)str1T;
-   const UINT32* str2 = (const UINT32*)str2T;
+bool
+UNICODE_MATCH2(const char* str1T, const char* str2T, int64_t strWidth1, int64_t strWidth2) {
+   const uint32_t* str1 = (const uint32_t*)str1T;
+   const uint32_t* str2 = (const uint32_t*)str2T;
    strWidth1 /= 4;
    strWidth2 /= 4;
    while (1) {
@@ -324,8 +324,8 @@ UNICODE_MATCH2(const char* str1T, const char* str2T, INT64 strWidth1, INT64 strW
 
 
 FORCE_INLINE
-BOOLEAN
-STRING_MATCH2(const char* str1, const char* str2, INT64 strWidth1, INT64 strWidth2) {
+bool
+STRING_MATCH2(const char* str1, const char* str2, int64_t strWidth1, int64_t strWidth2) {
    while (1) {
 
       // Check for when one string ends and the other has not yet
@@ -349,8 +349,8 @@ STRING_MATCH2(const char* str1, const char* str2, INT64 strWidth1, INT64 strWidt
 
 
 template<typename T, typename U>
-INT64 CHashLinear<T, U>::GetHashSize(
-   INT64 numberOfEntries) {
+int64_t CHashLinear<T, U>::GetHashSize(
+   int64_t numberOfEntries) {
 
    // Check for perfect hashes first when type size is small
    //if (sizeof(T) == 1) {
@@ -377,8 +377,8 @@ INT64 CHashLinear<T, U>::GetHashSize(
       int i = 0;
       while ((1LL << i) < numberOfEntries) i++;
 
-      INT64 result= (1LL << i);
-      INT64 maxhashsize = (1LL << 31);
+      int64_t result= (1LL << i);
+      int64_t maxhashsize = (1LL << 31);
 
       // TODO: really need to change strategies if high unique count and high row count
       if (result > maxhashsize) {
@@ -392,7 +392,7 @@ INT64 CHashLinear<T, U>::GetHashSize(
 
 //-----------------------------------------------
 template<typename T, typename U>
-void CHashLinear<T, U>::FreeMemory(BOOL forceDeallocate) {
+void CHashLinear<T, U>::FreeMemory(bool forceDeallocate) {
 
    if (forceDeallocate || Deallocate) {
       //printf("deallocating\n");
@@ -409,13 +409,13 @@ void CHashLinear<T, U>::FreeMemory(BOOL forceDeallocate) {
 
 //-----------------------------------------------
 template<typename T, typename U>
-void CHashLinear<T, U>::AllocAndZeroBitFields(UINT64 hashSize) {
+void CHashLinear<T, U>::AllocAndZeroBitFields(uint64_t hashSize) {
 
    // Calculate how many bytes we need (in 64 bit/8 byte increments)
    BitAllocSize = (HashSize + 63) / 64;
-   BitAllocSize *= sizeof(UINT64);
+   BitAllocSize *= sizeof(uint64_t);
 
-   pBitFields = (UINT64*)WorkSpaceAllocSmall(BitAllocSize);
+   pBitFields = (uint64_t*)WorkSpaceAllocSmall(BitAllocSize);
 
    if (pBitFields) {
       // Fill with zeros to indicate no hash position is used yet
@@ -447,10 +447,10 @@ char* CHashLinear<T, U>::AllocHashTable(size_t allocSize) {
 // Returns NULL does not mean failure if sizeofExtraArray=0
 template<typename T, typename U>
 void* CHashLinear<T, U>::AllocMemory(
-   INT64 numberOfEntries,
-   INT64 sizeofStruct,
-   INT64 sizeofExtraArray,
-   BOOL  isFloat) {
+   int64_t numberOfEntries,
+   int64_t sizeofStruct,
+   int64_t sizeofExtraArray,
+   bool  isFloat) {
 
    if (sizeofStruct == -1) {
       sizeofStruct = sizeof(SingleKeyEntry);
@@ -493,7 +493,7 @@ void* CHashLinear<T, U>::AllocMemory(
    if (pBitFields) {
       if (sizeofExtraArray) {
          // 128 byte padding
-         INT64 padSize = (allocSize + 127) & ~127;
+         int64_t padSize = (allocSize + 127) & ~127;
          char* pRootBuffer = AllocHashTable(padSize + sizeofExtraArray);
 
          if (pRootBuffer) {
@@ -529,10 +529,10 @@ FORCE_INLINE
 void CHashLinear<T,U>::InternalGetLocation(
    U  i,
    HashLocation* pLocation,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    U*    pLocationOutput,
    T     item,
-   UINT64 hash) {
+   uint64_t hash) {
 
    const U        BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
 
@@ -541,7 +541,7 @@ void CHashLinear<T,U>::InternalGetLocation(
       if (pLocation[hash].value == item) {
          // return the first location
          pLocationOutput[i] = pLocation[hash].Location;
-         pBooleanOutput[i] = 1;
+         pBoolOutput[i] = 1;
          return;
       }
 
@@ -552,7 +552,7 @@ void CHashLinear<T,U>::InternalGetLocation(
    }
    // Not found
    pLocationOutput[i] = BAD_INDEX ;
-   pBooleanOutput[i] = 0;
+   pBoolOutput[i] = 0;
 }
 
 
@@ -569,8 +569,8 @@ void CHashLinear<T, U>::InternalGetLocationCategorical(
    HashLocation* pLocation,
    U*    pLocationOutput,
    T     item,
-   UINT64 hash,
-   INT64 *missed) {
+   uint64_t hash,
+   int64_t *missed) {
 
    while (IsBitSet(hash)) {
       // Check if we have a match from before
@@ -601,7 +601,7 @@ void CHashLinear<T, U>::InternalSetLocation(
    U  i,
    HashLocation* pLocation,
    T  item,
-   UINT64 hash) {
+   uint64_t hash) {
 
    while (IsBitSet(hash)) {
       // Check if we have a match from before
@@ -664,22 +664,22 @@ while (1) { \
 //
 template<typename T, typename U>
 void CHashLinear<T, U>::MakeHashLocationMK(
-   INT64 arraySize,
+   int64_t arraySize,
    T*    pInput,
-   INT64 totalItemSize,
-   INT64 hintSize) {
+   int64_t totalItemSize,
+   int64_t hintSize) {
 
    if (hintSize == 0) {
       hintSize = arraySize;
    }
 
    AllocMemory(hintSize, sizeof(HashLocationMK), 0, FALSE);
-   //UINT64 NumUnique = 0;
-   //UINT64 NumCollisions = 0;
+   //uint64_t NumUnique = 0;
+   //uint64_t NumCollisions = 0;
 
    HashLocationMK* pLocation = (HashLocationMK*)pHashTableAny;
 
-   UINT64*     pBitFields = this->pBitFields;
+   uint64_t*     pBitFields = this->pBitFields;
 
    if (!pLocation || !pBitFields) {
       return;
@@ -689,13 +689,13 @@ void CHashLinear<T, U>::MakeHashLocationMK(
 
    for (U i = 0; i < arraySize; i++) {
       const char* pMatch = pInput + (totalItemSize*i);
-      UINT64 hash = DEFAULT_HASH64(pMatch, totalItemSize);
+      uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
       hash = hash & (HashSize - 1);
 
       //printf("[%d] \n", (int)i);
 
       while (1) {
-         UINT64 index = hash >> 6;
+         uint64_t index = hash >> 6;
          if (pBitFields[index] & (1LL << (hash & 63))) {
             // Check if we have a match from before
             U Last = pLocation[hash].Location;
@@ -704,11 +704,11 @@ void CHashLinear<T, U>::MakeHashLocationMK(
             // TJD: August 2018 --unrolled MEMCMP and got 10-15% speedup
             const char* pSrc1 = pMatch;
             const char* pSrc2 = pMatch2;
-            INT64 length = totalItemSize;
+            int64_t length = totalItemSize;
 
             while (length >= 8) {
-               UINT64* p1 = (UINT64*)pSrc1;
-               UINT64* p2 = (UINT64*)pSrc2;
+               uint64_t* p1 = (uint64_t*)pSrc1;
+               uint64_t* p2 = (uint64_t*)pSrc2;
 
                if (*p1 != *p2) goto FAIL_MATCH;
                length -= 8;
@@ -716,8 +716,8 @@ void CHashLinear<T, U>::MakeHashLocationMK(
                pSrc2 += 8;
             }
             if (length >= 4) {
-               UINT32* p1 = (UINT32*)pSrc1;
-               UINT32* p2 = (UINT32*)pSrc2;
+               uint32_t* p1 = (uint32_t*)pSrc1;
+               uint32_t* p2 = (uint32_t*)pSrc2;
 
                if (*p1 != *p2) goto FAIL_MATCH;
                length -= 4;
@@ -769,18 +769,18 @@ void CHashLinear<T, U>::MakeHashLocationMK(
 //-----------------------------------------------
 // stores the index of the last matching index
 // ASSUMES that pVal1 and pVal2 are SORTED!!
-//  U is INT32 or INT64
-//  V is INT32, INT64, float, or double
+//  U is int32_t or int64_t
+//  V is int32_t, int64_t, float, or double
 template<typename U, typename V>
 void FindLastMatchCategorical(
-   INT64    arraySize1,
-   INT64    arraySize2,
+   int64_t    arraySize1,
+   int64_t    arraySize2,
    U*       pKey1,
    U*       pKey2,
    V*       pVal1,
    V*       pVal2,
    U*       pLocationOutput,
-   INT64    totalUniqueSize) {
+   int64_t    totalUniqueSize) {
 
    const U        BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
    U*       pLocation = (U*)WORKSPACE_ALLOC(totalUniqueSize * sizeof(U));
@@ -836,14 +836,14 @@ void FindLastMatchCategorical(
 // ASSUMES that pVal1 and pVal2 are SORTED!!
 template<typename T, typename U> template<typename V>
 void CHashLinear<T, U>::FindLastMatchMK(
-   INT64 arraySize1,
-   INT64 arraySize2,
+   int64_t arraySize1,
+   int64_t arraySize2,
    T*    pKey1,
    T*    pKey2,
    V*    pVal1,
    V*    pVal2,
    U*    pLocationOutput,
-   INT64 totalItemSize,
+   int64_t totalItemSize,
    bool allowExact) {
 
    AllocMemory(arraySize2, sizeof(HashLocationMK), 0, FALSE);
@@ -861,7 +861,7 @@ void CHashLinear<T, U>::FindLastMatchMK(
    while (i < arraySize1 && j < arraySize2) {
       if (pVal1[i] < pVal2[j] || (!allowExact &&  pVal1[i] == pVal2[j]) ) {
          const char* pMatch1 = pKey1 + (totalItemSize*i);
-         UINT64 hash = DEFAULT_HASH64(pMatch1, totalItemSize);
+         uint64_t hash = DEFAULT_HASH64(pMatch1, totalItemSize);
          hash = hash & (HashSize - 1);
 
          //TODO: should maybe put begin .. end into function implementing lookup for hashmap
@@ -894,7 +894,7 @@ void CHashLinear<T, U>::FindLastMatchMK(
       }
       else {
          const char* pMatch1 = pKey2 + (totalItemSize*j);
-         UINT64 hash = DEFAULT_HASH64(pMatch1, totalItemSize);
+         uint64_t hash = DEFAULT_HASH64(pMatch1, totalItemSize);
          hash = hash & (HashSize - 1);
 
          //TODO: should maybe start .. end into a function implementing insertion for hashmap
@@ -930,7 +930,7 @@ void CHashLinear<T, U>::FindLastMatchMK(
    }
    while (i < arraySize1) {
       const char* pMatch1 = pKey1 + (totalItemSize*i);
-      UINT64 hash = DEFAULT_HASH64(pMatch1, totalItemSize);
+      uint64_t hash = DEFAULT_HASH64(pMatch1, totalItemSize);
       hash = hash & (HashSize - 1);
 
       //TODO: should maybe put begin .. end into function implementing lookup for hashmap
@@ -972,14 +972,14 @@ void CHashLinear<T, U>::FindLastMatchMK(
 // TODO: Clean this up and merge with FindLastMatchMk
 template<typename T, typename U> template<typename V>
 void CHashLinear<T, U>::FindNextMatchMK(
-   INT64 arraySize1,
-   INT64 arraySize2,
+   int64_t arraySize1,
+   int64_t arraySize2,
    T*    pKey1,
    T*    pKey2,
    V*    pVal1,
    V*    pVal2,
    U*    pLocationOutput,
-   INT64 totalItemSize,
+   int64_t totalItemSize,
    bool allowExact) {
 
    AllocMemory(arraySize2, sizeof(HashLocationMK), 0, FALSE);
@@ -995,7 +995,7 @@ void CHashLinear<T, U>::FindNextMatchMK(
    while (i >= 0 && j >= 0) {
       if (pVal1[i] > pVal2[j] || (!allowExact &&  pVal1[i] == pVal2[j])) {
          const char* pMatch1 = pKey1 + (totalItemSize*i);
-         UINT64 hash = DEFAULT_HASH64(pMatch1, totalItemSize);
+         uint64_t hash = DEFAULT_HASH64(pMatch1, totalItemSize);
          hash = hash & (HashSize - 1);
 
          //TODO: should maybe put begin .. end into function implementing lookup for hashmap
@@ -1028,7 +1028,7 @@ void CHashLinear<T, U>::FindNextMatchMK(
       }
       else {
          const char* pMatch1 = pKey2 + (totalItemSize*j);
-         UINT64 hash = DEFAULT_HASH64(pMatch1, totalItemSize);
+         uint64_t hash = DEFAULT_HASH64(pMatch1, totalItemSize);
          hash = hash & (HashSize - 1);
 
          //TODO: should maybe start .. end into a function implementing insertion for hashmap
@@ -1064,7 +1064,7 @@ void CHashLinear<T, U>::FindNextMatchMK(
    }
    while (i >= 0) {
       const char* pMatch1 = pKey1 + (totalItemSize*i);
-      UINT64 hash = DEFAULT_HASH64(pMatch1, totalItemSize);
+      uint64_t hash = DEFAULT_HASH64(pMatch1, totalItemSize);
       hash = hash & (HashSize - 1);
 
       //TODO: should maybe put begin .. end into function implementing lookup for hashmap
@@ -1105,18 +1105,18 @@ void CHashLinear<T, U>::FindNextMatchMK(
 // T is the input type
 // U is the index output type (int8/16/32/64)
 //
-// outputs boolean array
+// outputs bool array
 // outputs location array
 //
 template<typename T, typename U>
 static void IsMemberMK(
    void* pHashLinearVoid,
-   INT64 arraySize,
+   int64_t arraySize,
    void* pInputT,
    void* pInput2T,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    void* pLocationOutputU,
-   INT64 totalItemSize) {
+   int64_t totalItemSize) {
 
    struct HashLocationMK
    {
@@ -1131,23 +1131,23 @@ static void IsMemberMK(
    T* pInput = (T*)pInputT;
    T* pInput2 = (T*)pInput2T;
 
-   UINT64 HashSize = pHashLinear->HashSize;
+   uint64_t HashSize = pHashLinear->HashSize;
 
    // to determine if hash location has been visited
-   UINT64*     pBitFields = pHashLinear->pBitFields;
+   uint64_t*     pBitFields = pHashLinear->pBitFields;
    const U        BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
 
-   LOGGING("in ismembermk  asize: %llu   isize: %llu  %p   %p  %p\n", arraySize, totalItemSize, pBitFields, pLocationOutput, pBooleanOutput);
+   LOGGING("in ismembermk  asize: %llu   isize: %llu  %p   %p  %p\n", arraySize, totalItemSize, pBitFields, pLocationOutput, pBoolOutput);
 
    for (U i = 0; i < arraySize; i++) {
       const char* pMatch = pInput + (totalItemSize*i);
-      UINT64 hash = DEFAULT_HASH64(pMatch, totalItemSize);
+      uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
       hash = hash & (HashSize - 1);
 
       //printf("[%d] %llu\n", (int)i, hash);
 
       while (1) {
-         UINT64 index = hash >> 6;
+         uint64_t index = hash >> 6;
          if (pBitFields[index] & (1LL << (hash & 63))) {
             // Check if we have a match from before
             U Last = pLocation[hash].Location;
@@ -1157,7 +1157,7 @@ static void IsMemberMK(
             if (!mresult) {
                // return the first location
                pLocationOutput[i] = pLocation[hash].Location;
-               pBooleanOutput[i] = 1;
+               pBoolOutput[i] = 1;
                break;
             }
 
@@ -1171,7 +1171,7 @@ static void IsMemberMK(
          //printf("[%d] Not found\n", (int)i);
          // Not found
          pLocationOutput[i] = BAD_INDEX;
-         pBooleanOutput[i] = 0;
+         pBoolOutput[i] = 0;
          break;
       }
    }
@@ -1183,16 +1183,16 @@ static void IsMemberMK(
 
 
 //=============================================
-#define HASH_INT1  INT64 h = (INT64)item; h= h % HashSize;
+#define HASH_INT1  int64_t h = (int64_t)item; h= h % HashSize;
 
-//#define HASH_INT32  UINT64 h = (UINT64)item; h ^= (h >> 16); h= h & (HashSize-1);
-//#define HASH_INT32 UINT64 h= fasthash64_8(item) & (HashSize-1);
-#define HASH_INT32  UINT64 h= _mm_crc32_u32(0, (UINT32)item) & (HashSize-1);
+//#define HASH_int32_t  uint64_t h = (uint64_t)item; h ^= (h >> 16); h= h & (HashSize-1);
+//#define HASH_int32_t uint64_t h= fasthash64_8(item) & (HashSize-1);
+#define HASH_int32_t  uint64_t h= _mm_crc32_u32(0, (uint32_t)item) & (HashSize-1);
 
-//#define HASH_INT64  UINT64 h= _mm_crc32_u64(0, item) & (HashSize-1);
-#define HASH_INT64 UINT64 h= fasthash64_8(item) & (HashSize-1);
+//#define HASH_int64_t  uint64_t h= _mm_crc32_u64(0, item) & (HashSize-1);
+#define HASH_int64_t uint64_t h= fasthash64_8(item) & (HashSize-1);
 
-#define HASH_INT128 UINT64 h= fasthash64_16((UINT64*)&pInput[i]) & (HashSize-1);
+#define HASH_INT128 uint64_t h= fasthash64_16((uint64_t*)&pInput[i]) & (HashSize-1);
 
 //=============================================
 //#define HASH_FLOAT1  h ^= h >> 16; h *= 0x85ebca6b; h ^= h >> 13; h *= 0xc2b2ae35; h ^= h >> 16;   h = h % HashSize;
@@ -1233,9 +1233,9 @@ static void IsMemberMK(
 //
 template<typename T, typename U>
 void CHashLinear<T,U>::MakeHashLocation(
-   INT64 arraySize,
+   int64_t arraySize,
    T*    pHashList,
-   INT64 hintSize) {
+   int64_t hintSize) {
 
    if (hintSize == 0) {
       hintSize = arraySize;
@@ -1247,7 +1247,7 @@ void CHashLinear<T,U>::MakeHashLocation(
    LOGGING("MakeHashLocation: hintSize %lld   HashSize %llu\n", hintSize, HashSize);
 
    HashLocation* pLocation = (HashLocation*)pHashTableAny;
-   UINT64*     pBitFields = this->pBitFields;
+   uint64_t*     pBitFields = this->pBitFields;
 
    if (!pLocation || !pBitFields) {
       return;
@@ -1264,7 +1264,7 @@ void CHashLinear<T,U>::MakeHashLocation(
       for (U i = 0; i < arraySize; i++) {
          // perfect hash
          T item = pHashList[i];
-         UINT64 hash = item;
+         uint64_t hash = item;
          INTERNAL_SET_LOCATION;
          //InternalSetLocation(i, pLocation, item, item);
       }
@@ -1275,7 +1275,7 @@ void CHashLinear<T,U>::MakeHashLocation(
             for (U i = 0; i < arraySize; i++) {
                T item = pHashList[i];
                HASH_INT1;
-               UINT64 hash = h;
+               uint64_t hash = h;
                INTERNAL_SET_LOCATION;
                //InternalSetLocation(i, pLocation, item, h);
             }
@@ -1284,8 +1284,8 @@ void CHashLinear<T,U>::MakeHashLocation(
 
             for (U i = 0; i < arraySize; i++) {
                T item = pHashList[i];
-               HASH_INT32;
-               UINT64 hash = h;
+               HASH_int32_t;
+               uint64_t hash = h;
                INTERNAL_SET_LOCATION;
                //InternalSetLocation(i, pLocation, item, h);
             }
@@ -1296,7 +1296,7 @@ void CHashLinear<T,U>::MakeHashLocation(
             for (U i = 0; i < arraySize; i++) {
                T item = pHashList[i];
                HASH_INT1;
-               UINT64 hash = h;
+               uint64_t hash = h;
                INTERNAL_SET_LOCATION;
                //InternalSetLocation(i, pLocation, item, h);
             }
@@ -1305,8 +1305,8 @@ void CHashLinear<T,U>::MakeHashLocation(
 
             for (U i = 0; i < arraySize; i++) {
                T item = pHashList[i];
-               HASH_INT64;
-               UINT64 hash = h;
+               HASH_int64_t;
+               uint64_t hash = h;
                INTERNAL_SET_LOCATION;
                //InternalSetLocation(i, pLocation, item, h);
             }
@@ -1335,17 +1335,17 @@ void CHashLinear<T,U>::MakeHashLocation(
 
 
 //-----------------------------------------------
-// outputs boolean array
+// outputs bool array
 // outputs location array
 //
 template<typename T, typename U>
-INT64 CHashLinear<T, U>::IsMemberCategorical(
-   INT64 arraySize,
+int64_t CHashLinear<T, U>::IsMemberCategorical(
+   int64_t arraySize,
    T*    pHashList,
    U*    pLocationOutput) {
 
    HashLocation* pLocation = (HashLocation*)pHashTableAny;
-   INT64 missed = 0;
+   int64_t missed = 0;
    if (sizeof(T) <= 2) {
       // perfect hash
       for (U i = 0; i < arraySize; i++) {
@@ -1368,7 +1368,7 @@ INT64 CHashLinear<T, U>::IsMemberCategorical(
 
             for (U i = 0; i < arraySize; i++) {
                T item = pHashList[i];
-               HASH_INT32;
+               HASH_int32_t;
                InternalGetLocationCategorical(i, pLocation, pLocationOutput, item, h, &missed);
             }
          }
@@ -1386,7 +1386,7 @@ INT64 CHashLinear<T, U>::IsMemberCategorical(
 
             for (U i = 0; i < arraySize; i++) {
                T item = pHashList[i];
-               HASH_INT64;
+               HASH_int64_t;
                InternalGetLocationCategorical(i, pLocation, pLocationOutput, item, h, &missed);
             }
          }
@@ -1403,12 +1403,12 @@ INT64 CHashLinear<T, U>::IsMemberCategorical(
 #define INNER_GET_LOCATION_PERFECT       \
    if (pBitFields[hash >> 6] & (1LL << (hash & 63))) { \
       pLocationOutput[i] = pLocation[hash].Location; \
-      pBooleanOutput[i] = 1; \
+      pBoolOutput[i] = 1; \
    } \
    else { \
       /* Not found */ \
       pLocationOutput[i] = BAD_INDEX; \
-      pBooleanOutput[i] = 0; \
+      pBoolOutput[i] = 0; \
    }
 
 
@@ -1420,7 +1420,7 @@ while (1) {             \
       if (pLocation[hash].value == item) {      \
          /* return the first location */ \
          pLocationOutput[i] = pLocation[hash].Location; \
-         pBooleanOutput[i] = 1; \
+         pBoolOutput[i] = 1; \
          break; \
       } \
       /* Linear goes to next position */ \
@@ -1432,7 +1432,7 @@ while (1) {             \
    else { \
       /* Not found */ \
       pLocationOutput[i] = BAD_INDEX; \
-      pBooleanOutput[i] = 0; \
+      pBoolOutput[i] = 0; \
       break; \
    } \
 }
@@ -1442,15 +1442,15 @@ while (1) {             \
 // T is the input type byte/float32/float64/int8/uint8/int16/uint16/int32/...
 // U is the index output type (int8/16/32/64)
 //
-// outputs boolean array
+// outputs bool array
 // outputs location array
 //
 template<typename T, typename U>
 void IsMember(
    void* pHashLinearVoid,
-   INT64 arraySize,
+   int64_t arraySize,
    void* pHashListT,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    void* pLocationOutputU) {
 
 
@@ -1461,14 +1461,14 @@ void IsMember(
    };
 
    CHashLinear<T, U>* pHashLinear = (CHashLinear<T, U>*)pHashLinearVoid;
-   UINT64 HashSize = pHashLinear->HashSize;
+   uint64_t HashSize = pHashLinear->HashSize;
 
    HashLocation* pLocation = (HashLocation*)pHashLinear->pHashTableAny;
    U* pLocationOutput = (U*)pLocationOutputU;
    T* pHashList = (T*)pHashListT;
 
    // make local reference on stack
-   UINT64* pBitFields = pHashLinear->pBitFields;
+   uint64_t* pBitFields = pHashLinear->pBitFields;
 
    const U        BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
 
@@ -1483,9 +1483,9 @@ void IsMember(
    if (sizeof(T) <= 2) {
       LOGGING("Perfect hash\n");
       // perfect hash
-      for (INT64 i = 0; i < arraySize; i++) {
+      for (int64_t i = 0; i < arraySize; i++) {
          T item = pHashList[i];
-         UINT64 hash = (UINT64)item;
+         uint64_t hash = (uint64_t)item;
          INNER_GET_LOCATION_PERFECT;
       }
    }
@@ -1494,42 +1494,42 @@ void IsMember(
 
       if (sizeof(T) == 4) {
          if (HashMode == HASH_MODE_PRIME) {
-            for (INT64 i = 0; i < arraySize; i++) {
+            for (int64_t i = 0; i < arraySize; i++) {
                T item = pHashList[i];
                HASH_INT1;
-               UINT64 hash = (UINT64)h;
+               uint64_t hash = (uint64_t)h;
                INNER_GET_LOCATION;
-               //InternalGetLocation(i, pLocation, pBooleanOutput, pLocationOutput, item, h);
+               //InternalGetLocation(i, pLocation, pBoolOutput, pLocationOutput, item, h);
             }
          }
          else {
 
-            for (INT64 i = 0; i < arraySize; i++) {
+            for (int64_t i = 0; i < arraySize; i++) {
                T item = pHashList[i];
-               HASH_INT32;
-               UINT64 hash = h;
+               HASH_int32_t;
+               uint64_t hash = h;
                INNER_GET_LOCATION;
-               //InternalGetLocation(i, pLocation, pBooleanOutput, pLocationOutput, item, h);
+               //InternalGetLocation(i, pLocation, pBoolOutput, pLocationOutput, item, h);
             }
          }
       }
       else
       if (sizeof(T) == 8) {
          if (HashMode == HASH_MODE_PRIME) {
-            for (INT64 i = 0; i < arraySize; i++) {
+            for (int64_t i = 0; i < arraySize; i++) {
                T item = pHashList[i];
                HASH_INT1;
-               UINT64 hash = (UINT64)h;
+               uint64_t hash = (uint64_t)h;
                INNER_GET_LOCATION;
-               //InternalGetLocation(i, pLocation, pBooleanOutput, pLocationOutput, item, h);
+               //InternalGetLocation(i, pLocation, pBoolOutput, pLocationOutput, item, h);
             }
          }
          else {
 
-            for (INT64 i = 0; i < arraySize; i++) {
+            for (int64_t i = 0; i < arraySize; i++) {
                T item = pHashList[i];
-               HASH_INT64;
-               UINT64 hash = h;
+               HASH_int64_t;
+               uint64_t hash = h;
                INNER_GET_LOCATION;
             }
          }
@@ -1546,10 +1546,10 @@ void IsMember(
 //-----------------------------------------
 // bits 32-51 appear to be sweet spot
 void CalculateHashBits64(
-   INT64 arraySize,
-   UINT64* pHashList) {
+   int64_t arraySize,
+   uint64_t* pHashList) {
 
-   INT64 position[64];
+   int64_t position[64];
    for (int i = 0; i < 64; i++) position[i] = 0;
 
    while (arraySize--) {
@@ -1568,10 +1568,10 @@ void CalculateHashBits64(
 //-----------------------------------------------
 // bits 3-22 appear to be sweet spot
 void CalculateHashBits32(
-   INT64 arraySize,
-   UINT32* pHashList) {
+   int64_t arraySize,
+   uint32_t* pHashList) {
 
-   INT64 position[32];
+   int64_t position[32];
    for (int i = 0; i < 32; i++) position[i] = 0;
 
    while (arraySize--) {
@@ -1592,9 +1592,9 @@ void CalculateHashBits32(
 //
 template<typename T, typename U>
 void CHashLinear<T, U>::MakeHashLocationFloat(
-   INT64 arraySize,
+   int64_t arraySize,
    T*    pHashList,
-   INT64 hintSize ) {
+   int64_t hintSize ) {
 
    if (hintSize == 0) {
       hintSize = arraySize;
@@ -1606,7 +1606,7 @@ void CHashLinear<T, U>::MakeHashLocationFloat(
    LOGGING("MakeHashLocationFloat: hintSize %lld   HashSize %llu\n", hintSize, HashSize);
 
    HashLocation* pLocation = (HashLocation*)pHashTableAny;
-   UINT64*     pBitFields = this->pBitFields;
+   uint64_t*     pBitFields = this->pBitFields;
 
    if (!pLocation || !pBitFields) {
       return;
@@ -1614,7 +1614,7 @@ void CHashLinear<T, U>::MakeHashLocationFloat(
 
    if (sizeof(T) == 8) {
       //printf("**double %llu\n", HashSize);
-      //CalculateHashBits64(arraySize, (UINT64*)pHashList);
+      //CalculateHashBits64(arraySize, (uint64_t*)pHashList);
 
       if (HashMode == HASH_MODE_PRIME) {
 
@@ -1622,10 +1622,10 @@ void CHashLinear<T, U>::MakeHashLocationFloat(
             T item = pHashList[i];
             // NAN CHECK FIRST
             if (item == item) {
-               UINT64* pHashList2 = (UINT64*)pHashList;
-               UINT64 h = pHashList2[i];
+               uint64_t* pHashList2 = (uint64_t*)pHashList;
+               uint64_t h = pHashList2[i];
                HASH_FLOAT3;
-               UINT64 hash = h;
+               uint64_t hash = h;
                INTERNAL_SET_LOCATION;
                //InternalSetLocation(i, pLocation, item, h);
             }
@@ -1636,10 +1636,10 @@ void CHashLinear<T, U>::MakeHashLocationFloat(
             T item = pHashList[i];
             // NAN CHECK FIRST
             if (item == item) {
-               UINT64* pHashList2 = (UINT64*)pHashList;
-               UINT64 h = pHashList2[i];
+               uint64_t* pHashList2 = (uint64_t*)pHashList;
+               uint64_t h = pHashList2[i];
                HASH_FLOAT4;
-               UINT64 hash = h;
+               uint64_t hash = h;
                INTERNAL_SET_LOCATION;
                //InternalSetLocation(i, pLocation, item, h);
             }
@@ -1648,7 +1648,7 @@ void CHashLinear<T, U>::MakeHashLocationFloat(
    }
    if (sizeof(T) == 4) {
       //printf("**single  %llu\n",HashSize);
-      //CalculateHashBits32(arraySize,(UINT32*)pHashList);
+      //CalculateHashBits32(arraySize,(uint32_t*)pHashList);
 
       if (HashMode == HASH_MODE_PRIME) {
 
@@ -1656,10 +1656,10 @@ void CHashLinear<T, U>::MakeHashLocationFloat(
             T item = pHashList[i];
             // NAN CHECK FIRST
             if (item == item) {
-               UINT32* pHashList2 = (UINT32*)pHashList;
-               UINT64 h = pHashList2[i];
+               uint32_t* pHashList2 = (uint32_t*)pHashList;
+               uint64_t h = pHashList2[i];
                HASH_FLOAT1;
-               UINT64 hash = h;
+               uint64_t hash = h;
                INTERNAL_SET_LOCATION;
                //InternalSetLocation(i, pLocation, item, h);
             }
@@ -1670,10 +1670,10 @@ void CHashLinear<T, U>::MakeHashLocationFloat(
             T item = pHashList[i];
             // NAN CHECK FIRST
             if (item == item) {
-               UINT32* pHashList2 = (UINT32*)pHashList;
-               UINT64 h = pHashList2[i];
+               uint32_t* pHashList2 = (uint32_t*)pHashList;
+               uint64_t h = pHashList2[i];
                HASH_FLOAT2;
-               UINT64 hash = h;
+               uint64_t hash = h;
                INTERNAL_SET_LOCATION;
                //InternalSetLocation(i, pLocation, item, h);
             }
@@ -1688,15 +1688,15 @@ void CHashLinear<T, U>::MakeHashLocationFloat(
 
 
 //-----------------------------------------------
-// outputs boolean array
+// outputs bool array
 // outputs location array
 //
 template<typename T, typename U>
 void IsMemberFloat(
    void* pHashLinearVoid,
-   INT64 arraySize,
+   int64_t arraySize,
    void* pHashListT,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    void* pLocationOutputU) {
 
    LOGGING("IsMemberFloat: arraySize %lld \n", arraySize);
@@ -1709,7 +1709,7 @@ void IsMemberFloat(
    };
 
    CHashLinear<T, U>* pHashLinear = (CHashLinear<T, U>*)pHashLinearVoid;
-   UINT64 HashSize = pHashLinear->HashSize;
+   uint64_t HashSize = pHashLinear->HashSize;
    int HashMode = pHashLinear->HashMode;
 
 
@@ -1718,47 +1718,47 @@ void IsMemberFloat(
    T* pHashList = (T*)pHashListT;
 
    // make local reference on stack
-   UINT64* pBitFields = pHashLinear->pBitFields;
+   uint64_t* pBitFields = pHashLinear->pBitFields;
 
    const U        BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
 
    if (sizeof(T) == 8) {
 
       if (HashMode == HASH_MODE_PRIME) {
-         for (INT64 i = 0; i < arraySize; i++) {
+         for (int64_t i = 0; i < arraySize; i++) {
             T item = pHashList[i];
             if (item == item) {
-               UINT64* pHashList2 = (UINT64*)pHashList;
-               UINT64 h = pHashList2[i];
+               uint64_t* pHashList2 = (uint64_t*)pHashList;
+               uint64_t h = pHashList2[i];
                HASH_FLOAT3;
-               UINT64 hash = (UINT64)h;
+               uint64_t hash = (uint64_t)h;
                INNER_GET_LOCATION;
-               //InternalGetLocation(i, pLocation, pBooleanOutput, pLocationOutput, item, h);
+               //InternalGetLocation(i, pLocation, pBoolOutput, pLocationOutput, item, h);
             }
             else {
                // Not found
                pLocationOutput[i] = BAD_INDEX;
-               pBooleanOutput[i] = 0;
+               pBoolOutput[i] = 0;
             }
          }
       }
       else {
 
-         for (INT64 i = 0; i < arraySize; i++) {
+         for (int64_t i = 0; i < arraySize; i++) {
             T item = pHashList[i];
             if (item == item) {
-               UINT64* pHashList2 = (UINT64*)pHashList;
-               UINT64 h = pHashList2[i];
+               uint64_t* pHashList2 = (uint64_t*)pHashList;
+               uint64_t h = pHashList2[i];
                HASH_FLOAT4;
-               UINT64 hash = (UINT64)h;
+               uint64_t hash = (uint64_t)h;
                INNER_GET_LOCATION;
-               //InternalGetLocation(i, pLocation, pBooleanOutput, pLocationOutput, item, h);
+               //InternalGetLocation(i, pLocation, pBoolOutput, pLocationOutput, item, h);
             }
             else {
 
                // Not found
                pLocationOutput[i] = BAD_INDEX;
-               pBooleanOutput[i] = 0;
+               pBoolOutput[i] = 0;
             }
          }
       }
@@ -1766,40 +1766,40 @@ void IsMemberFloat(
    if (sizeof(T) == 4) {
 
       if (HashMode == HASH_MODE_PRIME) {
-         for (INT64 i = 0; i < arraySize; i++) {
+         for (int64_t i = 0; i < arraySize; i++) {
             T item = pHashList[i];
             if (item == item) {
-               UINT32* pHashList2 = (UINT32*)pHashList;
-               UINT64 h = pHashList2[i];
+               uint32_t* pHashList2 = (uint32_t*)pHashList;
+               uint64_t h = pHashList2[i];
                HASH_FLOAT1;
-               UINT64 hash = (UINT64)h;
+               uint64_t hash = (uint64_t)h;
                INNER_GET_LOCATION;
-               //InternalGetLocation(i, pLocation, pBooleanOutput, pLocationOutput, item, h);
+               //InternalGetLocation(i, pLocation, pBoolOutput, pLocationOutput, item, h);
             }
             else {
                // Not found
                pLocationOutput[i] = BAD_INDEX;
-               pBooleanOutput[i] = 0;
+               pBoolOutput[i] = 0;
             }
          }
       }
       else {
 
-         for (INT64 i = 0; i < arraySize; i++) {
+         for (int64_t i = 0; i < arraySize; i++) {
             T item = pHashList[i];
             if (item == item) {
-               UINT32* pHashList2 = (UINT32*)pHashList;
-               UINT64 h = pHashList2[i];
+               uint32_t* pHashList2 = (uint32_t*)pHashList;
+               uint64_t h = pHashList2[i];
                HASH_FLOAT2;
-               UINT64 hash = (UINT64)h;
+               uint64_t hash = (uint64_t)h;
                INNER_GET_LOCATION;
-               //InternalGetLocation(i, pLocation, pBooleanOutput, pLocationOutput, item, h);
+               //InternalGetLocation(i, pLocation, pBoolOutput, pLocationOutput, item, h);
             }
             else {
 
                // Not found
                pLocationOutput[i] = BAD_INDEX;
-               pBooleanOutput[i] = 0;
+               pBoolOutput[i] = 0;
             }
          }
       }
@@ -1814,13 +1814,13 @@ void IsMemberFloat(
 // outputs location array + 1
 //
 template<typename T, typename U>
-INT64 CHashLinear<T, U>::IsMemberFloatCategorical(
-   INT64 arraySize,
+int64_t CHashLinear<T, U>::IsMemberFloatCategorical(
+   int64_t arraySize,
    T*    pHashList,
    U*    pLocationOutput) {
 
    HashLocation* pLocation = (HashLocation*)pHashTableAny;
-   INT64 missed = 0;
+   int64_t missed = 0;
 
    // BUG BUG -- LONG DOUBLE on Linux size 16
 
@@ -1830,8 +1830,8 @@ INT64 CHashLinear<T, U>::IsMemberFloatCategorical(
          for (U i = 0; i < arraySize; i++) {
             T item = pHashList[i];
             if (item == item) {
-               UINT64* pHashList2 = (UINT64*)pHashList;
-               UINT64 h = pHashList2[i];
+               uint64_t* pHashList2 = (uint64_t*)pHashList;
+               uint64_t h = pHashList2[i];
                HASH_FLOAT3;
                InternalGetLocationCategorical(i, pLocation, pLocationOutput, item, h, &missed);
             }
@@ -1847,8 +1847,8 @@ INT64 CHashLinear<T, U>::IsMemberFloatCategorical(
          for (U i = 0; i < arraySize; i++) {
             T item = pHashList[i];
             if (item == item) {
-               UINT64* pHashList2 = (UINT64*)pHashList;
-               UINT64 h = pHashList2[i];
+               uint64_t* pHashList2 = (uint64_t*)pHashList;
+               uint64_t h = pHashList2[i];
                HASH_FLOAT4;
                InternalGetLocationCategorical(i, pLocation, pLocationOutput, item, h, &missed);
             }
@@ -1868,8 +1868,8 @@ INT64 CHashLinear<T, U>::IsMemberFloatCategorical(
             for (U i = 0; i < arraySize; i++) {
                T item = pHashList[i];
                if (item == item) {
-                  UINT32* pHashList2 = (UINT32*)pHashList;
-                  UINT64 h = pHashList2[i];
+                  uint32_t* pHashList2 = (uint32_t*)pHashList;
+                  uint64_t h = pHashList2[i];
                   HASH_FLOAT1;
                   InternalGetLocationCategorical(i, pLocation,  pLocationOutput, item, h, &missed);
                }
@@ -1885,8 +1885,8 @@ INT64 CHashLinear<T, U>::IsMemberFloatCategorical(
             for (U i = 0; i < arraySize; i++) {
                T item = pHashList[i];
                if (item == item) {
-                  UINT32* pHashList2 = (UINT32*)pHashList;
-                  UINT64 h = pHashList2[i];
+                  uint32_t* pHashList2 = (uint32_t*)pHashList;
+                  uint64_t h = pHashList2[i];
                   HASH_FLOAT2;
                   InternalGetLocationCategorical(i, pLocation, pLocationOutput, item, h, &missed);
                }
@@ -1909,7 +1909,7 @@ INT64 CHashLinear<T, U>::IsMemberFloatCategorical(
 //===========================================================================
 
 #define GROUPBY_INNER_LOOP_PERFECT \
-UINT64 hash = (UINT64)item & (HashSize -1); \
+uint64_t hash = (uint64_t)item & (HashSize -1); \
 SingleKeyEntry* pKey = &pLocation[hash]; \
    if (pBitFieldsX[hash >> 6] & (1LL << (hash & 63))) { \
        pIndexArray[i] = pKey->UniqueKey;            \
@@ -1924,7 +1924,7 @@ SingleKeyEntry* pKey = &pLocation[hash]; \
 
 
 #define GROUPBY_INNER_LOOP \
-UINT64 hash = h; \
+uint64_t hash = h; \
 while (1) { \
    if (pBitFieldsX[hash >> 6] & (1LL << (hash & 63))) { \
       /* Check if we have a match from before */     \
@@ -1954,12 +1954,12 @@ while (1) { \
    }                                \
 }
 
-typedef PyArrayObject*(COPY_TO_SMALLER_ARRAY)(void* pFirstArrayIndex, INT64 numUnique, INT64 totalRows);
+typedef PyArrayObject*(COPY_TO_SMALLER_ARRAY)(void* pFirstArrayIndex, int64_t numUnique, int64_t totalRows);
 //-----------------------------------------------------------------------------------------
 // Returns AN ALLOCATED numpy array
 // if firstArray is NULL, it will allocate
 template<typename INDEX_TYPE>
-PyArrayObject* CopyToSmallerArray(void* pFirstArrayIndex, INT64 numUnique, INT64 totalRows, PyArrayObject* firstArray = NULL) {
+PyArrayObject* CopyToSmallerArray(void* pFirstArrayIndex, int64_t numUnique, int64_t totalRows, PyArrayObject* firstArray = NULL) {
 
    // check for out of memory
    if (!pFirstArrayIndex) {
@@ -2013,16 +2013,16 @@ PyArrayObject* CopyToSmallerArray(void* pFirstArrayIndex, INT64 numUnique, INT64
 // *pFirstArrayObject = CopyToSmallerArray<U>(pFirstArray, numUnique, totalRows);
 
 template<typename T, typename U>
-UINT64 CHashLinear<T, U>::GroupByFloat(
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t CHashLinear<T, U>::GroupByFloat(
+   int64_t totalRows,
+   int64_t totalItemSize,
    T* pInput,
    int coreType, // -1 when unknown  indicates only one array
                  // Return values
    U* pIndexArray,
    U* &pFirstArray,
    HASH_MODE hashMode,
-   INT64 hintSize,
+   int64_t hintSize,
    bool* pBoolFilter) {
 
    LOGGING("GroupByFloat: hintSize %lld   HashSize %llu  totalRows %lld\n", hintSize, HashSize, totalRows);
@@ -2031,14 +2031,14 @@ UINT64 CHashLinear<T, U>::GroupByFloat(
    SingleKeyEntry* pLocation = (SingleKeyEntry*)pHashTableAny;
 
    // make local reference on stack
-   UINT64* pBitFieldsX = pBitFields;
+   uint64_t* pBitFieldsX = pBitFields;
 
    switch (sizeof(T)) {
    case 4:
       if (pBoolFilter == NULL) {
          for (U i = 0; i < totalRows; i++) {
             T item = pInput[i];
-            UINT64 h = ((UINT32*)pInput)[i];
+            uint64_t h = ((uint32_t*)pInput)[i];
             HASH_FLOAT2;
             GROUPBY_INNER_LOOP;
          }
@@ -2048,7 +2048,7 @@ UINT64 CHashLinear<T, U>::GroupByFloat(
          // check to see if in filter
          if (pBoolFilter[i]) {
             T item = pInput[i];
-            UINT64 h = ((UINT32*)pInput)[i];
+            uint64_t h = ((uint32_t*)pInput)[i];
             HASH_FLOAT2;
             GROUPBY_INNER_LOOP;
          }
@@ -2062,7 +2062,7 @@ UINT64 CHashLinear<T, U>::GroupByFloat(
       if (pBoolFilter == NULL) {
          for (U i = 0; i < totalRows; i++) {
             T item = pInput[i];
-            UINT64 h = ((UINT64*)pInput)[i];
+            uint64_t h = ((uint64_t*)pInput)[i];
             HASH_FLOAT4;
             GROUPBY_INNER_LOOP;
          }
@@ -2072,7 +2072,7 @@ UINT64 CHashLinear<T, U>::GroupByFloat(
             // check to see if in filter
             if (pBoolFilter[i]) {
                T item = pInput[i];
-               UINT64 h = ((UINT64*)pInput)[i];
+               uint64_t h = ((uint64_t*)pInput)[i];
                HASH_FLOAT4;
                GROUPBY_INNER_LOOP;
             }
@@ -2084,7 +2084,7 @@ UINT64 CHashLinear<T, U>::GroupByFloat(
       break;
    }
 
-   LOGGING("GroupByFloat end! %I64d\n", (INT64)numUnique);
+   LOGGING("GroupByFloat end! %I64d\n", (int64_t)numUnique);
 
    return numUnique;
 }
@@ -2094,16 +2094,16 @@ UINT64 CHashLinear<T, U>::GroupByFloat(
 //------------------------------------------------------------------
 // Returns pFirstArray
 template<typename T, typename U>
-UINT64 CHashLinear<T, U>::GroupByItemSize(
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t CHashLinear<T, U>::GroupByItemSize(
+   int64_t totalRows,
+   int64_t totalItemSize,
    T* pInput,
    int coreType, // -1 when unknown  indicates only one array
                  // Return values
    U* pIndexArray,
    U* &pFirstArray,
    HASH_MODE hashMode,
-   INT64 hintSize,
+   int64_t hintSize,
    bool* pBoolFilter) {
 
    LOGGING("GroupByItem: hintSize %lld   HashSize %llu  totalRows %lld   sizeofT:%lld   sizeofU:%lld\n", hintSize, HashSize, totalRows, sizeof(T), sizeof(U));
@@ -2112,7 +2112,7 @@ UINT64 CHashLinear<T, U>::GroupByItemSize(
    SingleKeyEntry* pLocation = (SingleKeyEntry*)pHashTableAny;
 
    // make local reference on stack
-   UINT64* pBitFieldsX = pBitFields;
+   uint64_t* pBitFieldsX = pBitFields;
 
    switch (sizeof(T)) {
    case 1:
@@ -2165,7 +2165,7 @@ UINT64 CHashLinear<T, U>::GroupByItemSize(
       if (pBoolFilter == NULL) {
          for (U i = 0; i < totalRows; i++) {
             T item = pInput[i];
-            HASH_INT32;
+            HASH_int32_t;
             GROUPBY_INNER_LOOP;
          }
       }
@@ -2174,7 +2174,7 @@ UINT64 CHashLinear<T, U>::GroupByItemSize(
             // check to see if in filter
             if (pBoolFilter[i]) {
                T item = pInput[i];
-               HASH_INT32;
+               HASH_int32_t;
                GROUPBY_INNER_LOOP;
             }
             else {
@@ -2187,7 +2187,7 @@ UINT64 CHashLinear<T, U>::GroupByItemSize(
       if (pBoolFilter == NULL) {
          for (U i = 0; i < totalRows; i++) {
             T item = pInput[i];
-            HASH_INT64;
+            HASH_int64_t;
             GROUPBY_INNER_LOOP;
          }
       }
@@ -2196,7 +2196,7 @@ UINT64 CHashLinear<T, U>::GroupByItemSize(
             // check to see if in filter
             if (pBoolFilter[i]) {
                T item = pInput[i];
-               HASH_INT64;
+               HASH_int64_t;
                GROUPBY_INNER_LOOP;
             }
             else {
@@ -2245,9 +2245,9 @@ UINT64 CHashLinear<T, U>::GroupByItemSize(
 // hintSize can be 0 which will default to totalRows
 // pBoolFilter can be NULL
 template<typename T, typename U>
-UINT64 CHashLinear<T, U>::GroupBy(
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t CHashLinear<T, U>::GroupBy(
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput,
 
    int coreType, // -1 when unknown  indicates only one array
@@ -2257,7 +2257,7 @@ UINT64 CHashLinear<T, U>::GroupBy(
    U* &pFirstArray,
 
    HASH_MODE hashMode,
-   INT64 hintSize,
+   int64_t hintSize,
    bool* pBoolFilter) {
 
    LOGGING("GroupBy: hintSize %lld   HashSize %llu\n", hintSize, HashSize);
@@ -2267,14 +2267,14 @@ UINT64 CHashLinear<T, U>::GroupBy(
    MultiKeyEntry* pLocation = (MultiKeyEntry*)pHashTableAny;
 
    // make local reference on stack
-   UINT64* pBitFieldsX = pBitFields;
+   uint64_t* pBitFieldsX = pBitFields;
    if (pBoolFilter == NULL) {
       // make local reference on stack
 
       for (U i = 0; i < totalRows; i++) {
 
          const char* pMatch = pInput + (totalItemSize*i);
-         UINT64 hash = DEFAULT_HASH64(pMatch, totalItemSize);
+         uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
 
          // Use and mask to strip off high bits
          hash = hash & (HashSize - 1);
@@ -2321,7 +2321,7 @@ UINT64 CHashLinear<T, U>::GroupBy(
          if (pBoolFilter[i]) {
 
             const char* pMatch = pInput + (totalItemSize*i);
-            UINT64 hash = DEFAULT_HASH64(pMatch, totalItemSize);
+            uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
             // Use and mask to strip off high bits
             hash = hash & (HashSize - 1);
             while (1) {
@@ -2365,7 +2365,7 @@ UINT64 CHashLinear<T, U>::GroupBy(
       }
    }
 
-   LOGGING("%lld entries   hashSize %llu   %lld unique\n", totalRows, HashSize, (INT64)numUnique);
+   LOGGING("%lld entries   hashSize %llu   %lld unique\n", totalRows, HashSize, (int64_t)numUnique);
 
    // return to caller the first array that we reduced
    //*pFirstArrayObject = CopyToSmallerArray<U>(pFirstArray, numUnique, totalRows);
@@ -2381,9 +2381,9 @@ UINT64 CHashLinear<T, U>::GroupBy(
 // hintSize can be 0 which will default to totalRows
 // pBoolFilter can be NULL
 template<typename T, typename U>
-UINT64 CHashLinear<T, U>::GroupBySuper(
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t CHashLinear<T, U>::GroupBySuper(
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput,
 
    int coreType, // -1 when unknown  indicates only one array
@@ -2394,7 +2394,7 @@ UINT64 CHashLinear<T, U>::GroupBySuper(
    U* pUniqueArray,
    U* pUniqueCountArray,
    HASH_MODE hashMode,
-   INT64 hintSize,
+   int64_t hintSize,
    bool* pBoolFilter) {
 
    if (hintSize == 0) {
@@ -2417,16 +2417,16 @@ UINT64 CHashLinear<T, U>::GroupBySuper(
    //pUniqueArray[0] = GB_INVALID_INDEX;
 
    // make local reference on stack
-   UINT64* pBitFieldsX = pBitFields;
+   uint64_t* pBitFieldsX = pBitFields;
    if (pBoolFilter == NULL) {
       // make local reference on stack
 
       for (U i = 0; i < totalRows; i++) {
 
          const char* pMatch = pInput + (totalItemSize*i);
-         UINT64 hash = DEFAULT_HASH64(pMatch, totalItemSize);
-         //UINT64 hash = mHashOld(pMatch, totalItemSize);
-         //UINT64 hash = DEFAULT_HASH64(pMatch, totalItemSize);
+         uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
+         //uint64_t hash = mHashOld(pMatch, totalItemSize);
+         //uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
 
          //printf("%d", hash);
          // Use and mask to strip off high bits
@@ -2508,9 +2508,9 @@ UINT64 CHashLinear<T, U>::GroupBySuper(
          if (pBoolFilter[i]) {
 
             const char* pMatch = pInput + (totalItemSize*i);
-            UINT64 hash = DEFAULT_HASH64(pMatch, totalItemSize);
-            //UINT64 hash = mHashOld(pMatch, totalItemSize);
-            //UINT64 hash = DEFAULT_HASH64(pMatch, totalItemSize);
+            uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
+            //uint64_t hash = mHashOld(pMatch, totalItemSize);
+            //uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
 
             //printf("%d", hash);
             // Use and mask to strip off high bits
@@ -2616,9 +2616,9 @@ UINT64 CHashLinear<T, U>::GroupBySuper(
 // hintSize can be 0 which will default to totalRows
 // pBoolFilter option (can be NULL)
 template<typename T, typename U>
-UINT64 CHashLinear<T, U>::Unique(
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t CHashLinear<T, U>::Unique(
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput,
 
    // Return values
@@ -2629,7 +2629,7 @@ UINT64 CHashLinear<T, U>::Unique(
 
    // inpuys
    HASH_MODE hashMode,
-   INT64 hintSize,
+   int64_t hintSize,
    bool* pBoolFilter) {
 
    if (hintSize == 0) {
@@ -2655,7 +2655,7 @@ UINT64 CHashLinear<T, U>::Unique(
          // Make sure in the filter
          if (pBoolFilter[i]) {
             const char* pMatch = pInput + (totalItemSize*i);
-            UINT64 hash = DEFAULT_HASH64(pMatch, totalItemSize);
+            uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
             // Use and mask to strip off high bits
             hash = hash & (HashSize - 1);
             while (1) {
@@ -2703,7 +2703,7 @@ UINT64 CHashLinear<T, U>::Unique(
    else {
       for (U i = 0; i < totalRows; i++) {
          const char* pMatch = pInput + (totalItemSize*i);
-         UINT64 hash = DEFAULT_HASH64(pMatch, totalItemSize);
+         uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
          // Use and mask to strip off high bits
          hash = hash & (HashSize - 1);
          while (1) {
@@ -2747,7 +2747,7 @@ UINT64 CHashLinear<T, U>::Unique(
       }
    }
 
-   LOGGING("%llu entries   hashSize %lld    %lld unique\n", totalRows, (INT64)HashSize, (INT64)NumUnique);
+   LOGGING("%llu entries   hashSize %lld    %lld unique\n", totalRows, (int64_t)HashSize, (int64_t)NumUnique);
 
    return NumUnique;
 
@@ -2759,15 +2759,15 @@ UINT64 CHashLinear<T, U>::Unique(
 // Set hintSize < 0 if second pass so it will not allocate
 template<typename T, typename U>
 void CHashLinear<T, U>::MultiKeyRolling(
-   INT64 totalRows,
-   INT64 totalItemSize,
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput,
 
    // Return values
    U* pIndexArray,
    U* pRunningCountArray,
    HASH_MODE hashMode,
-   INT64 hintSize) {   // pass in -value to indicate reusing
+   int64_t hintSize) {   // pass in -value to indicate reusing
 
    if (totalItemSize > 16) { //sizeof(MultiKeyEntryRolling.Key))
       printf("!!!rolling key is too wide %lld\n", totalItemSize);
@@ -2792,7 +2792,7 @@ void CHashLinear<T, U>::MultiKeyRolling(
 
    for (U i = 0; i < totalRows; i++) {
       const char* pMatch = pInput + (totalItemSize*i);
-      UINT64 hash = DEFAULT_HASH64(pMatch, totalItemSize);
+      uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
 
       // Use and mask to strip off high bits
       hash = hash & (HashSize - 1);
@@ -2813,7 +2813,7 @@ void CHashLinear<T, U>::MultiKeyRolling(
             ++NumCollisions;
 
             // Bail on too many collisions (could return FALSE)
-            if ((INT64)NumCollisions > hintSize)
+            if ((int64_t)NumCollisions > hintSize)
                break;
 
             // Linear goes to next position
@@ -2846,8 +2846,8 @@ void CHashLinear<T, U>::MultiKeyRolling(
 // pBoolFilter can be NULL
 template<typename T, typename U>
 void CHashLinear<T, U>::MakeHashLocationMultiKey(
-   INT64 totalRows,
-   INT64 totalItemSize,
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput,
 
    // Return values
@@ -2857,12 +2857,12 @@ void CHashLinear<T, U>::MakeHashLocationMultiKey(
    U* pNextArray,
    U* pFirstArray,
    HASH_MODE hashMode,
-   INT64 hintSize,
+   int64_t hintSize,
    bool* pBoolFilter) {
 
-   //INT64 arraySize,
+   //int64_t arraySize,
    //const char* pHashList,
-   //INT32 strWidth) {
+   //int32_t strWidth) {
 
    if (hintSize == 0) {
       hintSize = totalRows;
@@ -2881,9 +2881,9 @@ void CHashLinear<T, U>::MakeHashLocationMultiKey(
 
    for (U i = 0; i < totalRows; i++) {
       const char* pMatch = pInput + (totalItemSize*i);
-      UINT64 hash = DEFAULT_HASH64(pMatch, totalItemSize);
-      //UINT64 hash = mHashOld(pMatch, totalItemSize);
-      //UINT64 hash = DEFAULT_HASH64(pMatch, totalItemSize);
+      uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
+      //uint64_t hash = mHashOld(pMatch, totalItemSize);
+      //uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
 
       //printf("%d", hash);
       // Use and mask to strip off high bits
@@ -2947,11 +2947,11 @@ void CHashLinear<T, U>::MakeHashLocationMultiKey(
 //
 template<typename T, typename U>
 void CHashLinear<T, U>::MakeHashLocationString(
-   INT64 arraySize,
+   int64_t arraySize,
    const char* pHashList,
-   INT64 strWidth,
-   INT64 hintSize,
-   BOOL  isUnicode) {
+   int64_t strWidth,
+   int64_t hintSize,
+   bool  isUnicode) {
 
    if (hintSize == 0) {
       hintSize = arraySize;
@@ -2969,7 +2969,7 @@ void CHashLinear<T, U>::MakeHashLocationString(
    }
 
    if (isUnicode) {
-      for (INT64 i = 0; i < arraySize; i++) {
+      for (int64_t i = 0; i < arraySize; i++) {
          HASH_UNICODE()
          // Use and mask to strip off high bits
          hash = hash & (HashSize - 1);
@@ -2977,7 +2977,7 @@ void CHashLinear<T, U>::MakeHashLocationString(
       }
    }
    else {
-      for (INT64 i = 0; i < arraySize; i++) {
+      for (int64_t i = 0; i < arraySize; i++) {
          HASH_STRING()
          // Use and mask to strip off high bits
          hash = hash & (HashSize - 1);
@@ -2997,8 +2997,8 @@ void CHashLinear<T, U>::InternalSetLocationString(
    U  i,
    HashLocation* pLocation,
    const char* strValue,
-   INT64 strWidth,
-   UINT64 hash) {
+   int64_t strWidth,
+   uint64_t hash) {
 
    //printf("**set %llu  width: %d  string: %s\n", hash, strWidth, strValue);
 
@@ -3028,7 +3028,7 @@ void CHashLinear<T, U>::InternalSetLocationString(
    SetBit(hash);
    ++NumUnique;
    pLocation[hash].Location = i;
-   pLocation[hash].value = (INT64)strValue;
+   pLocation[hash].value = (int64_t)strValue;
 
 }
 
@@ -3043,8 +3043,8 @@ void CHashLinear<T, U>::InternalSetLocationUnicode(
    U  i,
    HashLocation* pLocation,
    const char* strValue,
-   INT64 strWidth,
-   UINT64 hash) {
+   int64_t strWidth,
+   uint64_t hash) {
 
    //printf("**set %llu  width: %d  string: %s\n", hash, strWidth, strValue);
 
@@ -3074,7 +3074,7 @@ void CHashLinear<T, U>::InternalSetLocationUnicode(
    SetBit(hash);
    ++NumUnique;
    pLocation[hash].Location = i;
-   pLocation[hash].value = (INT64)strValue;
+   pLocation[hash].value = (int64_t)strValue;
 
 }
 
@@ -3088,13 +3088,13 @@ void CHashLinear<T, U>::InternalSetLocationUnicode(
 template <typename T, typename U>
 FORCE_INLINE
 void CHashLinear<T, U>::InternalGetLocationString(
-   INT64  i,
+   int64_t  i,
    HashLocation* pLocation,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    U*    pLocationOutput,
    const char* strValue,
-   INT64 strWidth,
-   UINT64 hash) {
+   int64_t strWidth,
+   uint64_t hash) {
 
    const U        BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
 
@@ -3104,7 +3104,7 @@ void CHashLinear<T, U>::InternalGetLocationString(
       if (STRING_MATCH((const char*)pLocation[hash].value, strValue, strWidth)) {
          // return the first location
          pLocationOutput[i] = pLocation[hash].Location;
-         pBooleanOutput[i] = 1;
+         pBoolOutput[i] = 1;
          return;
       }
 
@@ -3115,7 +3115,7 @@ void CHashLinear<T, U>::InternalGetLocationString(
    }
    // Not found
    pLocationOutput[i] = BAD_INDEX;
-   pBooleanOutput[i] = 0;
+   pBoolOutput[i] = 0;
 }
 
 
@@ -3128,13 +3128,13 @@ void CHashLinear<T, U>::InternalGetLocationString(
 template <typename T, typename U>
 FORCE_INLINE
 void CHashLinear<T, U>::InternalGetLocationUnicode(
-   INT64  i,
+   int64_t  i,
    HashLocation* pLocation,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    U*    pLocationOutput,
    const char* strValue,
-   INT64 strWidth,
-   UINT64 hash) {
+   int64_t strWidth,
+   uint64_t hash) {
 
    const U        BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
 
@@ -3144,7 +3144,7 @@ void CHashLinear<T, U>::InternalGetLocationUnicode(
       if (UNICODE_MATCH((const char*)pLocation[hash].value, strValue, strWidth)) {
          // return the first location
          pLocationOutput[i] = pLocation[hash].Location;
-         pBooleanOutput[i] = 1;
+         pBoolOutput[i] = 1;
          return;
       }
 
@@ -3155,7 +3155,7 @@ void CHashLinear<T, U>::InternalGetLocationUnicode(
    }
    // Not found
    pLocationOutput[i] = BAD_INDEX;
-   pBooleanOutput[i] = 0;
+   pBoolOutput[i] = 0;
 }
 
 
@@ -3168,14 +3168,14 @@ void CHashLinear<T, U>::InternalGetLocationUnicode(
 template <typename T, typename U>
 FORCE_INLINE
 void CHashLinear<T, U>::InternalGetLocationString2(
-   INT64  i,
+   int64_t  i,
    HashLocation* pLocation,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    U*    pLocationOutput,
    const char* strValue,
-   INT64 strWidth,
-   INT64 strWidth2,
-   UINT64 hash) {
+   int64_t strWidth,
+   int64_t strWidth2,
+   uint64_t hash) {
 
    const U        BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
 
@@ -3187,7 +3187,7 @@ void CHashLinear<T, U>::InternalGetLocationString2(
          //printf("match\n");
          // return the first location
          pLocationOutput[i] = pLocation[hash].Location;
-         pBooleanOutput[i] = 1;
+         pBoolOutput[i] = 1;
          return;
       }
 
@@ -3199,7 +3199,7 @@ void CHashLinear<T, U>::InternalGetLocationString2(
    }
    // Not found
    pLocationOutput[i] = BAD_INDEX;
-   pBooleanOutput[i] = 0;
+   pBoolOutput[i] = 0;
 }
 
 
@@ -3213,14 +3213,14 @@ void CHashLinear<T, U>::InternalGetLocationString2(
 template <typename T, typename U>
 FORCE_INLINE
 void CHashLinear<T, U>::InternalGetLocationUnicode2(
-   INT64  i,
+   int64_t  i,
    HashLocation* pLocation,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    U*    pLocationOutput,
    const char* strValue,
-   INT64 strWidth,
-   INT64 strWidth2,
-   UINT64 hash) {
+   int64_t strWidth,
+   int64_t strWidth2,
+   uint64_t hash) {
 
    const U        BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
 
@@ -3232,7 +3232,7 @@ void CHashLinear<T, U>::InternalGetLocationUnicode2(
          //printf("match\n");
          // return the first location
          pLocationOutput[i] = pLocation[hash].Location;
-         pBooleanOutput[i] = 1;
+         pBoolOutput[i] = 1;
          return;
       }
 
@@ -3244,7 +3244,7 @@ void CHashLinear<T, U>::InternalGetLocationUnicode2(
    }
    // Not found
    pLocationOutput[i] = BAD_INDEX;
-   pBooleanOutput[i] = 0;
+   pBoolOutput[i] = 0;
 }
 
 
@@ -3259,13 +3259,13 @@ void CHashLinear<T, U>::InternalGetLocationUnicode2(
 template <typename T, typename U>
 FORCE_INLINE
 void CHashLinear<T, U>::InternalGetLocationStringCategorical(
-   INT64  i,
+   int64_t  i,
    HashLocation* pLocation,
    U*    pLocationOutput,
    const char* strValue,
-   INT64 strWidth,
-   UINT64 hash,
-   INT64* missed) {
+   int64_t strWidth,
+   uint64_t hash,
+   int64_t* missed) {
 
    while (IsBitSet(hash)) {
       // Check if we have a match from before
@@ -3296,14 +3296,14 @@ void CHashLinear<T, U>::InternalGetLocationStringCategorical(
 template <typename T, typename U>
 FORCE_INLINE
 void CHashLinear<T, U>::InternalGetLocationString2Categorical(
-   INT64  i,
+   int64_t  i,
    HashLocation* pLocation,
    U*    pLocationOutput,
    const char* strValue,
-   INT64 strWidth,
-   INT64 strWidth2,
-   UINT64 hash,
-   INT64* missed) {
+   int64_t strWidth,
+   int64_t strWidth2,
+   uint64_t hash,
+   int64_t* missed) {
 
    while (IsBitSet(hash)) {
       // Check if we have a match from before
@@ -3337,14 +3337,14 @@ void CHashLinear<T, U>::InternalGetLocationString2Categorical(
 // strWidth2 was used in InternalSetLocationString and refers to second argument
 
 template<typename T, typename U>
-static INT64 IsMemberStringCategorical(
+static int64_t IsMemberStringCategorical(
    void* pHashLinearVoid,
-   INT64 arraySize,
-   INT64 strWidth,
-   INT64 strWidth2,
+   int64_t arraySize,
+   int64_t strWidth,
+   int64_t strWidth2,
    const char* pHashList,
    void*  pLocationOutputU,
-   BOOL   isUnicode) {
+   bool   isUnicode) {
 
    struct HashLocation
    {
@@ -3357,24 +3357,24 @@ static INT64 IsMemberStringCategorical(
    HashLocation* pLocation = (HashLocation*)pHashLinear->pHashTableAny;
    U* pLocationOutput = (U*)pLocationOutputU;
 
-   INT64 missed = 0;
-   UINT64 HashSize = pHashLinear->HashSize;
+   int64_t missed = 0;
+   uint64_t HashSize = pHashLinear->HashSize;
 
    // to determine if hash location has been visited
-   UINT64*     pBitFields = pHashLinear->pBitFields;
+   uint64_t*     pBitFields = pHashLinear->pBitFields;
 
    if (strWidth == strWidth2) {
       //-------------------------------------------------------------------
       // STRINGS are SAME SIZE --------------------------------------------
       if (isUnicode) {
-         for (INT64 i = 0; i < arraySize; i++) {
+         for (int64_t i = 0; i < arraySize; i++) {
             HASH_UNICODE()
 
             // Use and mask to strip off high bits
             hash = hash & (HashSize - 1);
 
             while (1) {
-               UINT64 index = hash >> 6;
+               uint64_t index = hash >> 6;
                if (pBitFields[index] & (1LL << (hash & 63))) {
                   // Check if we have a match from before
                   // Check if we have a match from before
@@ -3404,13 +3404,13 @@ static INT64 IsMemberStringCategorical(
       }
       else {
 
-         for (INT64 i = 0; i < arraySize; i++) {
+         for (int64_t i = 0; i < arraySize; i++) {
             HASH_STRING()
 
                // Use and mask to strip off high bits
                hash = hash & (HashSize - 1);
             while (1) {
-               UINT64 index = hash >> 6;
+               uint64_t index = hash >> 6;
                if (pBitFields[index] & (1LL << (hash & 63))) {
                   // Check if we have a match from before
                   if (STRING_MATCH((const char*)pLocation[hash].value, strStart, strWidth)) {
@@ -3441,14 +3441,14 @@ static INT64 IsMemberStringCategorical(
       //-------------------------------------------------------------------
       // STRINGS are DIFFERENT SIZE --------------------------------------------
       if (isUnicode) {
-         for (INT64 i = 0; i < arraySize; i++) {
+         for (int64_t i = 0; i < arraySize; i++) {
             HASH_UNICODE()
 
             // Use and mask to strip off high bits
             hash = hash & (pHashLinear->HashSize - 1);
 
             while (1) {
-               UINT64 index = hash >> 6;
+               uint64_t index = hash >> 6;
                if (pBitFields[index] & (1LL << (hash & 63))) {
                   // Check if we have a match from before
                   // Check if we have a match from before
@@ -3478,14 +3478,14 @@ static INT64 IsMemberStringCategorical(
       }
       else {
 
-         for (INT64 i = 0; i < arraySize; i++) {
+         for (int64_t i = 0; i < arraySize; i++) {
             HASH_STRING()
 
             // Use and mask to strip off high bits
             hash = hash & (pHashLinear->HashSize - 1);
 
             while (1) {
-               UINT64 index = hash >> 6;
+               uint64_t index = hash >> 6;
                if (pBitFields[index] & (1LL << (hash & 63))) {
                   // Check if we have a match from before
                   if (STRING_MATCH2((const char*)pLocation[hash].value, strStart, strWidth2, strWidth)) {
@@ -3519,7 +3519,7 @@ static INT64 IsMemberStringCategorical(
 
 
 //-----------------------------------------------
-// outputs boolean array
+// outputs bool array
 // outputs location array
 //
 // strWidth is the width for pHashList and the first argument called passed
@@ -3527,13 +3527,13 @@ static INT64 IsMemberStringCategorical(
 
 template<typename T, typename U>
 void CHashLinear<T, U>::IsMemberString(
-   INT64 arraySize,
-   INT64 strWidth,
-   INT64 strWidth2,
+   int64_t arraySize,
+   int64_t strWidth,
+   int64_t strWidth2,
    const char* pHashList,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    U*    pLocationOutput,
-   BOOL  isUnicode) {
+   bool  isUnicode) {
 
    HashLocation* pLocation = (HashLocation*)pHashTableAny;
 
@@ -3541,23 +3541,23 @@ void CHashLinear<T, U>::IsMemberString(
       //-------------------------------------------------------------------
       // STRINGS are SAME SIZE --------------------------------------------
       if (isUnicode) {
-         for (INT64 i = 0; i < arraySize; i++) {
+         for (int64_t i = 0; i < arraySize; i++) {
             HASH_UNICODE()
 
             // Use and mask to strip off high bits
             hash = hash & (HashSize - 1);
             //printf("**uni hash %lld\n", (long long)hash);
-            InternalGetLocationUnicode(i, pLocation, pBooleanOutput, pLocationOutput, strStart, strWidth,  hash);
+            InternalGetLocationUnicode(i, pLocation, pBoolOutput, pLocationOutput, strStart, strWidth,  hash);
          }
       }
       else {
 
-         for (INT64 i = 0; i < arraySize; i++) {
+         for (int64_t i = 0; i < arraySize; i++) {
             HASH_STRING()
 
             // Use and mask to strip off high bits
             hash = hash & (HashSize - 1);
-            InternalGetLocationString(i, pLocation, pBooleanOutput, pLocationOutput, strStart, strWidth,  hash);
+            InternalGetLocationString(i, pLocation, pBoolOutput, pLocationOutput, strStart, strWidth,  hash);
          }
       }
    }
@@ -3565,22 +3565,22 @@ void CHashLinear<T, U>::IsMemberString(
       //-------------------------------------------------------------------
       // STRINGS are DIFFERENT SIZE --------------------------------------------
       if (isUnicode) {
-         for (INT64 i = 0; i < arraySize; i++) {
+         for (int64_t i = 0; i < arraySize; i++) {
             HASH_UNICODE()
 
             // Use and mask to strip off high bits
             hash = hash & (HashSize - 1);
-            InternalGetLocationUnicode2(i, pLocation, pBooleanOutput, pLocationOutput, strStart, strWidth2, strWidth, hash);
+            InternalGetLocationUnicode2(i, pLocation, pBoolOutput, pLocationOutput, strStart, strWidth2, strWidth, hash);
          }
       }
       else {
 
-         for (INT64 i = 0; i < arraySize; i++) {
+         for (int64_t i = 0; i < arraySize; i++) {
             HASH_STRING()
 
             // Use and mask to strip off high bits
             hash = hash & (HashSize - 1);
-            InternalGetLocationString2(i, pLocation, pBooleanOutput, pLocationOutput, strStart, strWidth2, strWidth, hash);
+            InternalGetLocationString2(i, pLocation, pBoolOutput, pLocationOutput, strStart, strWidth2, strWidth, hash);
          }
       }
    }
@@ -3592,9 +3592,9 @@ void CHashLinear<T, U>::IsMemberString(
 
 typedef void(*ISMEMBER_MT)(
    void* pHashLinearVoid,
-   INT64 arraySize,
+   int64_t arraySize,
    void* pHashList,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    void* pLocationOutputU);
 
 //--------------------------------------------------------------------
@@ -3603,12 +3603,12 @@ struct IMMT_CALLBACK {
 
    void* pHashLinearVoid;
 
-   INT64 size1;
+   int64_t size1;
    void* pHashList;
-   INT8* pBooleanOutput;
+   int8_t* pBoolOutput;
    void* pOutput;
-   INT64 typeSizeIn;
-   INT64 typeSizeOut;
+   int64_t typeSizeIn;
+   int64_t typeSizeOut;
 
 } stIMMTCallback;
 
@@ -3616,23 +3616,23 @@ struct IMMT_CALLBACK {
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL IMMTThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
-   BOOL didSomeWork = FALSE;
+static bool IMMTThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
+   bool didSomeWork = FALSE;
    IMMT_CALLBACK* Callback = (IMMT_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    char* pInput1 = (char *)Callback->pHashList;
    char* pOutput = (char*)Callback->pOutput;
-   INT64 lenX;
-   INT64 workBlock;
+   int64_t lenX;
+   int64_t workBlock;
 
    // As long as there is work to do
    while ((lenX = pstWorkerItem->GetNextWorkBlock(&workBlock)) > 0) {
 
-      INT64 inputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeIn;
-      INT64 outputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeOut;
-      INT64 booleanAdj = pstWorkerItem->BlockSize * workBlock;
+      int64_t inputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeIn;
+      int64_t outputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeOut;
+      int64_t boolAdj = pstWorkerItem->BlockSize * workBlock;
 
-      Callback->anyIMMTCallback(Callback->pHashLinearVoid, lenX, pInput1 + inputAdj, Callback->pBooleanOutput + booleanAdj, pOutput + outputAdj);
+      Callback->anyIMMTCallback(Callback->pHashLinearVoid, lenX, pInput1 + inputAdj, Callback->pBoolOutput + boolAdj, pOutput + outputAdj);
 
       // Indicate we completed a block
       didSomeWork = TRUE;
@@ -3651,12 +3651,12 @@ static BOOL IMMTThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int cor
 static void IsMemberMultiThread(
    ISMEMBER_MT pFunction,
    void* pHashLinearVoid,
-   INT64 arraySize,
+   int64_t arraySize,
    void* pHashList,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    void* pLocationOutputU,
-   INT64 sizeInput,
-   INT64 sizeOutput) {
+   int64_t sizeInput,
+   int64_t sizeOutput) {
 
 
    stMATH_WORKER_ITEM* pWorkItem = g_cMathWorker->GetWorkItem(arraySize);
@@ -3664,7 +3664,7 @@ static void IsMemberMultiThread(
    if (pWorkItem == NULL) {
 
       // Threading not allowed for this work item, call it directly from main thread
-      pFunction(pHashLinearVoid, arraySize, pHashList, pBooleanOutput, pLocationOutputU);
+      pFunction(pHashLinearVoid, arraySize, pHashList, pBoolOutput, pLocationOutputU);
    }
    else {
       // Each thread will call this routine with the callbackArg
@@ -3676,7 +3676,7 @@ static void IsMemberMultiThread(
       stIMMTCallback.anyIMMTCallback = pFunction;
       stIMMTCallback.size1 = arraySize;
       stIMMTCallback.pHashList = pHashList;
-      stIMMTCallback.pBooleanOutput = pBooleanOutput;
+      stIMMTCallback.pBoolOutput = pBoolOutput;
       stIMMTCallback.pOutput = pLocationOutputU;
       stIMMTCallback.typeSizeIn = sizeInput;
       stIMMTCallback.typeSizeOut = sizeOutput;
@@ -3691,45 +3691,45 @@ static void IsMemberMultiThread(
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
-// floats are 4 bytes and will be handled like INT32 or UIN32
+// floats are 4 bytes and will be handled like int32_t or UIN32
 //
 //    First arg: existing  numpy array
 //    Second arg: existing  numpy array
 //    Third arg: hashmode (1 or 2)
 //
 // Returns in pOutput: index location of second arg -- where first arg found in second arg
-// Returns in pBooleanOutput: True if found, False otherwise
+// Returns in pBoolOutput: True if found, False otherwise
 template<typename U>
 void* IsMemberHash32(
-   INT64 size1,
+   int64_t size1,
    void* pInput1,
 
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
 
    U* pOutput,
 
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    INT sizeType,
    HASH_MODE hashMode,
-   INT64 hintSize) {
+   int64_t hintSize) {
 
 
    // Allocate hash
 
    switch (sizeType) {
    case 1: {
-      CHashLinear<UINT8, U>* pHashLinear = new CHashLinear<UINT8, U>(HASH_MODE_MASK);
-      pHashLinear->MakeHashLocation(size2, (UINT8*)pInput2, 256 / 2);
-      IsMemberMultiThread(IsMember<UINT8, U>, pHashLinear, size1, (UINT8*)pInput1, pBooleanOutput, (U*)pOutput, sizeof(UINT8), sizeof(U));
+      CHashLinear<uint8_t, U>* pHashLinear = new CHashLinear<uint8_t, U>(HASH_MODE_MASK);
+      pHashLinear->MakeHashLocation(size2, (uint8_t*)pInput2, 256 / 2);
+      IsMemberMultiThread(IsMember<uint8_t, U>, pHashLinear, size1, (uint8_t*)pInput1, pBoolOutput, (U*)pOutput, sizeof(uint8_t), sizeof(U));
       delete pHashLinear;
       return NULL;
    }
            break;
    case 2: {
-      CHashLinear<UINT16, U>* pHashLinear = new CHashLinear<UINT16, U>(HASH_MODE_MASK);
-      pHashLinear->MakeHashLocation(size2, (UINT16*)pInput2, 65536 / 2);
-      IsMemberMultiThread(IsMember<UINT16, U>, pHashLinear, size1, (UINT16*)pInput1, pBooleanOutput, (U*)pOutput, sizeof(UINT16), sizeof(U));
+      CHashLinear<uint16_t, U>* pHashLinear = new CHashLinear<uint16_t, U>(HASH_MODE_MASK);
+      pHashLinear->MakeHashLocation(size2, (uint16_t*)pInput2, 65536 / 2);
+      IsMemberMultiThread(IsMember<uint16_t, U>, pHashLinear, size1, (uint16_t*)pInput1, pBoolOutput, (U*)pOutput, sizeof(uint16_t), sizeof(U));
       delete pHashLinear;
       return NULL;
    }
@@ -3737,18 +3737,18 @@ void* IsMemberHash32(
 
    case 4:
    {
-      CHashLinear<UINT32, U>* pHashLinear = new CHashLinear<UINT32, U>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT32*)pInput2, hintSize);
-      IsMemberMultiThread(IsMember<UINT32, U>, pHashLinear, size1, (UINT32*)pInput1, pBooleanOutput, (U*)pOutput, sizeof(UINT32), sizeof(U));
+      CHashLinear<uint32_t, U>* pHashLinear = new CHashLinear<uint32_t, U>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint32_t*)pInput2, hintSize);
+      IsMemberMultiThread(IsMember<uint32_t, U>, pHashLinear, size1, (uint32_t*)pInput1, pBoolOutput, (U*)pOutput, sizeof(uint32_t), sizeof(U));
       delete pHashLinear;
       return NULL;
    }
    break;
    case 8:
    {
-      CHashLinear<UINT64, U>* pHashLinear = new CHashLinear<UINT64, U>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT64*)pInput2, hintSize);
-      IsMemberMultiThread(IsMember<UINT64, U>, pHashLinear, size1, (UINT64*)pInput1, pBooleanOutput, (U*)pOutput, sizeof(UINT64), sizeof(U));
+      CHashLinear<uint64_t, U>* pHashLinear = new CHashLinear<uint64_t, U>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint64_t*)pInput2, hintSize);
+      IsMemberMultiThread(IsMember<uint64_t, U>, pHashLinear, size1, (uint64_t*)pInput1, pBoolOutput, (U*)pOutput, sizeof(uint64_t), sizeof(U));
       delete pHashLinear;
       return NULL;
    }
@@ -3757,7 +3757,7 @@ void* IsMemberHash32(
    {
       CHashLinear<FLOAT, U>* pHashLinear = new CHashLinear<FLOAT, U>(hashMode);
       pHashLinear->MakeHashLocationFloat(size2, (FLOAT*)pInput2, hintSize);
-      IsMemberMultiThread(IsMemberFloat<FLOAT, U>, pHashLinear, size1, (FLOAT*)pInput1, pBooleanOutput, (U*)pOutput, sizeof(FLOAT), sizeof(U));
+      IsMemberMultiThread(IsMemberFloat<FLOAT, U>, pHashLinear, size1, (FLOAT*)pInput1, pBoolOutput, (U*)pOutput, sizeof(FLOAT), sizeof(U));
       delete pHashLinear;
       return NULL;
    }
@@ -3766,7 +3766,7 @@ void* IsMemberHash32(
    {
       CHashLinear<DOUBLE, U>* pHashLinear = new CHashLinear<DOUBLE, U>(hashMode);
       pHashLinear->MakeHashLocationFloat(size2, (DOUBLE*)pInput2, hintSize);
-      IsMemberMultiThread(IsMemberFloat<DOUBLE, U>, pHashLinear, size1, (DOUBLE*)pInput1, pBooleanOutput, (U*)pOutput, sizeof(DOUBLE), sizeof(U));
+      IsMemberMultiThread(IsMemberFloat<DOUBLE, U>, pHashLinear, size1, (DOUBLE*)pInput1, pBoolOutput, (U*)pOutput, sizeof(DOUBLE), sizeof(U));
       delete pHashLinear;
       return NULL;
    }
@@ -3785,31 +3785,31 @@ void* IsMemberHash32(
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
-// floats are + 100 and will be handled differnt from INT64 or UIN32
+// floats are + 100 and will be handled differnt from int64_t or UIN32
 void* IsMemberHash64(
-   INT64 size1,
+   int64_t size1,
    void* pInput1,
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
-   INT64* pOutput,
-   INT8* pBooleanOutput,
+   int64_t* pOutput,
+   int8_t* pBoolOutput,
    INT sizeType,
    HASH_MODE hashMode,
-   INT64 hintSize) {
+   int64_t hintSize) {
 
    switch (sizeType) {
    case 1: {
-      CHashLinear<UINT8, INT64>* pHashLinear = new CHashLinear<UINT8, INT64>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT8*)pInput2, hintSize);
-      IsMember<UINT8, INT64>(pHashLinear, size1, (UINT8*)pInput1, pBooleanOutput, (INT64*)pOutput);
+      CHashLinear<uint8_t, int64_t>* pHashLinear = new CHashLinear<uint8_t, int64_t>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint8_t*)pInput2, hintSize);
+      IsMember<uint8_t, int64_t>(pHashLinear, size1, (uint8_t*)pInput1, pBoolOutput, (int64_t*)pOutput);
       delete pHashLinear;
       return NULL;
    }
            break;
    case 2: {
-      CHashLinear<UINT16, INT64>* pHashLinear = new CHashLinear<UINT16, INT64>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT16*)pInput2, hintSize);
-      IsMember<UINT16, INT64>(pHashLinear, size1, (UINT16*)pInput1, pBooleanOutput, (INT64*)pOutput);
+      CHashLinear<uint16_t, int64_t>* pHashLinear = new CHashLinear<uint16_t, int64_t>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint16_t*)pInput2, hintSize);
+      IsMember<uint16_t, int64_t>(pHashLinear, size1, (uint16_t*)pInput1, pBoolOutput, (int64_t*)pOutput);
       delete pHashLinear;
       return NULL;
    }
@@ -3817,36 +3817,36 @@ void* IsMemberHash64(
 
    case 4:
    {
-      CHashLinear<UINT32, INT64>* pHashLinear = new CHashLinear<UINT32, INT64>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT32*)pInput2, hintSize);
-      IsMember<UINT32, INT64>(pHashLinear, size1, (UINT32*)pInput1, pBooleanOutput, (INT64*)pOutput);
+      CHashLinear<uint32_t, int64_t>* pHashLinear = new CHashLinear<uint32_t, int64_t>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint32_t*)pInput2, hintSize);
+      IsMember<uint32_t, int64_t>(pHashLinear, size1, (uint32_t*)pInput1, pBoolOutput, (int64_t*)pOutput);
       delete pHashLinear;
       return NULL;
    }
    break;
    case 8:
    {
-      CHashLinear<UINT64, INT64>* pHashLinear = new CHashLinear<UINT64, INT64>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT64*)pInput2, hintSize);
-      IsMember<UINT64, INT64>(pHashLinear, size1, (UINT64*)pInput1, pBooleanOutput, (INT64*)pOutput);
+      CHashLinear<uint64_t, int64_t>* pHashLinear = new CHashLinear<uint64_t, int64_t>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint64_t*)pInput2, hintSize);
+      IsMember<uint64_t, int64_t>(pHashLinear, size1, (uint64_t*)pInput1, pBoolOutput, (int64_t*)pOutput);
       delete pHashLinear;
       return NULL;
    }
    break;
    case 104:
    {
-      CHashLinear<FLOAT, INT64>* pHashLinear = new CHashLinear<FLOAT, INT64>(hashMode);
+      CHashLinear<FLOAT, int64_t>* pHashLinear = new CHashLinear<FLOAT, int64_t>(hashMode);
       pHashLinear->MakeHashLocationFloat(size2, (FLOAT*)pInput2, hintSize);
-      IsMemberFloat<FLOAT, INT64>(pHashLinear, size1, (FLOAT*)pInput1, pBooleanOutput, (INT64*)pOutput);
+      IsMemberFloat<FLOAT, int64_t>(pHashLinear, size1, (FLOAT*)pInput1, pBoolOutput, (int64_t*)pOutput);
       delete pHashLinear;
       return NULL;
    }
    break;
    case 108:
    {
-      CHashLinear<DOUBLE, INT64>* pHashLinear = new CHashLinear<DOUBLE, INT64>(hashMode);
+      CHashLinear<DOUBLE, int64_t>* pHashLinear = new CHashLinear<DOUBLE, int64_t>(hashMode);
       pHashLinear->MakeHashLocationFloat(size2, (DOUBLE*)pInput2, hintSize);
-      IsMemberFloat<DOUBLE, INT64>(pHashLinear, size1, (DOUBLE*)pInput1, pBooleanOutput, (INT64*)pOutput);
+      IsMemberFloat<DOUBLE, int64_t>(pHashLinear, size1, (DOUBLE*)pInput1, pBoolOutput, (int64_t*)pOutput);
       delete pHashLinear;
       return NULL;
    }
@@ -3861,42 +3861,42 @@ void* IsMemberHash64(
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
-// floats are 4 bytes and will be handled like INT32 or UIN32
+// floats are 4 bytes and will be handled like int32_t or UIN32
 //
 //    First arg: existing  numpy array
 //    Second arg: existing  numpy array
 //    Third arg: hashmode (1 or 2)
 //
 // Returns in pOutput: index location of second arg -- where first arg found in second arg
-// Returns in pBooleanOutput: True if found, False otherwise
-INT64 IsMemberHashCategorical(
-   INT64 size1,
+// Returns in pBoolOutput: True if found, False otherwise
+int64_t IsMemberHashCategorical(
+   int64_t size1,
    void* pInput1,
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
-   INT32* pOutput,
+   int32_t* pOutput,
    INT sizeType,
    HASH_MODE hashMode,
-   INT64 hintSize) {
+   int64_t hintSize) {
 
 
-   INT64 missed = 0;
+   int64_t missed = 0;
    // Allocate hash
 
    switch (sizeType) {
    case 1: {
-      CHashLinear<UINT8, INT32>* pHashLinear = new CHashLinear<UINT8, INT32>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT8*)pInput2, hintSize);
-      missed = pHashLinear->IsMemberCategorical(size1, (UINT8*)pInput1, pOutput);
+      CHashLinear<uint8_t, int32_t>* pHashLinear = new CHashLinear<uint8_t, int32_t>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint8_t*)pInput2, hintSize);
+      missed = pHashLinear->IsMemberCategorical(size1, (uint8_t*)pInput1, pOutput);
       delete pHashLinear;
       return missed;
    }
    break;
 
    case 2: {
-      CHashLinear<UINT16, INT32>* pHashLinear = new CHashLinear<UINT16, INT32>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT16*)pInput2, hintSize);
-      missed = pHashLinear->IsMemberCategorical(size1, (UINT16*)pInput1, pOutput);
+      CHashLinear<uint16_t, int32_t>* pHashLinear = new CHashLinear<uint16_t, int32_t>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint16_t*)pInput2, hintSize);
+      missed = pHashLinear->IsMemberCategorical(size1, (uint16_t*)pInput1, pOutput);
       delete pHashLinear;
       return missed;
    }
@@ -3904,25 +3904,25 @@ INT64 IsMemberHashCategorical(
 
    case 4:
    {
-      CHashLinear<UINT32, INT32>* pHashLinear = new CHashLinear<UINT32, INT32>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT32*)pInput2, hintSize);
-      missed = pHashLinear->IsMemberCategorical(size1, (UINT32*)pInput1, pOutput);
+      CHashLinear<uint32_t, int32_t>* pHashLinear = new CHashLinear<uint32_t, int32_t>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint32_t*)pInput2, hintSize);
+      missed = pHashLinear->IsMemberCategorical(size1, (uint32_t*)pInput1, pOutput);
       delete pHashLinear;
       return missed;
    }
    break;
    case 8:
    {
-      CHashLinear<UINT64, INT32>* pHashLinear = new CHashLinear<UINT64, INT32>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT64*)pInput2, hintSize);
-      missed = pHashLinear->IsMemberCategorical(size1, (UINT64*)pInput1, pOutput);
+      CHashLinear<uint64_t, int32_t>* pHashLinear = new CHashLinear<uint64_t, int32_t>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint64_t*)pInput2, hintSize);
+      missed = pHashLinear->IsMemberCategorical(size1, (uint64_t*)pInput1, pOutput);
       delete pHashLinear;
       return missed;
    }
    break;
    case 104:
    {
-      CHashLinear<FLOAT, INT32>* pHashLinear = new CHashLinear<FLOAT, INT32>(hashMode);
+      CHashLinear<FLOAT, int32_t>* pHashLinear = new CHashLinear<FLOAT, int32_t>(hashMode);
       pHashLinear->MakeHashLocationFloat(size2, (FLOAT*)pInput2, hintSize);
       missed = pHashLinear->IsMemberFloatCategorical(size1, (FLOAT*)pInput1, pOutput);
       delete pHashLinear;
@@ -3931,7 +3931,7 @@ INT64 IsMemberHashCategorical(
    break;
    case 108:
    {
-      CHashLinear<DOUBLE, INT32>* pHashLinear = new CHashLinear<DOUBLE, INT32>(hashMode);
+      CHashLinear<DOUBLE, int32_t>* pHashLinear = new CHashLinear<DOUBLE, int32_t>(hashMode);
       pHashLinear->MakeHashLocationFloat(size2, (DOUBLE*)pInput2, hintSize);
       missed = pHashLinear->IsMemberFloatCategorical(size1, (DOUBLE*)pInput1, pOutput);
       delete pHashLinear;
@@ -3940,7 +3940,7 @@ INT64 IsMemberHashCategorical(
    break;
    case 116:
    {
-      CHashLinear<long double, INT32>* pHashLinear = new CHashLinear<long double, INT32>(hashMode);
+      CHashLinear<long double, int32_t>* pHashLinear = new CHashLinear<long double, int32_t>(hashMode);
       pHashLinear->MakeHashLocationFloat(size2, (long double*)pInput2, hintSize);
       missed = pHashLinear->IsMemberFloatCategorical(size1, (long double*)pInput1, pOutput);
       delete pHashLinear;
@@ -3958,42 +3958,42 @@ INT64 IsMemberHashCategorical(
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
-// floats are 4 bytes and will be handled like INT32 or UIN32
+// floats are 4 bytes and will be handled like int32_t or UIN32
 //
 //    First arg: existing  numpy array
 //    Second arg: existing  numpy array
 //    Third arg: hashmode (1 or 2)
 //
 // Returns in pOutput: index location of second arg -- where first arg found in second arg
-// Returns in pBooleanOutput: True if found, False otherwise
-INT64 IsMemberHashCategorical64(
-   INT64 size1,
+// Returns in pBoolOutput: True if found, False otherwise
+int64_t IsMemberHashCategorical64(
+   int64_t size1,
    void* pInput1,
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
-   INT64* pOutput,
+   int64_t* pOutput,
    INT sizeType,
    HASH_MODE hashMode,
-   INT64 hintSize) {
+   int64_t hintSize) {
 
 
-   INT64 missed = 0;
+   int64_t missed = 0;
    // Allocate hash
 
    switch (sizeType) {
    case 1: {
-      CHashLinear<UINT8, INT64>* pHashLinear = new CHashLinear<UINT8, INT64>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT8*)pInput2, hintSize);
-      missed = pHashLinear->IsMemberCategorical(size1, (UINT8*)pInput1, pOutput);
+      CHashLinear<uint8_t, int64_t>* pHashLinear = new CHashLinear<uint8_t, int64_t>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint8_t*)pInput2, hintSize);
+      missed = pHashLinear->IsMemberCategorical(size1, (uint8_t*)pInput1, pOutput);
       delete pHashLinear;
       return missed;
    }
            break;
 
    case 2: {
-      CHashLinear<UINT16, INT64>* pHashLinear = new CHashLinear<UINT16, INT64>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT16*)pInput2, hintSize);
-      missed = pHashLinear->IsMemberCategorical(size1, (UINT16*)pInput1, pOutput);
+      CHashLinear<uint16_t, int64_t>* pHashLinear = new CHashLinear<uint16_t, int64_t>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint16_t*)pInput2, hintSize);
+      missed = pHashLinear->IsMemberCategorical(size1, (uint16_t*)pInput1, pOutput);
       delete pHashLinear;
       return missed;
    }
@@ -4001,25 +4001,25 @@ INT64 IsMemberHashCategorical64(
 
    case 4:
    {
-      CHashLinear<UINT32, INT64>* pHashLinear = new CHashLinear<UINT32, INT64>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT32*)pInput2, hintSize);
-      missed = pHashLinear->IsMemberCategorical(size1, (UINT32*)pInput1, pOutput);
+      CHashLinear<uint32_t, int64_t>* pHashLinear = new CHashLinear<uint32_t, int64_t>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint32_t*)pInput2, hintSize);
+      missed = pHashLinear->IsMemberCategorical(size1, (uint32_t*)pInput1, pOutput);
       delete pHashLinear;
       return missed;
    }
    break;
    case 8:
    {
-      CHashLinear<UINT64, INT64>* pHashLinear = new CHashLinear<UINT64, INT64>(hashMode);
-      pHashLinear->MakeHashLocation(size2, (UINT64*)pInput2, hintSize);
-      missed = pHashLinear->IsMemberCategorical(size1, (UINT64*)pInput1, pOutput);
+      CHashLinear<uint64_t, int64_t>* pHashLinear = new CHashLinear<uint64_t, int64_t>(hashMode);
+      pHashLinear->MakeHashLocation(size2, (uint64_t*)pInput2, hintSize);
+      missed = pHashLinear->IsMemberCategorical(size1, (uint64_t*)pInput1, pOutput);
       delete pHashLinear;
       return missed;
    }
    break;
    case 104:
    {
-      CHashLinear<FLOAT, INT64>* pHashLinear = new CHashLinear<FLOAT, INT64>(hashMode);
+      CHashLinear<FLOAT, int64_t>* pHashLinear = new CHashLinear<FLOAT, int64_t>(hashMode);
       pHashLinear->MakeHashLocationFloat(size2, (FLOAT*)pInput2, hintSize);
       missed = pHashLinear->IsMemberFloatCategorical(size1, (FLOAT*)pInput1, pOutput);
       delete pHashLinear;
@@ -4028,7 +4028,7 @@ INT64 IsMemberHashCategorical64(
    break;
    case 108:
    {
-      CHashLinear<DOUBLE, INT64>* pHashLinear = new CHashLinear<DOUBLE, INT64>(hashMode);
+      CHashLinear<DOUBLE, int64_t>* pHashLinear = new CHashLinear<DOUBLE, int64_t>(hashMode);
       pHashLinear->MakeHashLocationFloat(size2, (DOUBLE*)pInput2, hintSize);
       missed = pHashLinear->IsMemberFloatCategorical(size1, (DOUBLE*)pInput1, pOutput);
       delete pHashLinear;
@@ -4037,7 +4037,7 @@ INT64 IsMemberHashCategorical64(
    break;
    case 116:
    {
-      CHashLinear<long double, INT64>* pHashLinear = new CHashLinear<long double, INT64>(hashMode);
+      CHashLinear<long double, int64_t>* pHashLinear = new CHashLinear<long double, int64_t>(hashMode);
       pHashLinear->MakeHashLocationFloat(size2, (long double*)pInput2, hintSize);
       missed = pHashLinear->IsMemberFloatCategorical(size1, (long double*)pInput1, pOutput);
       delete pHashLinear;
@@ -4055,7 +4055,7 @@ INT64 IsMemberHashCategorical64(
 
 //===================================================================================================
 
-typedef INT64(*ISMEMBER_STRING)(void* pHashLinearVoid, INT64 arraySize, INT64 strWidth1, INT64 strWidth2, const char* pHashList, void*    pLocationOutputU, BOOL isUnicode);
+typedef int64_t(*ISMEMBER_STRING)(void* pHashLinearVoid, int64_t arraySize, int64_t strWidth1, int64_t strWidth2, const char* pHashList, void*    pLocationOutputU, bool isUnicode);
 
 //--------------------------------------------------------------------
 struct IMS_CALLBACK {
@@ -4063,16 +4063,16 @@ struct IMS_CALLBACK {
 
    void* pHashLinearVoid;
 
-   INT64 size1;
-   INT64 strWidth1;
+   int64_t size1;
+   int64_t strWidth1;
    const char* pInput1;
-   INT64 size2;
-   INT64 strWidth2;
+   int64_t size2;
+   int64_t strWidth2;
    void* pOutput;
-   INT64 typeSizeOut;
-   INT64 missed;
+   int64_t typeSizeOut;
+   int64_t missed;
 
-   BOOL  isUnicode;
+   bool  isUnicode;
 
 } stIMSCallback;
 
@@ -4080,23 +4080,23 @@ struct IMS_CALLBACK {
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL IMSThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
-   BOOL didSomeWork = FALSE;
+static bool IMSThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
+   bool didSomeWork = FALSE;
    IMS_CALLBACK* Callback = (IMS_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
-   BOOL isUnicode = Callback->isUnicode;
+   bool isUnicode = Callback->isUnicode;
    char* pInput1 = (char *)Callback->pInput1;
    char* pOutput = (char*)Callback->pOutput;
-   INT64 lenX;
-   INT64 workBlock;
+   int64_t lenX;
+   int64_t workBlock;
 
    // As long as there is work to do
    while ((lenX = pstWorkerItem->GetNextWorkBlock(&workBlock)) > 0) {
 
-      INT64 inputAdj = pstWorkerItem->BlockSize * workBlock * Callback->strWidth1;
-      INT64 outputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeOut;
+      int64_t inputAdj = pstWorkerItem->BlockSize * workBlock * Callback->strWidth1;
+      int64_t outputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeOut;
 
-      INT64 missed = Callback->anyIMSCallback(Callback->pHashLinearVoid, lenX, Callback->strWidth1, Callback->strWidth2, pInput1 + inputAdj, pOutput + outputAdj, isUnicode);
+      int64_t missed = Callback->anyIMSCallback(Callback->pHashLinearVoid, lenX, Callback->strWidth1, Callback->strWidth2, pInput1 + inputAdj, pOutput + outputAdj, isUnicode);
 
       // Careful with multithreading -- only set it to 1
       if (missed) {
@@ -4119,19 +4119,19 @@ static BOOL IMSThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
 template<typename U>
-INT64 IsMemberHashStringCategorical(
-   INT64 size1,
-   INT64 strWidth1,
+int64_t IsMemberHashStringCategorical(
+   int64_t size1,
+   int64_t strWidth1,
    const char* pInput1,
-   INT64 size2,
-   INT64 strWidth2,
+   int64_t size2,
+   int64_t strWidth2,
    const char* pInput2,
    U* pOutput,
    HASH_MODE hashMode,
-   INT64 hintSize,
-   BOOL isUnicode) {
+   int64_t hintSize,
+   bool isUnicode) {
 
-   CHashLinear<UINT64, U>* pHashLinear = new CHashLinear<UINT64, U>(hashMode);
+   CHashLinear<uint64_t, U>* pHashLinear = new CHashLinear<uint64_t, U>(hashMode);
 
    LOGGING("MakeHashLocationString  %lld  %p  strdwidth2: %lld  hashMode %d\n", size2, pInput2, strWidth2, (int)hashMode);
 
@@ -4142,10 +4142,10 @@ INT64 IsMemberHashStringCategorical(
 
    // Second pass find matches
    // We can multithread it
-   INT64 missed;
+   int64_t missed;
 
    stMATH_WORKER_ITEM* pWorkItem = g_cMathWorker->GetWorkItem(size1);
-   ISMEMBER_STRING pFunction = IsMemberStringCategorical<UINT64, U>;
+   ISMEMBER_STRING pFunction = IsMemberStringCategorical<uint64_t, U>;
 
    if (pWorkItem == NULL) {
 
@@ -4188,19 +4188,19 @@ INT64 IsMemberHashStringCategorical(
 //  Based on the sizeType it will call different hash functions
 template<typename U>
 void IsMemberHashString32(
-   INT64 size1,
-   INT64 strWidth1,
+   int64_t size1,
+   int64_t strWidth1,
    const char* pInput1,
-   INT64 size2,
-   INT64 strWidth2,
+   int64_t size2,
+   int64_t strWidth2,
    const char* pInput2,
    U* pOutput,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    HASH_MODE hashMode,
-   INT64 hintSize,
-   BOOL isUnicode) {
+   int64_t hintSize,
+   bool isUnicode) {
 
-   CHashLinear<UINT64, U>* pHashLinear = new CHashLinear<UINT64, U>(hashMode);
+   CHashLinear<uint64_t, U>* pHashLinear = new CHashLinear<uint64_t, U>(hashMode);
 
    LOGGING("MakeHashLocationString  %lld  %p  strdwidth2: %lld  hashMode %d\n", size2, pInput2, strWidth2, (int)hashMode);
 
@@ -4211,7 +4211,7 @@ void IsMemberHashString32(
 
    // Second pass find matches
    // We can multithread it
-   pHashLinear->IsMemberString(size1, strWidth1, strWidth2, pInput1, pBooleanOutput, pOutput, isUnicode);
+   pHashLinear->IsMemberString(size1, strWidth1, strWidth2, pInput1, pBoolOutput, pOutput, isUnicode);
 
    LOGGING("IsMemberHashString32  done\n");
 
@@ -4222,21 +4222,21 @@ void IsMemberHashString32(
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
 void IsMemberHashString64(
-   INT64 size1,
-   INT64 strWidth1,
+   int64_t size1,
+   int64_t strWidth1,
    const char* pInput1,
-   INT64 size2,
-   INT64 strWidth2,
+   int64_t size2,
+   int64_t strWidth2,
    const char* pInput2,
-   INT64* pOutput,
-   INT8* pBooleanOutput,
+   int64_t* pOutput,
+   int8_t* pBoolOutput,
    HASH_MODE hashMode,
-   INT64 hintSize,
-   BOOL isUnicode) {
+   int64_t hintSize,
+   bool isUnicode) {
 
-   CHashLinear<UINT64, INT64>* pHashLinear = new CHashLinear<UINT64, INT64>(hashMode);
+   CHashLinear<uint64_t, int64_t>* pHashLinear = new CHashLinear<uint64_t, int64_t>(hashMode);
    pHashLinear->MakeHashLocationString(size2, pInput2, strWidth2, hintSize, isUnicode);
-   pHashLinear->IsMemberString(size1, strWidth1, strWidth2, pInput1, pBooleanOutput, (INT64*)pOutput, isUnicode);
+   pHashLinear->IsMemberString(size1, strWidth1, strWidth2, pInput1, pBoolOutput, (int64_t*)pOutput, isUnicode);
    delete pHashLinear;
 }
 
@@ -4244,28 +4244,28 @@ void IsMemberHashString64(
 //-----------------------------------------------------------------------------------------
 // Returns 8/16/32/64 bit indexes
 template<typename KEY_TYPE>
-BOOL MergePreBinned(
-   INT64 size1,
+bool MergePreBinned(
+   int64_t size1,
    KEY_TYPE*    pKey1,
    void* pInVal1,
-   INT64 size2,
+   int64_t size2,
    KEY_TYPE*    pKey2,
    void* pInVal2,
    KEY_TYPE*    pOutput,
-   INT64 totalUniqueSize,
+   int64_t totalUniqueSize,
    HASH_MODE hashMode,
    INT dtype) {
 
-   BOOL success = TRUE;
+   bool success = TRUE;
 
    LOGGING("AlignCategorical32 dtype: %d  size1: %lld  size2: %lld\n", dtype, size1, size2);
 
    switch (dtype) {
    CASE_NPY_INT64:
-      FindLastMatchCategorical<KEY_TYPE, INT64>(size1, size2, pKey1, pKey2, (INT64*)pInVal1, (INT64*)pInVal2, pOutput, totalUniqueSize);
+      FindLastMatchCategorical<KEY_TYPE, int64_t>(size1, size2, pKey1, pKey2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalUniqueSize);
       break;
    CASE_NPY_INT32:
-      FindLastMatchCategorical<KEY_TYPE, INT32>(size1, size2, pKey1, pKey2, (INT32*)pInVal1, (INT32*)pInVal2, pOutput, totalUniqueSize);
+      FindLastMatchCategorical<KEY_TYPE, int32_t>(size1, size2, pKey1, pKey2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalUniqueSize);
       break;
    case NPY_FLOAT64:
       FindLastMatchCategorical<KEY_TYPE, double>(size1, size2, pKey1, pKey2, (double*)pInVal1, (double*)pInVal2, pOutput, totalUniqueSize);
@@ -4289,38 +4289,38 @@ BOOL MergePreBinned(
 //-----------------------------------------------------------------------------------------
 //-----------------------------------------------------------------------------------------
 // Returns 32 bit indexes
-BOOL AlignHashMK32(
-   INT64 size1,
+bool AlignHashMK32(
+   int64_t size1,
    void* pInput1,
    void* pInVal1,
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
    void* pInVal2,
-   INT32* pOutput,
-   INT64 totalItemSize,
+   int32_t* pOutput,
+   int64_t totalItemSize,
    HASH_MODE hashMode,
    INT dtype,
    bool isForward,
    bool allowExact) {
 
-   BOOL success = TRUE;
-   CHashLinear<char, INT32>* pHashLinear = new CHashLinear<char, INT32>(hashMode);
+   bool success = TRUE;
+   CHashLinear<char, int32_t>* pHashLinear = new CHashLinear<char, int32_t>(hashMode);
 
    switch (dtype) {
    CASE_NPY_INT64:
       if (isForward) {
-         pHashLinear->FindNextMatchMK<INT64>(size1, size2, (char*)pInput1, (char*)pInput2, (INT64*)pInVal1, (INT64*)pInVal2, pOutput, totalItemSize, allowExact);
+         pHashLinear->FindNextMatchMK<int64_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
       else {
-         pHashLinear->FindLastMatchMK<INT64>(size1, size2, (char*)pInput1, (char*)pInput2, (INT64*)pInVal1, (INT64*)pInVal2, pOutput, totalItemSize, allowExact);
+         pHashLinear->FindLastMatchMK<int64_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
       break;
    CASE_NPY_INT32:
       if (isForward) {
-         pHashLinear->FindNextMatchMK<INT32>(size1, size2, (char*)pInput1, (char*)pInput2, (INT32*)pInVal1, (INT32*)pInVal2, pOutput, totalItemSize, allowExact);
+         pHashLinear->FindNextMatchMK<int32_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
       else {
-         pHashLinear->FindLastMatchMK<INT32>(size1, size2, (char*)pInput1, (char*)pInput2, (INT32*)pInVal1, (INT32*)pInVal2, pOutput, totalItemSize, allowExact);
+         pHashLinear->FindLastMatchMK<int32_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
       break;
    case NPY_FLOAT64:
@@ -4350,40 +4350,40 @@ BOOL AlignHashMK32(
 
 //-----------------------------------------------------------------------------------------
 // Returns 64 bit indexes
-BOOL AlignHashMK64(
-   INT64 size1,
+bool AlignHashMK64(
+   int64_t size1,
    void* pInput1,
    void* pInVal1,
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
    void* pInVal2,
-   INT64* pOutput,
-   INT64 totalItemSize,
+   int64_t* pOutput,
+   int64_t totalItemSize,
    HASH_MODE hashMode,
    INT dtype,
    bool isForward,
    bool allowExact) {
 
 
-   BOOL success = TRUE;
-   CHashLinear<char, INT64>* pHashLinear = new CHashLinear<char, INT64>(hashMode);
+   bool success = TRUE;
+   CHashLinear<char, int64_t>* pHashLinear = new CHashLinear<char, int64_t>(hashMode);
 
    switch (dtype) {
    CASE_NPY_INT64:
       if (isForward) {
-         pHashLinear->FindNextMatchMK<INT64>(size1, size2, (char*)pInput1, (char*)pInput2, (INT64*)pInVal1, (INT64*)pInVal2, pOutput, totalItemSize, allowExact);
+         pHashLinear->FindNextMatchMK<int64_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
       else {
-         pHashLinear->FindLastMatchMK<INT64>(size1, size2, (char*)pInput1, (char*)pInput2, (INT64*)pInVal1, (INT64*)pInVal2, pOutput, totalItemSize, allowExact);
+         pHashLinear->FindLastMatchMK<int64_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
 
       break;
    CASE_NPY_INT32:
       if (isForward) {
-         pHashLinear->FindNextMatchMK<INT32>(size1, size2, (char*)pInput1, (char*)pInput2, (INT32*)pInVal1, (INT32*)pInVal2, pOutput, totalItemSize, allowExact);
+         pHashLinear->FindNextMatchMK<int32_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
       else {
-         pHashLinear->FindLastMatchMK<INT32>(size1, size2, (char*)pInput1, (char*)pInput2, (INT32*)pInVal1, (INT32*)pInVal2, pOutput, totalItemSize, allowExact);
+         pHashLinear->FindLastMatchMK<int32_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
       break;
    case NPY_FLOAT64:
@@ -4414,21 +4414,21 @@ BOOL AlignHashMK64(
 //----------------------------------------------
 // any non standard size
 template<typename HASH_TYPE, typename INDEX_TYPE>
-UINT64
+uint64_t
 DoLinearHash(
-   INT64 totalRows,
-   INT64 totalItemSize,
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,
    INDEX_TYPE* pIndexArray,
    void** pFirstArrayVoid,
    void** pHashTableAny,
-   INT64* hashTableSize,
+   int64_t* hashTableSize,
    HASH_MODE hashMode,
-   INT64  hintSize,
+   int64_t  hintSize,
    bool* pBoolFilter) {
 
-   UINT64 numUnique = 0;
+   uint64_t numUnique = 0;
    CHashLinear<HASH_TYPE, INDEX_TYPE>* pHashLinear = new CHashLinear<HASH_TYPE, INDEX_TYPE>(hashMode, FALSE);
    INDEX_TYPE* pFirstArray = (INDEX_TYPE*)pHashLinear->AllocMemory(hintSize, -2, sizeof(INDEX_TYPE) * (totalRows + 1), FALSE);
 
@@ -4447,21 +4447,21 @@ DoLinearHash(
 //----------------------------------------------
 // common float
 template<typename HASH_TYPE, typename INDEX_TYPE>
-UINT64
+uint64_t
 DoLinearHashFloat(
-   INT64 totalRows,
-   INT64 totalItemSize,
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,
    INDEX_TYPE* pIndexArray,
    void** pFirstArrayVoid,
    void** pHashTableAny,
-   INT64* hashTableSize,
+   int64_t* hashTableSize,
    HASH_MODE hashMode,
-   INT64  hintSize,
+   int64_t  hintSize,
    bool* pBoolFilter) {
 
-   UINT64 numUnique = 0;
+   uint64_t numUnique = 0;
    CHashLinear<HASH_TYPE, INDEX_TYPE>* pHashLinear = new CHashLinear<HASH_TYPE, INDEX_TYPE>(hashMode, FALSE);
    INDEX_TYPE* pFirstArray = (INDEX_TYPE*)pHashLinear->AllocMemory(hintSize, -1, sizeof(INDEX_TYPE) * (totalRows + 1), FALSE);
 
@@ -4479,21 +4479,21 @@ DoLinearHashFloat(
 //----------------------------------------------
 // common types non-float
 template<typename HASH_TYPE, typename INDEX_TYPE>
-UINT64
+uint64_t
 DoLinearHashItemSize(
-   INT64 totalRows,
-   INT64 totalItemSize,
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,  // This is the numpy type code, e.g. NPY_FLOAT32
    INDEX_TYPE* pIndexArray,
    void** pFirstArrayVoid,
    void** pHashTableAny,
-   INT64* hashTableSize,
+   int64_t* hashTableSize,
    HASH_MODE hashMode,
-   INT64  hintSize,
+   int64_t  hintSize,
    bool* pBoolFilter) {
 
-   UINT64 numUnique = 0;
+   uint64_t numUnique = 0;
 
    CHashLinear<HASH_TYPE, INDEX_TYPE>* pHashLinear = new CHashLinear<HASH_TYPE, INDEX_TYPE>(hashMode, FALSE);
    INDEX_TYPE* pFirstArray = (INDEX_TYPE*)pHashLinear->AllocMemory(hintSize, -1, sizeof(INDEX_TYPE) * (totalRows + 1), FALSE);
@@ -4516,22 +4516,22 @@ DoLinearHashItemSize(
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
 template<typename INDEX_TYPE>
-UINT64 GroupByInternal(
+uint64_t GroupByInternal(
    void** pFirstArray,
    void** pHashTableAny,
-   INT64* hashTableSize,
+   int64_t* hashTableSize,
 
-   INT64 totalRows,
-   INT64 totalItemSize,
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,
    INDEX_TYPE* pIndexArray,
    HASH_MODE hashMode,
-   INT64  hintSize,
+   int64_t  hintSize,
    bool* pBoolFilter) {
 
-   UINT64 numUnique = 0;
-   BOOL calculated = FALSE;
+   uint64_t numUnique = 0;
+   bool calculated = FALSE;
 
    if (hintSize == 0) {
       hintSize = totalRows;
@@ -4548,7 +4548,7 @@ UINT64 GroupByInternal(
    {
       // so that nans compare, we tell it is uint32
       numUnique =
-         DoLinearHashFloat<UINT32, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
+         DoLinearHashFloat<uint32_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
       calculated = TRUE;
    }
    break;
@@ -4556,7 +4556,7 @@ UINT64 GroupByInternal(
    {
       // so that nans compare, we tell it is uint64
       numUnique =
-         DoLinearHashFloat<UINT64, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
+         DoLinearHashFloat<uint64_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
       calculated = TRUE;
    }
    break;
@@ -4568,28 +4568,28 @@ UINT64 GroupByInternal(
       case 1:
       {
          numUnique =
-            DoLinearHashItemSize<UINT8, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, 256/2, pBoolFilter);
+            DoLinearHashItemSize<uint8_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, 256/2, pBoolFilter);
          calculated = TRUE;
       }
       break;
       case 2:
       {
          numUnique =
-            DoLinearHashItemSize<UINT16, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, 65536/2, pBoolFilter);
+            DoLinearHashItemSize<uint16_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, 65536/2, pBoolFilter);
          calculated = TRUE;
       }
       break;
       case 4:
       {
          numUnique =
-            DoLinearHashItemSize<UINT32, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
+            DoLinearHashItemSize<uint32_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
          calculated = TRUE;
       }
       break;
       case 8:
       {
          numUnique =
-            DoLinearHashItemSize<UINT64, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
+            DoLinearHashItemSize<uint64_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
          calculated = TRUE;
       }
       break;
@@ -4598,7 +4598,7 @@ UINT64 GroupByInternal(
 
    if (calculated == FALSE) {
       numUnique =
-         DoLinearHash<UINT32, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
+         DoLinearHash<uint32_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
    }
 
    return numUnique;
@@ -4607,22 +4607,22 @@ UINT64 GroupByInternal(
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
-UINT64 GroupBy32Super(
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t GroupBy32Super(
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,
-   INT32* pIndexArray,
-   INT32* pNextArray,
-   INT32* pUniqueArray,
-   INT32* pUniqueCountArray,
+   int32_t* pIndexArray,
+   int32_t* pNextArray,
+   int32_t* pUniqueArray,
+   int32_t* pUniqueCountArray,
    HASH_MODE hashMode,
-   INT64  hintSize,
+   int64_t  hintSize,
    bool* pBoolFilter) {
 
-   UINT64 numUnique = 0;
+   uint64_t numUnique = 0;
 
-   CHashLinear<UINT32, INT32>* pHashLinear = new CHashLinear<UINT32, INT32>(hashMode);
+   CHashLinear<uint32_t, int32_t>* pHashLinear = new CHashLinear<uint32_t, int32_t>(hashMode);
    numUnique =
       pHashLinear->GroupBySuper(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pNextArray, pUniqueArray, pUniqueCountArray, hashMode, hintSize, pBoolFilter);
    delete pHashLinear;
@@ -4633,21 +4633,21 @@ UINT64 GroupBy32Super(
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
-UINT64 GroupBy64Super(
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t GroupBy64Super(
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,
-   INT64* pIndexArray,
-   INT64* pNextArray,
-   INT64* pUniqueArray,
-   INT64* pUniqueCountArray,
+   int64_t* pIndexArray,
+   int64_t* pNextArray,
+   int64_t* pUniqueArray,
+   int64_t* pUniqueCountArray,
    HASH_MODE hashMode,
-   INT64  hintSize,
+   int64_t  hintSize,
    bool* pBoolFilter) {
 
-   CHashLinear<UINT64, INT64>* pHashLinear = new CHashLinear<UINT64, INT64>(hashMode);
-   UINT64 numUnique =
+   CHashLinear<uint64_t, int64_t>* pHashLinear = new CHashLinear<uint64_t, int64_t>(hashMode);
+   uint64_t numUnique =
       pHashLinear->GroupBySuper(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pNextArray, pUniqueArray, pUniqueCountArray, hashMode, hintSize, pBoolFilter);
 
    delete pHashLinear;
@@ -4658,19 +4658,19 @@ UINT64 GroupBy64Super(
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
-UINT64 Unique32(
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t Unique32(
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
 
-   INT32* pIndexArray,
-   INT32* pCountArray,
+   int32_t* pIndexArray,
+   int32_t* pCountArray,
    HASH_MODE hashMode,
-   INT64  hintSize,
+   int64_t  hintSize,
    bool* pBoolFilter) {
 
-   CHashLinear<UINT32, INT32>* pHashLinear = new CHashLinear<UINT32, INT32>(hashMode);
-   UINT64 numUnique =
+   CHashLinear<uint32_t, int32_t>* pHashLinear = new CHashLinear<uint32_t, int32_t>(hashMode);
+   uint64_t numUnique =
       pHashLinear->Unique(totalRows, totalItemSize, pInput1, pIndexArray, pCountArray, hashMode, hintSize, pBoolFilter);
 
    delete pHashLinear;
@@ -4680,19 +4680,19 @@ UINT64 Unique32(
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
-UINT64 Unique64(
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t Unique64(
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
 
-   INT64* pIndexArray,
-   INT64* pCountArray,
+   int64_t* pIndexArray,
+   int64_t* pCountArray,
    HASH_MODE hashMode,
-   INT64  hintSize,
+   int64_t  hintSize,
    bool* pBoolFilter) {
 
-   CHashLinear<UINT32, INT64>* pHashLinear = new CHashLinear<UINT32, INT64>(hashMode);
-   UINT64 numUnique =
+   CHashLinear<uint32_t, int64_t>* pHashLinear = new CHashLinear<uint32_t, int64_t>(hashMode);
+   uint64_t numUnique =
       pHashLinear->Unique(totalRows, totalItemSize, pInput1, pIndexArray, pCountArray, hashMode, hintSize, pBoolFilter);
 
    delete pHashLinear;
@@ -4702,11 +4702,11 @@ UINT64 Unique64(
 //-----------------------------------------------------------------------------------------
 void MultiKeyRollingStep2Delete(
    void* pHashLinearLast) {
-   CHashLinear<UINT64, INT64>* pHashLinear;
+   CHashLinear<uint64_t, int64_t>* pHashLinear;
 
    // If we are rolling, they will pass back what we returned
    if (pHashLinearLast) {
-      pHashLinear = (CHashLinear<UINT64, INT64>*)pHashLinearLast;
+      pHashLinear = (CHashLinear<uint64_t, int64_t>*)pHashLinearLast;
       delete pHashLinear;
    }
 }
@@ -4714,27 +4714,27 @@ void MultiKeyRollingStep2Delete(
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
 void* MultiKeyRollingStep2(
-   INT64 totalRows,
-   INT64 totalItemSize,
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
 
-   INT64* pIndexArray,
-   INT64* pRunningCountArray,
+   int64_t* pIndexArray,
+   int64_t* pRunningCountArray,
    HASH_MODE hashMode,
-   INT64 hintSize,
-   UINT64* numUnique,     // returned back
+   int64_t hintSize,
+   uint64_t* numUnique,     // returned back
    void* pHashLinearLast) {
 
-   CHashLinear<UINT64, INT64>* pHashLinear;
+   CHashLinear<uint64_t, int64_t>* pHashLinear;
 
    // If we are rolling, they will pass back what we returned
    if (pHashLinearLast) {
-      pHashLinear = (CHashLinear<UINT64, INT64>*)pHashLinearLast;
+      pHashLinear = (CHashLinear<uint64_t, int64_t>*)pHashLinearLast;
       hintSize = -1;
       LOGGING("Rolling using existing! %llu\n", pHashLinear->NumUnique);
    }
    else {
-      pHashLinear  = new CHashLinear<UINT64, INT64>(hashMode);
+      pHashLinear  = new CHashLinear<uint64_t, int64_t>(hashMode);
    }
 
    pHashLinear->MultiKeyRolling(totalRows, totalItemSize, pInput1, pIndexArray, pRunningCountArray, hashMode, hintSize);
@@ -4748,20 +4748,20 @@ void* MultiKeyRollingStep2(
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
 void* MultiKeyHash32(
-   INT64 totalRows,
-   INT64 totalItemSize,
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
 
-   INT32* pIndexArray,
-   INT32* pRunningCountArray,
-   INT32* pPrevArray,
-   INT32* pNextArray,
-   INT32* pFirstArray,
+   int32_t* pIndexArray,
+   int32_t* pRunningCountArray,
+   int32_t* pPrevArray,
+   int32_t* pNextArray,
+   int32_t* pFirstArray,
    HASH_MODE hashMode,
-   INT64 hintSize,
+   int64_t hintSize,
    bool* pBoolFilter) {
 
-   CHashLinear<UINT32, INT32>* pHashLinear = new CHashLinear<UINT32, INT32>(hashMode);
+   CHashLinear<uint32_t, int32_t>* pHashLinear = new CHashLinear<uint32_t, int32_t>(hashMode);
    pHashLinear->MakeHashLocationMultiKey(totalRows, totalItemSize, pInput1, pIndexArray, pRunningCountArray, pPrevArray, pNextArray, pFirstArray, hashMode, hintSize, pBoolFilter);
    delete pHashLinear;
    return NULL;
@@ -4771,20 +4771,20 @@ void* MultiKeyHash32(
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
 void* MultiKeyHash64(
-   INT64 totalRows,
-   INT64 totalItemSize,
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
 
-   INT64* pIndexArray,
-   INT64* pRunningCountArray,
-   INT64* pPrevArray,
-   INT64* pNextArray,
-   INT64* pFirstArray,
+   int64_t* pIndexArray,
+   int64_t* pRunningCountArray,
+   int64_t* pPrevArray,
+   int64_t* pNextArray,
+   int64_t* pFirstArray,
    HASH_MODE hashMode,
-   INT64 hintSize,
+   int64_t hintSize,
    bool* pBoolFilter) {
 
-   CHashLinear<UINT32, INT64>* pHashLinear = new CHashLinear<UINT32, INT64>(hashMode);
+   CHashLinear<uint32_t, int64_t>* pHashLinear = new CHashLinear<uint32_t, int64_t>(hashMode);
    pHashLinear->MakeHashLocationMultiKey(totalRows, totalItemSize, pInput1, pIndexArray, pRunningCountArray, pPrevArray, pNextArray, pFirstArray, hashMode, hintSize, pBoolFilter);
    delete pHashLinear;
    return NULL;
@@ -4799,44 +4799,44 @@ void* MultiKeyHash64(
 void IsMemberHashString32Pre(
    PyArrayObject** indexArray,
    PyArrayObject* inArr1,
-   INT64 size1,
-   INT64 strWidth1,
+   int64_t size1,
+   int64_t strWidth1,
    const char* pInput1,
-   INT64 size2,
-   INT64 strWidth2,
+   int64_t size2,
+   int64_t strWidth2,
    const char* pInput2,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    HASH_MODE hashMode,
-   INT64 hintSize,
-   BOOL isUnicode) {
+   int64_t hintSize,
+   bool isUnicode) {
 
-   INT64 size = size1;
+   int64_t size = size1;
    if (size2 > size) {
       size = size2;
    }
 
    if (size < 100) {
       *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT8);
-      INT8* pDataOut2 = (INT8*)PyArray_BYTES(*indexArray);
-      IsMemberHashString32<INT8>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, pBooleanOutput, HASH_MODE(hashMode), hintSize, isUnicode);
+      int8_t* pDataOut2 = (int8_t*)PyArray_BYTES(*indexArray);
+      IsMemberHashString32<int8_t>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, pBoolOutput, HASH_MODE(hashMode), hintSize, isUnicode);
 
    }
    else if (size < 30000) {
       *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT16);
-      INT16* pDataOut2 = (INT16*)PyArray_BYTES(*indexArray);
-      IsMemberHashString32<INT16>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, pBooleanOutput, HASH_MODE(hashMode), hintSize, isUnicode);
+      int16_t* pDataOut2 = (int16_t*)PyArray_BYTES(*indexArray);
+      IsMemberHashString32<int16_t>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, pBoolOutput, HASH_MODE(hashMode), hintSize, isUnicode);
 
    }
    else if (size < 2000000000) {
       *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
-      INT32* pDataOut2 = (INT32*)PyArray_BYTES(*indexArray);
-      IsMemberHashString32<INT32>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, pBooleanOutput, HASH_MODE(hashMode), hintSize, isUnicode);
+      int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(*indexArray);
+      IsMemberHashString32<int32_t>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, pBoolOutput, HASH_MODE(hashMode), hintSize, isUnicode);
 
    }
    else {
       *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT64);
-      INT64* pDataOut2 = (INT64*)PyArray_BYTES(*indexArray);
-      IsMemberHashString32<INT64>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, pBooleanOutput, HASH_MODE(hashMode), hintSize, isUnicode);
+      int64_t* pDataOut2 = (int64_t*)PyArray_BYTES(*indexArray);
+      IsMemberHashString32<int64_t>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, pBoolOutput, HASH_MODE(hashMode), hintSize, isUnicode);
    }
 
 }
@@ -4846,43 +4846,43 @@ void IsMemberHashString32Pre(
 //-----------------------------------------------------------------------------------------
 // Should follow categorical size checks
 //
-INT64 IsMemberCategoricalHashStringPre(
+int64_t IsMemberCategoricalHashStringPre(
    PyArrayObject** indexArray,
    PyArrayObject* inArr1,
-   INT64 size1,
-   INT64 strWidth1,
+   int64_t size1,
+   int64_t strWidth1,
    const char* pInput1,
-   INT64 size2,
-   INT64 strWidth2,
+   int64_t size2,
+   int64_t strWidth2,
    const char* pInput2,
    HASH_MODE hashMode,
-   INT64 hintSize,
-   BOOL isUnicode) {
+   int64_t hintSize,
+   bool isUnicode) {
 
-   INT64 missed = 0;
+   int64_t missed = 0;
 
    if (size2 < 100) {
       *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT8);
-      INT8* pDataOut2 = (INT8*)PyArray_BYTES(*indexArray);
-      missed = IsMemberHashStringCategorical<INT8>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, HASH_MODE(hashMode), hintSize, isUnicode);
+      int8_t* pDataOut2 = (int8_t*)PyArray_BYTES(*indexArray);
+      missed = IsMemberHashStringCategorical<int8_t>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, HASH_MODE(hashMode), hintSize, isUnicode);
 
    }
    else if (size2 < 30000) {
       *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT16);
-      INT16* pDataOut2 = (INT16*)PyArray_BYTES(*indexArray);
-      missed = IsMemberHashStringCategorical<INT16>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, HASH_MODE(hashMode), hintSize, isUnicode);
+      int16_t* pDataOut2 = (int16_t*)PyArray_BYTES(*indexArray);
+      missed = IsMemberHashStringCategorical<int16_t>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, HASH_MODE(hashMode), hintSize, isUnicode);
 
    }
    else if (size2 < 2000000000) {
       *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
-      INT32* pDataOut2 = (INT32*)PyArray_BYTES(*indexArray);
-      missed = IsMemberHashStringCategorical<INT32>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, HASH_MODE(hashMode), hintSize, isUnicode);
+      int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(*indexArray);
+      missed = IsMemberHashStringCategorical<int32_t>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, HASH_MODE(hashMode), hintSize, isUnicode);
 
    }
    else {
       *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT64);
-      INT64* pDataOut2 = (INT64*)PyArray_BYTES(*indexArray);
-      missed = IsMemberHashStringCategorical<INT64>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, HASH_MODE(hashMode), hintSize, isUnicode);
+      int64_t* pDataOut2 = (int64_t*)PyArray_BYTES(*indexArray);
+      missed = IsMemberHashStringCategorical<int64_t>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, HASH_MODE(hashMode), hintSize, isUnicode);
 
    }
 
@@ -4894,12 +4894,12 @@ INT64 IsMemberCategoricalHashStringPre(
 
 typedef void(*ISMEMBER_MK)(
    void* pHashLinearVoid,
-   INT64 arraySize,
+   int64_t arraySize,
    void* pInputT,
    void* pInput2T,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    void* pLocationOutputU,
-   INT64 totalItemSize);
+   int64_t totalItemSize);
 
 //--------------------------------------------------------------------
 struct IMMK_CALLBACK {
@@ -4907,14 +4907,14 @@ struct IMMK_CALLBACK {
 
    void* pHashLinearVoid;
 
-   INT64 size1;
+   int64_t size1;
    void* pInput1;
-   INT64 size2;         // size of the second argument
+   int64_t size2;         // size of the second argument
    void* pInput2;
-   INT8* pBooleanOutput;
+   int8_t* pBoolOutput;
    void* pOutput;
-   INT64 totalItemSize;
-   INT64 typeSizeOut;
+   int64_t totalItemSize;
+   int64_t typeSizeOut;
 
 } stIMMKCallback;
 
@@ -4922,23 +4922,23 @@ struct IMMK_CALLBACK {
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL IMMKThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
-   BOOL didSomeWork = FALSE;
+static bool IMMKThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
+   bool didSomeWork = FALSE;
    IMMK_CALLBACK* Callback = (IMMK_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    char* pInput1 = (char *)Callback->pInput1;
    char* pOutput = (char*)Callback->pOutput;
-   INT64 lenX;
-   INT64 workBlock;
+   int64_t lenX;
+   int64_t workBlock;
 
    // As long as there is work to do
    while ((lenX = pstWorkerItem->GetNextWorkBlock(&workBlock)) > 0) {
 
-      INT64 inputAdj = pstWorkerItem->BlockSize * workBlock * Callback->totalItemSize;
-      INT64 outputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeOut;
-      INT64 booleanAdj = pstWorkerItem->BlockSize * workBlock ;
+      int64_t inputAdj = pstWorkerItem->BlockSize * workBlock * Callback->totalItemSize;
+      int64_t outputAdj = pstWorkerItem->BlockSize * workBlock * Callback->typeSizeOut;
+      int64_t boolAdj = pstWorkerItem->BlockSize * workBlock ;
 
-      Callback->anyIMMKCallback(Callback->pHashLinearVoid, lenX, pInput1 + inputAdj, Callback->pInput2, Callback->pBooleanOutput + booleanAdj, pOutput + outputAdj, Callback->totalItemSize);
+      Callback->anyIMMKCallback(Callback->pHashLinearVoid, lenX, pInput1 + inputAdj, Callback->pInput2, Callback->pBoolOutput + boolAdj, pOutput + outputAdj, Callback->totalItemSize);
 
       // Indicate we completed a block
       didSomeWork = TRUE;
@@ -4957,14 +4957,14 @@ static BOOL IMMKThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int cor
 //  Based on the sizeType it will call different hash functions
 template<typename U>
 void IsMemberHashMK(
-   INT64 size1,
+   int64_t size1,
    void* pInput1,
-   INT64 size2,         // size of the second argument
+   int64_t size2,         // size of the second argument
    void* pInput2,
-   INT8* pBooleanOutput,
+   int8_t* pBoolOutput,
    U*    pOutput,
-   INT64 totalItemSize,
-   INT64 hintSize,
+   int64_t totalItemSize,
+   int64_t hintSize,
    HASH_MODE hashMode) {
 
    LOGGING("ismember hash  sz1:%lld  sz2:%lld   totalitemsize:%lld  %p  %p\n", size1, size2, totalItemSize, pInput1, pInput2);
@@ -4978,7 +4978,7 @@ void IsMemberHashMK(
    if (pWorkItem == NULL) {
 
       // Threading not allowed for this work item, call it directly from main thread
-      pFunction(pHashLinear, size1, (char*)pInput1, (char*)pInput2, pBooleanOutput, pOutput, totalItemSize);
+      pFunction(pHashLinear, size1, (char*)pInput1, (char*)pInput2, pBoolOutput, pOutput, totalItemSize);
 
    }
    else {
@@ -4993,7 +4993,7 @@ void IsMemberHashMK(
       stIMMKCallback.pInput1 = pInput1;
       stIMMKCallback.size2 = size2;
       stIMMKCallback.pInput2 = pInput2;
-      stIMMKCallback.pBooleanOutput = pBooleanOutput;
+      stIMMKCallback.pBoolOutput = pBoolOutput;
       stIMMKCallback.pOutput = pOutput;
       stIMMKCallback.totalItemSize = totalItemSize;
       stIMMKCallback.typeSizeOut = sizeof(U);
@@ -5013,20 +5013,20 @@ void IsMemberHashMK(
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
-// floats are 4 bytes and will be handled like INT32 or UIN32
+// floats are 4 bytes and will be handled like int32_t or UIN32
 void IsMemberHashMKPre(
    PyArrayObject** indexArray,
-   INT64 size1,
+   int64_t size1,
    void* pInput1,
-   INT64 size2,         // size of the second argument
+   int64_t size2,         // size of the second argument
    void* pInput2,
-   INT8* pBooleanOutput,
-   INT64 totalItemSize,
-   INT64 hintSize,
+   int8_t* pBoolOutput,
+   int64_t totalItemSize,
+   int64_t hintSize,
    HASH_MODE hashMode) {
 
 
-   INT64 size = size1;
+   int64_t size = size1;
 
    if (size2 > size1) {
       size = size2;
@@ -5037,29 +5037,29 @@ void IsMemberHashMKPre(
    if (size < 100) {
       *indexArray = AllocateNumpyArray(1, (npy_intp*)&size1, NPY_INT8);
       if (*indexArray) {
-         INT8* pOutput = (INT8*)PyArray_BYTES(*indexArray);
-         IsMemberHashMK<INT8>(size1, pInput1, size2, pInput2, pBooleanOutput, pOutput, totalItemSize, hintSize, hashMode);
+         int8_t* pOutput = (int8_t*)PyArray_BYTES(*indexArray);
+         IsMemberHashMK<int8_t>(size1, pInput1, size2, pInput2, pBoolOutput, pOutput, totalItemSize, hintSize, hashMode);
       }
    }
    else if (size < 30000) {
       *indexArray = AllocateNumpyArray(1, (npy_intp*)&size1, NPY_INT16);
       if (*indexArray) {
-         INT16* pOutput = (INT16*)PyArray_BYTES(*indexArray);
-         IsMemberHashMK<INT16>(size1, pInput1, size2, pInput2, pBooleanOutput, pOutput, totalItemSize, hintSize, hashMode);
+         int16_t* pOutput = (int16_t*)PyArray_BYTES(*indexArray);
+         IsMemberHashMK<int16_t>(size1, pInput1, size2, pInput2, pBoolOutput, pOutput, totalItemSize, hintSize, hashMode);
       }
    }
    else if (size < 2000000000) {
       *indexArray = AllocateNumpyArray(1, (npy_intp*)&size1, NPY_INT32);
       if (*indexArray) {
-         INT32* pOutput = (INT32*)PyArray_BYTES(*indexArray);
-         IsMemberHashMK<INT32>(size1, pInput1, size2, pInput2, pBooleanOutput, pOutput, totalItemSize, hintSize, hashMode);
+         int32_t* pOutput = (int32_t*)PyArray_BYTES(*indexArray);
+         IsMemberHashMK<int32_t>(size1, pInput1, size2, pInput2, pBoolOutput, pOutput, totalItemSize, hintSize, hashMode);
       }
    }
    else {
       *indexArray = AllocateNumpyArray(1, (npy_intp*)&size1, NPY_INT64);
       if (*indexArray) {
-         INT64* pOutput = (INT64*)PyArray_BYTES(*indexArray);
-         IsMemberHashMK<INT64>(size1, pInput1, size2, pInput2, pBooleanOutput, pOutput, totalItemSize, hintSize, hashMode);
+         int64_t* pOutput = (int64_t*)PyArray_BYTES(*indexArray);
+         IsMemberHashMK<int64_t>(size1, pInput1, size2, pInput2, pBoolOutput, pOutput, totalItemSize, hintSize, hashMode);
       }
    }
    CHECK_MEMORY_ERROR(*indexArray);
@@ -5086,8 +5086,8 @@ void IsMemberHashMKPre(
 //    Second arg: existing  numpy array
 //    Third arg: hashmode (1 or 2)
 //    Fourth arg: <optional> hashSize (default to 0)
-//    Returns: boolean array and optional INT32 location array
-//       boolean array: True if first arg found in second arg
+//    Returns: bool array and optional int32_t location array
+//       bool array: True if first arg found in second arg
 //       index: index location of where first arg found in second arg  (index into second arg)
 
 /*
@@ -5139,7 +5139,7 @@ IsMember32(PyObject *self, PyObject *args)
    PyArrayObject *inArr1 = NULL;
    PyArrayObject *inArr2 = NULL;
    int hashMode = 2;
-   INT64 hintSize = 0;
+   int64_t hintSize = 0;
 
    Py_ssize_t tupleSize = PyTuple_GET_SIZE(args);
 
@@ -5159,8 +5159,8 @@ IsMember32(PyObject *self, PyObject *args)
       if (!PyArg_ParseTuple(args, "O!O!iL", &PyArray_Type, &inArr1, &PyArray_Type, &inArr2, &hashMode, &hintSize)) return NULL;
 
    }
-   INT32 arrayType1 = PyArray_TYPE(inArr1);
-   INT32 arrayType2 = PyArray_TYPE(inArr2);
+   int32_t arrayType1 = PyArray_TYPE(inArr1);
+   int32_t arrayType2 = PyArray_TYPE(inArr2);
 
    int sizeType1 = (int)NpyItemSize((PyObject*)inArr1);
    int sizeType2 = (int)NpyItemSize((PyObject*)inArr2);
@@ -5215,8 +5215,8 @@ IsMember32(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   INT64 arraySize1 = ArrayLength(inArr1);
-   INT64 arraySize2 = ArrayLength(inArr2);
+   int64_t arraySize1 = ArrayLength(inArr1);
+   int64_t arraySize2 = ArrayLength(inArr2);
 
    PyArrayObject* boolArray = AllocateLikeNumpyArray(inArr1, NPY_BOOL);
 
@@ -5224,7 +5224,7 @@ IsMember32(PyObject *self, PyObject *args)
       void* pDataIn1 = PyArray_BYTES(inArr1);
       void* pDataIn2 = PyArray_BYTES(inArr2);
 
-      INT8* pDataOut1 = (INT8*)PyArray_BYTES(boolArray);
+      int8_t* pDataOut1 = (int8_t*)PyArray_BYTES(boolArray);
 
       PyArrayObject* indexArray = NULL;
 
@@ -5266,16 +5266,16 @@ IsMember32(PyObject *self, PyObject *args)
             void* pDataOut2 = PyArray_BYTES(indexArray);
             switch (dtype) {
             case NPY_INT8:
-               IsMemberHash32<INT8>(arraySize1, pDataIn1, arraySize2, pDataIn2, (INT8*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
+               IsMemberHash32<int8_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int8_t*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
                break;
             case NPY_INT16:
-               IsMemberHash32<INT16>(arraySize1, pDataIn1, arraySize2, pDataIn2, (INT16*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
+               IsMemberHash32<int16_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int16_t*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
                break;
             case NPY_INT32:
-               IsMemberHash32<INT32>(arraySize1, pDataIn1, arraySize2, pDataIn2, (INT32*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
+               IsMemberHash32<int32_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int32_t*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
                break;
             case NPY_INT64:
-               IsMemberHash32<INT64>(arraySize1, pDataIn1, arraySize2, pDataIn2, (INT64*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
+               IsMemberHash32<int64_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int64_t*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
                break;
             }
          }
@@ -5297,7 +5297,7 @@ IsMember32(PyObject *self, PyObject *args)
 /**
  * @brief
  *
- * @tparam _Index The type of the integer indices used and returned by this function. Should be INT32 or INT64.
+ * @tparam _Index The type of the integer indices used and returned by this function. Should be int32_t or int64_t.
  * @param partitionLength
  * @param pCutOffs
  * @param totalRows
@@ -5309,7 +5309,7 @@ IsMember32(PyObject *self, PyObject *args)
  * @param hashMode
  * @param hintSize
  * @param pBoolFilter
- * @return UINT64
+ * @return uint64_t
  */
 #if defined(__GNUC__) && __GNUC__ < 5
 // Workaround for old versions of gcc which don't have enable_if_t
@@ -5320,22 +5320,22 @@ template <typename _Index>
 //template <typename _Index,
 //   std::enable_if_t<std::is_integral<_Index>::value, int> = 0>
 #endif
-static UINT64 GroupByImpl(
-   const INT64  partitionLength, // may be 0
-   INT64* const pCutOffs,        // may be NULL
-   const INT64 totalRows,
-   const INT64 totalItemSize,
+static uint64_t GroupByImpl(
+   const int64_t  partitionLength, // may be 0
+   int64_t* const pCutOffs,        // may be NULL
+   const int64_t totalRows,
+   const int64_t totalItemSize,
    const char* const pInput1,
    const int coreType,
    _Index* const pIndexArray,
    PyArrayObject** pFirstArrayObject,
    const HASH_MODE hashMode,
-   const INT64   hintSize,
+   const int64_t   hintSize,
    bool* const pBoolFilter) {
 
    _Index* pFirstArray = nullptr;
    void* pHashTableAny = nullptr;
-   INT64  hashTableSize = 0;
+   int64_t  hashTableSize = 0;
 
    if (partitionLength) {
       // turn off threading? or memory allocations?
@@ -5352,37 +5352,37 @@ static UINT64 GroupByImpl(
       struct PARTITION_GB {
          _Index* pFirstArray;
          void* pHashTableAny;
-         INT64  HashTableSize;
-         INT64  NumUnique;
-         INT64  TotalRows;
+         int64_t  HashTableSize;
+         int64_t  NumUnique;
+         int64_t  TotalRows;
       };
 
       // MT callback
       struct MKGBCallbackStruct {
          PARTITION_GB* pPartitions;
-         INT64             PartitionLength;
-         INT64* pCutOffs;
+         int64_t             PartitionLength;
+         int64_t* pCutOffs;
 
-         INT64             TotalRows;
-         INT64             TotalItemSize;
+         int64_t             TotalRows;
+         int64_t             TotalItemSize;
          const char* pInput1;
 
          int               CoreType;
          _Index* pIndexArray;
          HASH_MODE         HashMode;
-         INT64             HintSize;
+         int64_t             HintSize;
          bool* pBoolFilter;
       };
 
       // This is the routine that will be called back from multiple threads
-      auto lambdaMKGBCallback = [](void* callbackArgT, int core, INT64 count) -> BOOL {
+      auto lambdaMKGBCallback = [](void* callbackArgT, int core, int64_t count) -> bool {
          auto* cb = static_cast<MKGBCallbackStruct*>(callbackArgT);
 
-         INT64* pCutOffs = cb->pCutOffs;
+         int64_t* pCutOffs = cb->pCutOffs;
          PARTITION_GB* pPartition = &cb->pPartitions[count];
 
-         INT64             partOffset = 0;
-         INT64             partLength = pCutOffs[count];
+         int64_t             partOffset = 0;
+         int64_t             partLength = pCutOffs[count];
          bool* pBoolFilter = cb->pBoolFilter;
          auto* pIndexArray = cb->pIndexArray;
          const char* pInput1 = cb->pInput1;
@@ -5404,7 +5404,7 @@ static UINT64 GroupByImpl(
          pInput1 += (partOffset * cb->TotalItemSize);
 
          // NOW HASH the data
-         pPartition->NumUnique = (INT64)
+         pPartition->NumUnique = (int64_t)
             GroupByInternal<_Index>(
                // These three are returned, they have to be deallocated
                reinterpret_cast<void**>(&pPartition->pFirstArray), &pPartition->pHashTableAny, &pPartition->HashTableSize,
@@ -5450,9 +5450,9 @@ static UINT64 GroupByImpl(
       CHECK_MEMORY_ERROR(cutoffsArray);
       if (!cutoffsArray) return 0;
 
-      INT64* pCutOffs = (INT64*)PyArray_BYTES(cutoffsArray);
+      int64_t* pCutOffs = (int64_t*)PyArray_BYTES(cutoffsArray);
 
-      INT64 totalUniques = 0;
+      int64_t totalUniques = 0;
       for (int i = 0; i < partitionLength; i++) {
          totalUniques += pPartitions[i].NumUnique;
          pCutOffs[i] = totalUniques;
@@ -5464,7 +5464,7 @@ static UINT64 GroupByImpl(
 
       _Index* pFirstArray = (_Index*)PyArray_BYTES(firstArray);
 
-      INT64 startpos = 0;
+      int64_t startpos = 0;
 
       // Clean up------------------------------
       for (int i = 0; i < partitionLength; i++) {
@@ -5496,7 +5496,7 @@ static UINT64 GroupByImpl(
       // This makes for a more complicated GroupBy as in parallel mode, it has to shut down the low level caching
       // Further, the size of the first array is not known until the unique count is known
 
-      UINT64 numUnique =
+      uint64_t numUnique =
          GroupByInternal<_Index>(
 
             reinterpret_cast<void**>(&pFirstArray), &pHashTableAny, &hashTableSize,
@@ -5520,40 +5520,40 @@ static UINT64 GroupByImpl(
 }
 
 //===================================================================================================
-UINT64 GroupBy32(
-   INT64  partitionLength, // may be 0
-   INT64* pCutOffs,        // may be NULL
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t GroupBy32(
+   int64_t  partitionLength, // may be 0
+   int64_t* pCutOffs,        // may be NULL
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,
    void* pIndexArray,
    PyArrayObject** pFirstArrayObject,
    HASH_MODE hashMode,
-   INT64   hintSize,
+   int64_t   hintSize,
    bool* pBoolFilter) {
    // Call the templated implementation of this function.
-   using index_type = INT32;
+   using index_type = int32_t;
    return GroupByImpl<index_type>(
       partitionLength, pCutOffs, totalRows, totalItemSize, pInput1, coreType,
       static_cast<index_type*>(pIndexArray), pFirstArrayObject, hashMode, hintSize, pBoolFilter);
 }
 
 //===================================================================================================
-UINT64 GroupBy64(
-   INT64  partitionLength, // may be 0
-   INT64* pCutOffs,        // may be NULL
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t GroupBy64(
+   int64_t  partitionLength, // may be 0
+   int64_t* pCutOffs,        // may be NULL
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,
    void* pIndexArray,
    PyArrayObject** pFirstArrayObject,
    HASH_MODE hashMode,
-   INT64   hintSize,
+   int64_t   hintSize,
    bool* pBoolFilter) {
    // Call the templated implementation of this function.
-   using index_type = INT64;
+   using index_type = int64_t;
    return GroupByImpl<index_type>(
       partitionLength, pCutOffs, totalRows, totalItemSize, pInput1, coreType,
       static_cast<index_type*>(pIndexArray), pFirstArrayObject, hashMode, hintSize, pBoolFilter);
@@ -5568,7 +5568,7 @@ PyObject *MergeBinnedAndSorted(PyObject *self, PyObject *args)
    PyArrayObject* key2;
    PyArrayObject* pvalArray1;
    PyArrayObject* pvalArray2;
-   INT64 totalUniqueSize;
+   int64_t totalUniqueSize;
 
    if (!PyArg_ParseTuple(
       args, "O!O!O!O!L",
@@ -5583,8 +5583,8 @@ PyObject *MergeBinnedAndSorted(PyObject *self, PyObject *args)
    }
 
    LOGGING("Unique size %lld\n", totalUniqueSize);
-   INT32 dtype1 = ObjectToDtype((PyArrayObject*)pvalArray1);
-   INT32 dtype2 = ObjectToDtype((PyArrayObject*)pvalArray2);
+   int32_t dtype1 = ObjectToDtype((PyArrayObject*)pvalArray1);
+   int32_t dtype2 = ObjectToDtype((PyArrayObject*)pvalArray2);
 
    if (dtype1 < 0) {
       PyErr_Format(PyExc_ValueError, "MergeBinnedAndSorted data types are not understood dtype.num: %d vs %d", dtype1, dtype2);
@@ -5609,29 +5609,29 @@ PyObject *MergeBinnedAndSorted(PyObject *self, PyObject *args)
 
    PyArrayObject* indexArray = (PyArrayObject*)Py_None;
    bool isIndex32 = TRUE;
-   BOOL success = FALSE;
+   bool success = FALSE;
 
    indexArray = AllocateLikeNumpyArray(key1, dtype1);
 
    if (indexArray) {
       switch (dtype1) {
       case NPY_INT8:
-         success = MergePreBinned<INT8>(ArrayLength(key1), (INT8*)pKey1, pVal1, ArrayLength(key2), (INT8*)pKey2, pVal2, (INT8*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
+         success = MergePreBinned<int8_t>(ArrayLength(key1), (int8_t*)pKey1, pVal1, ArrayLength(key2), (int8_t*)pKey2, pVal2, (int8_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
       case NPY_INT16:
-         success = MergePreBinned<INT16>(ArrayLength(key1), (INT16*)pKey1, pVal1, ArrayLength(key2), (INT16*)pKey2, pVal2, (INT16*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
+         success = MergePreBinned<int16_t>(ArrayLength(key1), (int16_t*)pKey1, pVal1, ArrayLength(key2), (int16_t*)pKey2, pVal2, (int16_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
       CASE_NPY_INT32:
-         success = MergePreBinned<INT32>(ArrayLength(key1), (INT32*)pKey1, pVal1, ArrayLength(key2), (INT32*)pKey2, pVal2, (INT32*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
+         success = MergePreBinned<int32_t>(ArrayLength(key1), (int32_t*)pKey1, pVal1, ArrayLength(key2), (int32_t*)pKey2, pVal2, (int32_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
       CASE_NPY_INT64:
-         success = MergePreBinned<INT64>(ArrayLength(key1), (INT64*)pKey1, pVal1, ArrayLength(key2), (INT64*)pKey2, pVal2, (INT64*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
+         success = MergePreBinned<int64_t>(ArrayLength(key1), (int64_t*)pKey1, pVal1, ArrayLength(key2), (int64_t*)pKey2, pVal2, (int64_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
       }
    }
 
    if (!success) {
-      PyErr_Format(PyExc_ValueError, "MultiKeyAlign failed.  Only accepts INT32,INT64,FLOAT32,FLOAT64");
+      PyErr_Format(PyExc_ValueError, "MultiKeyAlign failed.  Only accepts int32_t,int64_t,FLOAT32,FLOAT64");
       return NULL;
    }
    return (PyObject*)indexArray;

--- a/src/HashLinear.cpp
+++ b/src/HashLinear.cpp
@@ -273,24 +273,24 @@ UNICODE_MATCH(const char* str1T, const char* str2T, int64_t strWidth1) {
    const uint32_t* str2 = (const uint32_t*)str2T;
    strWidth1 /= 4;
    while (strWidth1 > 0) {
-      if (*str1 != *str2) return FALSE;
+      if (*str1 != *str2) return false;
       ++str1;
       ++str2;
       --strWidth1;
    }
-   return TRUE;
+   return true;
 }
 
 FORCE_INLINE
 bool
 STRING_MATCH(const char* str1, const char* str2, int64_t strWidth1) {
    while (strWidth1 > 0) {
-      if (*str1 != *str2) return FALSE;
+      if (*str1 != *str2) return false;
       ++str1;
       ++str2;
       --strWidth1;
    }
-   return TRUE;
+   return true;
 }
 
 
@@ -305,21 +305,21 @@ UNICODE_MATCH2(const char* str1T, const char* str2T, int64_t strWidth1, int64_t 
 
       // Check for when one string ends and the other has not yet
       if (strWidth1 == 0) {
-         if (*str2 == 0) return TRUE;
-         return FALSE;
+         if (*str2 == 0) return true;
+         return false;
       }
       if (strWidth2 == 0) {
-         if (*str1 == 0) return TRUE;
-         return FALSE;
+         if (*str1 == 0) return true;
+         return false;
       }
 
-      if (*str1 != *str2) return FALSE;
+      if (*str1 != *str2) return false;
       ++str1;
       ++str2;
       --strWidth1;
       --strWidth2;
    }
-   return TRUE;
+   return true;
 }
 
 
@@ -330,21 +330,21 @@ STRING_MATCH2(const char* str1, const char* str2, int64_t strWidth1, int64_t str
 
       // Check for when one string ends and the other has not yet
       if (strWidth1 == 0) {
-         if (*str2 == 0) return TRUE;
-         return FALSE;
+         if (*str2 == 0) return true;
+         return false;
       }
       if (strWidth2 == 0) {
-         if (*str1 == 0) return TRUE;
-         return FALSE;
+         if (*str1 == 0) return true;
+         return false;
       }
 
-      if (*str1 != *str2) return FALSE;
+      if (*str1 != *str2) return false;
 ++str1;
 ++str2;
 --strWidth1;
 --strWidth2;
    }
-   return TRUE;
+   return true;
 }
 
 
@@ -484,7 +484,7 @@ void* CHashLinear<T, U>::AllocMemory(
 
    size_t allocSize = HashSize * sizeofStruct;
 
-   FreeMemory(TRUE);
+   FreeMemory(true);
 
    LOGGING("Hash size selected %llu for NumEntries %llu -- allocation size %llu\n", HashSize, NumEntries, allocSize);
 
@@ -673,7 +673,7 @@ void CHashLinear<T, U>::MakeHashLocationMK(
       hintSize = arraySize;
    }
 
-   AllocMemory(hintSize, sizeof(HashLocationMK), 0, FALSE);
+   AllocMemory(hintSize, sizeof(HashLocationMK), 0, false);
    //uint64_t NumUnique = 0;
    //uint64_t NumCollisions = 0;
 
@@ -846,7 +846,7 @@ void CHashLinear<T, U>::FindLastMatchMK(
    int64_t totalItemSize,
    bool allowExact) {
 
-   AllocMemory(arraySize2, sizeof(HashLocationMK), 0, FALSE);
+   AllocMemory(arraySize2, sizeof(HashLocationMK), 0, false);
 
    HashLocationMK* pLocation = (HashLocationMK*)pHashTableAny;
 
@@ -982,7 +982,7 @@ void CHashLinear<T, U>::FindNextMatchMK(
    int64_t totalItemSize,
    bool allowExact) {
 
-   AllocMemory(arraySize2, sizeof(HashLocationMK), 0, FALSE);
+   AllocMemory(arraySize2, sizeof(HashLocationMK), 0, false);
    const U        BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
 
    HashLocationMK* pLocation = (HashLocationMK*)pHashTableAny;
@@ -1241,7 +1241,7 @@ void CHashLinear<T,U>::MakeHashLocation(
       hintSize = arraySize;
    }
 
-   AllocMemory(hintSize, sizeof(HashLocation), 0, FALSE);
+   AllocMemory(hintSize, sizeof(HashLocation), 0, false);
    NumUnique = 0;
 
    LOGGING("MakeHashLocation: hintSize %lld   HashSize %llu\n", hintSize, HashSize);
@@ -1600,7 +1600,7 @@ void CHashLinear<T, U>::MakeHashLocationFloat(
       hintSize = arraySize;
    }
 
-   AllocMemory(hintSize, sizeof(HashLocation), 0, TRUE);
+   AllocMemory(hintSize, sizeof(HashLocation), 0, true);
    NumUnique = 0;
 
    LOGGING("MakeHashLocationFloat: hintSize %lld   HashSize %llu\n", hintSize, HashSize);
@@ -2400,7 +2400,7 @@ uint64_t CHashLinear<T, U>::GroupBySuper(
    if (hintSize == 0) {
       hintSize = totalRows;
    }
-   AllocMemory(hintSize, sizeof(MultiKeyEntrySuper), 0, FALSE);
+   AllocMemory(hintSize, sizeof(MultiKeyEntrySuper), 0, false);
 
    LOGGING("GroupBySuper: hintSize %lld   HashSize %llu\n", hintSize, HashSize);
 
@@ -2636,7 +2636,7 @@ uint64_t CHashLinear<T, U>::Unique(
       hintSize = totalRows;
    }
 
-   AllocMemory(hintSize, sizeof(UniqueEntry), 0, FALSE);
+   AllocMemory(hintSize, sizeof(UniqueEntry), 0, false);
 
    LOGGING("Unique: hintSize:%lld   HashSize:%llu  sizeoftypeU:%lld   sizeoftypeT:%lld\n", hintSize, HashSize, sizeof(U), sizeof(T));
 
@@ -2778,7 +2778,7 @@ void CHashLinear<T, U>::MultiKeyRolling(
       if (hintSize == 0) {
          hintSize = totalRows;
       }
-      AllocMemory(hintSize, sizeof(MultiKeyEntryRolling), 0, FALSE);
+      AllocMemory(hintSize, sizeof(MultiKeyEntryRolling), 0, false);
       NumUnique = 0;
    }
 
@@ -2812,7 +2812,7 @@ void CHashLinear<T, U>::MultiKeyRolling(
             // This entry is not us so we must have collided
             ++NumCollisions;
 
-            // Bail on too many collisions (could return FALSE)
+            // Bail on too many collisions (could return false)
             if ((int64_t)NumCollisions > hintSize)
                break;
 
@@ -2867,7 +2867,7 @@ void CHashLinear<T, U>::MakeHashLocationMultiKey(
    if (hintSize == 0) {
       hintSize = totalRows;
    }
-   AllocMemory(hintSize, sizeof(MultiKeyEntry), 0, FALSE);
+   AllocMemory(hintSize, sizeof(MultiKeyEntry), 0, false);
    NumUnique = 0;
 
    LOGGING("MakeHashLocationMultiKey: hintSize %lld   HashSize %llu\n", hintSize, HashSize);
@@ -2957,7 +2957,7 @@ void CHashLinear<T, U>::MakeHashLocationString(
       hintSize = arraySize;
    }
 
-   AllocMemory(hintSize, sizeof(HashLocation), 0, FALSE);
+   AllocMemory(hintSize, sizeof(HashLocation), 0, false);
    NumUnique = 0;
 
    LOGGING("MakeHashLocationString: hintSize %lld   HashSize %llu\n", hintSize, HashSize);
@@ -3617,7 +3617,7 @@ struct IMMT_CALLBACK {
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
 static bool IMMTThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
-   bool didSomeWork = FALSE;
+   bool didSomeWork = false;
    IMMT_CALLBACK* Callback = (IMMT_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    char* pInput1 = (char *)Callback->pHashList;
@@ -3635,7 +3635,7 @@ static bool IMMTThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int cor
       Callback->anyIMMTCallback(Callback->pHashLinearVoid, lenX, pInput1 + inputAdj, Callback->pBoolOutput + boolAdj, pOutput + outputAdj);
 
       // Indicate we completed a block
-      didSomeWork = TRUE;
+      didSomeWork = true;
 
       // tell others we completed this work block
       pstWorkerItem->CompleteWorkBlock();
@@ -3710,7 +3710,7 @@ void* IsMemberHash32(
    U* pOutput,
 
    int8_t* pBoolOutput,
-   INT sizeType,
+   int32_t sizeType,
    HASH_MODE hashMode,
    int64_t hintSize) {
 
@@ -3755,18 +3755,18 @@ void* IsMemberHash32(
    break;
    case 104:
    {
-      CHashLinear<FLOAT, U>* pHashLinear = new CHashLinear<FLOAT, U>(hashMode);
-      pHashLinear->MakeHashLocationFloat(size2, (FLOAT*)pInput2, hintSize);
-      IsMemberMultiThread(IsMemberFloat<FLOAT, U>, pHashLinear, size1, (FLOAT*)pInput1, pBoolOutput, (U*)pOutput, sizeof(FLOAT), sizeof(U));
+      CHashLinear<float, U>* pHashLinear = new CHashLinear<float, U>(hashMode);
+      pHashLinear->MakeHashLocationFloat(size2, (float*)pInput2, hintSize);
+      IsMemberMultiThread(IsMemberFloat<float, U>, pHashLinear, size1, (float*)pInput1, pBoolOutput, (U*)pOutput, sizeof(float), sizeof(U));
       delete pHashLinear;
       return NULL;
    }
    break;
    case 108:
    {
-      CHashLinear<DOUBLE, U>* pHashLinear = new CHashLinear<DOUBLE, U>(hashMode);
-      pHashLinear->MakeHashLocationFloat(size2, (DOUBLE*)pInput2, hintSize);
-      IsMemberMultiThread(IsMemberFloat<DOUBLE, U>, pHashLinear, size1, (DOUBLE*)pInput1, pBoolOutput, (U*)pOutput, sizeof(DOUBLE), sizeof(U));
+      CHashLinear<double, U>* pHashLinear = new CHashLinear<double, U>(hashMode);
+      pHashLinear->MakeHashLocationFloat(size2, (double*)pInput2, hintSize);
+      IsMemberMultiThread(IsMemberFloat<double, U>, pHashLinear, size1, (double*)pInput1, pBoolOutput, (U*)pOutput, sizeof(double), sizeof(U));
       delete pHashLinear;
       return NULL;
    }
@@ -3793,7 +3793,7 @@ void* IsMemberHash64(
    void* pInput2,
    int64_t* pOutput,
    int8_t* pBoolOutput,
-   INT sizeType,
+   int32_t sizeType,
    HASH_MODE hashMode,
    int64_t hintSize) {
 
@@ -3835,18 +3835,18 @@ void* IsMemberHash64(
    break;
    case 104:
    {
-      CHashLinear<FLOAT, int64_t>* pHashLinear = new CHashLinear<FLOAT, int64_t>(hashMode);
-      pHashLinear->MakeHashLocationFloat(size2, (FLOAT*)pInput2, hintSize);
-      IsMemberFloat<FLOAT, int64_t>(pHashLinear, size1, (FLOAT*)pInput1, pBoolOutput, (int64_t*)pOutput);
+      CHashLinear<float, int64_t>* pHashLinear = new CHashLinear<float, int64_t>(hashMode);
+      pHashLinear->MakeHashLocationFloat(size2, (float*)pInput2, hintSize);
+      IsMemberFloat<float, int64_t>(pHashLinear, size1, (float*)pInput1, pBoolOutput, (int64_t*)pOutput);
       delete pHashLinear;
       return NULL;
    }
    break;
    case 108:
    {
-      CHashLinear<DOUBLE, int64_t>* pHashLinear = new CHashLinear<DOUBLE, int64_t>(hashMode);
-      pHashLinear->MakeHashLocationFloat(size2, (DOUBLE*)pInput2, hintSize);
-      IsMemberFloat<DOUBLE, int64_t>(pHashLinear, size1, (DOUBLE*)pInput1, pBoolOutput, (int64_t*)pOutput);
+      CHashLinear<double, int64_t>* pHashLinear = new CHashLinear<double, int64_t>(hashMode);
+      pHashLinear->MakeHashLocationFloat(size2, (double*)pInput2, hintSize);
+      IsMemberFloat<double, int64_t>(pHashLinear, size1, (double*)pInput1, pBoolOutput, (int64_t*)pOutput);
       delete pHashLinear;
       return NULL;
    }
@@ -3875,7 +3875,7 @@ int64_t IsMemberHashCategorical(
    int64_t size2,
    void* pInput2,
    int32_t* pOutput,
-   INT sizeType,
+   int32_t sizeType,
    HASH_MODE hashMode,
    int64_t hintSize) {
 
@@ -3922,18 +3922,18 @@ int64_t IsMemberHashCategorical(
    break;
    case 104:
    {
-      CHashLinear<FLOAT, int32_t>* pHashLinear = new CHashLinear<FLOAT, int32_t>(hashMode);
-      pHashLinear->MakeHashLocationFloat(size2, (FLOAT*)pInput2, hintSize);
-      missed = pHashLinear->IsMemberFloatCategorical(size1, (FLOAT*)pInput1, pOutput);
+      CHashLinear<float, int32_t>* pHashLinear = new CHashLinear<float, int32_t>(hashMode);
+      pHashLinear->MakeHashLocationFloat(size2, (float*)pInput2, hintSize);
+      missed = pHashLinear->IsMemberFloatCategorical(size1, (float*)pInput1, pOutput);
       delete pHashLinear;
       return missed;
    }
    break;
    case 108:
    {
-      CHashLinear<DOUBLE, int32_t>* pHashLinear = new CHashLinear<DOUBLE, int32_t>(hashMode);
-      pHashLinear->MakeHashLocationFloat(size2, (DOUBLE*)pInput2, hintSize);
-      missed = pHashLinear->IsMemberFloatCategorical(size1, (DOUBLE*)pInput1, pOutput);
+      CHashLinear<double, int32_t>* pHashLinear = new CHashLinear<double, int32_t>(hashMode);
+      pHashLinear->MakeHashLocationFloat(size2, (double*)pInput2, hintSize);
+      missed = pHashLinear->IsMemberFloatCategorical(size1, (double*)pInput1, pOutput);
       delete pHashLinear;
       return missed;
    }
@@ -3972,7 +3972,7 @@ int64_t IsMemberHashCategorical64(
    int64_t size2,
    void* pInput2,
    int64_t* pOutput,
-   INT sizeType,
+   int32_t sizeType,
    HASH_MODE hashMode,
    int64_t hintSize) {
 
@@ -4019,18 +4019,18 @@ int64_t IsMemberHashCategorical64(
    break;
    case 104:
    {
-      CHashLinear<FLOAT, int64_t>* pHashLinear = new CHashLinear<FLOAT, int64_t>(hashMode);
-      pHashLinear->MakeHashLocationFloat(size2, (FLOAT*)pInput2, hintSize);
-      missed = pHashLinear->IsMemberFloatCategorical(size1, (FLOAT*)pInput1, pOutput);
+      CHashLinear<float, int64_t>* pHashLinear = new CHashLinear<float, int64_t>(hashMode);
+      pHashLinear->MakeHashLocationFloat(size2, (float*)pInput2, hintSize);
+      missed = pHashLinear->IsMemberFloatCategorical(size1, (float*)pInput1, pOutput);
       delete pHashLinear;
       return missed;
    }
    break;
    case 108:
    {
-      CHashLinear<DOUBLE, int64_t>* pHashLinear = new CHashLinear<DOUBLE, int64_t>(hashMode);
-      pHashLinear->MakeHashLocationFloat(size2, (DOUBLE*)pInput2, hintSize);
-      missed = pHashLinear->IsMemberFloatCategorical(size1, (DOUBLE*)pInput1, pOutput);
+      CHashLinear<double, int64_t>* pHashLinear = new CHashLinear<double, int64_t>(hashMode);
+      pHashLinear->MakeHashLocationFloat(size2, (double*)pInput2, hintSize);
+      missed = pHashLinear->IsMemberFloatCategorical(size1, (double*)pInput1, pOutput);
       delete pHashLinear;
       return missed;
    }
@@ -4081,7 +4081,7 @@ struct IMS_CALLBACK {
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
 static bool IMSThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
-   bool didSomeWork = FALSE;
+   bool didSomeWork = false;
    IMS_CALLBACK* Callback = (IMS_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    bool isUnicode = Callback->isUnicode;
@@ -4104,7 +4104,7 @@ static bool IMSThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core
       }
 
       // Indicate we completed a block
-      didSomeWork = TRUE;
+      didSomeWork = true;
 
       // tell others we completed this work block
       pstWorkerItem->CompleteWorkBlock();
@@ -4254,17 +4254,18 @@ bool MergePreBinned(
    KEY_TYPE*    pOutput,
    int64_t totalUniqueSize,
    HASH_MODE hashMode,
-   INT dtype) {
+   int32_t dtype) {
 
-   bool success = TRUE;
+   bool success = true;
 
    LOGGING("AlignCategorical32 dtype: %d  size1: %lld  size2: %lld\n", dtype, size1, size2);
 
    switch (dtype) {
-   CASE_NPY_INT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       FindLastMatchCategorical<KEY_TYPE, int64_t>(size1, size2, pKey1, pKey2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalUniqueSize);
       break;
-   CASE_NPY_INT32:
+   case NPY_INT32:
       FindLastMatchCategorical<KEY_TYPE, int32_t>(size1, size2, pKey1, pKey2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalUniqueSize);
       break;
    case NPY_FLOAT64:
@@ -4274,7 +4275,7 @@ bool MergePreBinned(
       FindLastMatchCategorical<KEY_TYPE, float>(size1, size2, pKey1, pKey2, (float*)pInVal1, (float*)pInVal2, pOutput, totalUniqueSize);
       break;
    default:
-      success = FALSE;
+      success = false;
       break;
    }
    return success;
@@ -4299,15 +4300,16 @@ bool AlignHashMK32(
    int32_t* pOutput,
    int64_t totalItemSize,
    HASH_MODE hashMode,
-   INT dtype,
+   int32_t dtype,
    bool isForward,
    bool allowExact) {
 
-   bool success = TRUE;
+   bool success = true;
    CHashLinear<char, int32_t>* pHashLinear = new CHashLinear<char, int32_t>(hashMode);
 
    switch (dtype) {
-   CASE_NPY_INT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       if (isForward) {
          pHashLinear->FindNextMatchMK<int64_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
@@ -4315,7 +4317,7 @@ bool AlignHashMK32(
          pHashLinear->FindLastMatchMK<int64_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
       break;
-   CASE_NPY_INT32:
+   case NPY_INT32:
       if (isForward) {
          pHashLinear->FindNextMatchMK<int32_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
@@ -4340,7 +4342,7 @@ bool AlignHashMK32(
       }
       break;
    default:
-      success = FALSE;
+      success = false;
       break;
    }
    delete pHashLinear;
@@ -4360,16 +4362,17 @@ bool AlignHashMK64(
    int64_t* pOutput,
    int64_t totalItemSize,
    HASH_MODE hashMode,
-   INT dtype,
+   int32_t dtype,
    bool isForward,
    bool allowExact) {
 
 
-   bool success = TRUE;
+   bool success = true;
    CHashLinear<char, int64_t>* pHashLinear = new CHashLinear<char, int64_t>(hashMode);
 
    switch (dtype) {
-   CASE_NPY_INT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       if (isForward) {
          pHashLinear->FindNextMatchMK<int64_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
@@ -4378,7 +4381,7 @@ bool AlignHashMK64(
       }
 
       break;
-   CASE_NPY_INT32:
+   case NPY_INT32:
       if (isForward) {
          pHashLinear->FindNextMatchMK<int32_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
@@ -4403,7 +4406,7 @@ bool AlignHashMK64(
       }
       break;
    default:
-      success = FALSE;
+      success = false;
       break;
    }
    delete pHashLinear;
@@ -4429,8 +4432,8 @@ DoLinearHash(
    bool* pBoolFilter) {
 
    uint64_t numUnique = 0;
-   CHashLinear<HASH_TYPE, INDEX_TYPE>* pHashLinear = new CHashLinear<HASH_TYPE, INDEX_TYPE>(hashMode, FALSE);
-   INDEX_TYPE* pFirstArray = (INDEX_TYPE*)pHashLinear->AllocMemory(hintSize, -2, sizeof(INDEX_TYPE) * (totalRows + 1), FALSE);
+   CHashLinear<HASH_TYPE, INDEX_TYPE>* pHashLinear = new CHashLinear<HASH_TYPE, INDEX_TYPE>(hashMode, false);
+   INDEX_TYPE* pFirstArray = (INDEX_TYPE*)pHashLinear->AllocMemory(hintSize, -2, sizeof(INDEX_TYPE) * (totalRows + 1), false);
 
    // Handles any size
    numUnique =
@@ -4462,8 +4465,8 @@ DoLinearHashFloat(
    bool* pBoolFilter) {
 
    uint64_t numUnique = 0;
-   CHashLinear<HASH_TYPE, INDEX_TYPE>* pHashLinear = new CHashLinear<HASH_TYPE, INDEX_TYPE>(hashMode, FALSE);
-   INDEX_TYPE* pFirstArray = (INDEX_TYPE*)pHashLinear->AllocMemory(hintSize, -1, sizeof(INDEX_TYPE) * (totalRows + 1), FALSE);
+   CHashLinear<HASH_TYPE, INDEX_TYPE>* pHashLinear = new CHashLinear<HASH_TYPE, INDEX_TYPE>(hashMode, false);
+   INDEX_TYPE* pFirstArray = (INDEX_TYPE*)pHashLinear->AllocMemory(hintSize, -1, sizeof(INDEX_TYPE) * (totalRows + 1), false);
 
    numUnique =
       pHashLinear->GroupByFloat(totalRows, totalItemSize, (HASH_TYPE*)pInput1, coreType, pIndexArray, pFirstArray, hashMode, hintSize, pBoolFilter);
@@ -4495,8 +4498,8 @@ DoLinearHashItemSize(
 
    uint64_t numUnique = 0;
 
-   CHashLinear<HASH_TYPE, INDEX_TYPE>* pHashLinear = new CHashLinear<HASH_TYPE, INDEX_TYPE>(hashMode, FALSE);
-   INDEX_TYPE* pFirstArray = (INDEX_TYPE*)pHashLinear->AllocMemory(hintSize, -1, sizeof(INDEX_TYPE) * (totalRows + 1), FALSE);
+   CHashLinear<HASH_TYPE, INDEX_TYPE>* pHashLinear = new CHashLinear<HASH_TYPE, INDEX_TYPE>(hashMode, false);
+   INDEX_TYPE* pFirstArray = (INDEX_TYPE*)pHashLinear->AllocMemory(hintSize, -1, sizeof(INDEX_TYPE) * (totalRows + 1), false);
 
    if (pFirstArray) {
       numUnique =
@@ -4531,7 +4534,7 @@ uint64_t GroupByInternal(
    bool* pBoolFilter) {
 
    uint64_t numUnique = 0;
-   bool calculated = FALSE;
+   bool calculated = false;
 
    if (hintSize == 0) {
       hintSize = totalRows;
@@ -4549,7 +4552,7 @@ uint64_t GroupByInternal(
       // so that nans compare, we tell it is uint32
       numUnique =
          DoLinearHashFloat<uint32_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
-      calculated = TRUE;
+      calculated = true;
    }
    break;
    case NPY_FLOAT64:
@@ -4557,46 +4560,46 @@ uint64_t GroupByInternal(
       // so that nans compare, we tell it is uint64
       numUnique =
          DoLinearHashFloat<uint64_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
-      calculated = TRUE;
+      calculated = true;
    }
    break;
    }
 
    // Now go based on size
-   if (calculated == FALSE) {
+   if (calculated == false) {
       switch (totalItemSize) {
       case 1:
       {
          numUnique =
             DoLinearHashItemSize<uint8_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, 256/2, pBoolFilter);
-         calculated = TRUE;
+         calculated = true;
       }
       break;
       case 2:
       {
          numUnique =
             DoLinearHashItemSize<uint16_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, 65536/2, pBoolFilter);
-         calculated = TRUE;
+         calculated = true;
       }
       break;
       case 4:
       {
          numUnique =
             DoLinearHashItemSize<uint32_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
-         calculated = TRUE;
+         calculated = true;
       }
       break;
       case 8:
       {
          numUnique =
             DoLinearHashItemSize<uint64_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
-         calculated = TRUE;
+         calculated = true;
       }
       break;
       }
    }
 
-   if (calculated == FALSE) {
+   if (calculated == false) {
       numUnique =
          DoLinearHash<uint32_t, INDEX_TYPE>(totalRows, totalItemSize, pInput1, coreType, pIndexArray, pFirstArray, pHashTableAny, hashTableSize, hashMode, hintSize, pBoolFilter);
    }
@@ -4923,7 +4926,7 @@ struct IMMK_CALLBACK {
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
 static bool IMMKThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
-   bool didSomeWork = FALSE;
+   bool didSomeWork = false;
    IMMK_CALLBACK* Callback = (IMMK_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    char* pInput1 = (char *)Callback->pInput1;
@@ -4941,7 +4944,7 @@ static bool IMMKThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int cor
       Callback->anyIMMKCallback(Callback->pHashLinearVoid, lenX, pInput1 + inputAdj, Callback->pInput2, Callback->pBoolOutput + boolAdj, pOutput + outputAdj, Callback->totalItemSize);
 
       // Indicate we completed a block
-      didSomeWork = TRUE;
+      didSomeWork = true;
 
       // tell others we completed this work block
       pstWorkerItem->CompleteWorkBlock();
@@ -5168,31 +5171,35 @@ IsMember32(PyObject *self, PyObject *args)
    LOGGING("IsMember32 %s vs %s   size: %d  %d\n", NpyToString(arrayType1), NpyToString(arrayType2), sizeType1, sizeType2);
 
    switch (arrayType1) {
-   CASE_NPY_INT32:
+   case NPY_INT32:
       arrayType1 = NPY_INT32;
       break;
-   CASE_NPY_UINT32:
+   case NPY_UINT32:
       arrayType1 = NPY_UINT32;
       break;
-   CASE_NPY_INT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       arrayType1 = NPY_INT64;
       break;
-   CASE_NPY_UINT64:
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
       arrayType1 = NPY_UINT64;
       break;
    }
 
    switch (arrayType2) {
-   CASE_NPY_INT32:
+   case NPY_INT32:
       arrayType2 = NPY_INT32;
       break;
-   CASE_NPY_UINT32:
+   case NPY_UINT32:
       arrayType2 = NPY_UINT32;
       break;
-   CASE_NPY_INT64:
+   case NPY_INT64:
+   case NPY_LONGLONG:
       arrayType2 = NPY_INT64;
       break;
-   CASE_NPY_UINT64:
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
       arrayType2 = NPY_UINT64;
       break;
    }
@@ -5418,7 +5425,7 @@ static uint64_t GroupByImpl(
                cb->HintSize,
                pBoolFilter);
 
-         return TRUE;
+         return true;
       };
 
       PARTITION_GB* pPartitions = (PARTITION_GB*)WORKSPACE_ALLOC(partitionLength * sizeof(PARTITION_GB));
@@ -5439,7 +5446,7 @@ static uint64_t GroupByImpl(
       stMKGBCallback.pBoolFilter = pBoolFilter;
 
       // turn off caching since multiple threads will allocate ----------
-      g_cMathWorker->NoCaching = TRUE;
+      g_cMathWorker->NoCaching = true;
 
       g_cMathWorker->DoMultiThreadedWork(static_cast<int>(partitionLength), lambdaMKGBCallback, &stMKGBCallback);
 
@@ -5478,7 +5485,7 @@ static uint64_t GroupByImpl(
       }
 
       // turn caching back on -----------------------------------------
-      g_cMathWorker->NoCaching = FALSE;
+      g_cMathWorker->NoCaching = false;
 
       WORKSPACE_FREE(pPartitions);
 
@@ -5608,8 +5615,8 @@ PyObject *MergeBinnedAndSorted(PyObject *self, PyObject *args)
    void* pKey2 = PyArray_BYTES(key2);
 
    PyArrayObject* indexArray = (PyArrayObject*)Py_None;
-   bool isIndex32 = TRUE;
-   bool success = FALSE;
+   bool isIndex32 = true;
+   bool success = false;
 
    indexArray = AllocateLikeNumpyArray(key1, dtype1);
 
@@ -5621,17 +5628,18 @@ PyObject *MergeBinnedAndSorted(PyObject *self, PyObject *args)
       case NPY_INT16:
          success = MergePreBinned<int16_t>(ArrayLength(key1), (int16_t*)pKey1, pVal1, ArrayLength(key2), (int16_t*)pKey2, pVal2, (int16_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
-      CASE_NPY_INT32:
+      case NPY_INT32:
          success = MergePreBinned<int32_t>(ArrayLength(key1), (int32_t*)pKey1, pVal1, ArrayLength(key2), (int32_t*)pKey2, pVal2, (int32_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
-      CASE_NPY_INT64:
+      case NPY_INT64:
+      case NPY_LONGLONG:
          success = MergePreBinned<int64_t>(ArrayLength(key1), (int64_t*)pKey1, pVal1, ArrayLength(key2), (int64_t*)pKey2, pVal2, (int64_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
       }
    }
 
    if (!success) {
-      PyErr_Format(PyExc_ValueError, "MultiKeyAlign failed.  Only accepts int32_t,int64_t,FLOAT32,FLOAT64");
+      PyErr_Format(PyExc_ValueError, "MultiKeyAlign failed.  Only accepts int32_t,int64_t,float32,float64");
       return NULL;
    }
    return (PyObject*)indexArray;

--- a/src/HashLinear.cpp
+++ b/src/HashLinear.cpp
@@ -28,7 +28,7 @@
 //static constexpr int numpy_type_code = -1;   // -1 is an invalid code, because if something uses this specialization we want it to break.
 //
 //template<>
-//static constexpr int numpy_type_code<int32_t> = NPY_INT32;
+//static constexpr int numpy_type_code<int32_t> = NPY_INT;
 //
 //template<>
 //static constexpr int numpy_type_code<int64_t> = NPY_INT64;
@@ -44,7 +44,7 @@ struct numpy_type_code
 template<>
 struct numpy_type_code<int32_t>
 {
-   static constexpr int value = NPY_INT32;
+   static constexpr int value = NPY_INT;
 };
 
 template<>
@@ -1981,7 +1981,7 @@ PyArrayObject* CopyToSmallerArray(void* pFirstArrayIndex, int64_t numUnique, int
          firstArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT16);
          break;
       case 4:
-         firstArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT32);
+         firstArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT);
          break;
       case 8:
          firstArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT64);
@@ -4265,7 +4265,7 @@ bool MergePreBinned(
    case NPY_LONGLONG:
       FindLastMatchCategorical<KEY_TYPE, int64_t>(size1, size2, pKey1, pKey2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalUniqueSize);
       break;
-   case NPY_INT32:
+   case NPY_INT:
       FindLastMatchCategorical<KEY_TYPE, int32_t>(size1, size2, pKey1, pKey2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalUniqueSize);
       break;
    case NPY_FLOAT64:
@@ -4317,7 +4317,7 @@ bool AlignHashMK32(
          pHashLinear->FindLastMatchMK<int64_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int64_t*)pInVal1, (int64_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
       break;
-   case NPY_INT32:
+   case NPY_INT:
       if (isForward) {
          pHashLinear->FindNextMatchMK<int32_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
@@ -4381,7 +4381,7 @@ bool AlignHashMK64(
       }
 
       break;
-   case NPY_INT32:
+   case NPY_INT:
       if (isForward) {
          pHashLinear->FindNextMatchMK<int32_t>(size1, size2, (char*)pInput1, (char*)pInput2, (int32_t*)pInVal1, (int32_t*)pInVal2, pOutput, totalItemSize, allowExact);
       }
@@ -4831,7 +4831,7 @@ void IsMemberHashString32Pre(
 
    }
    else if (size < 2000000000) {
-      *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
+      *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT);
       int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(*indexArray);
       IsMemberHashString32<int32_t>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, pBoolOutput, HASH_MODE(hashMode), hintSize, isUnicode);
 
@@ -4877,7 +4877,7 @@ int64_t IsMemberCategoricalHashStringPre(
 
    }
    else if (size2 < 2000000000) {
-      *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
+      *indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT);
       int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(*indexArray);
       missed = IsMemberHashStringCategorical<int32_t>(size1, strWidth1, (const char*)pInput1, size2, strWidth2, (const char*)pInput2, pDataOut2, HASH_MODE(hashMode), hintSize, isUnicode);
 
@@ -5052,7 +5052,7 @@ void IsMemberHashMKPre(
       }
    }
    else if (size < 2000000000) {
-      *indexArray = AllocateNumpyArray(1, (npy_intp*)&size1, NPY_INT32);
+      *indexArray = AllocateNumpyArray(1, (npy_intp*)&size1, NPY_INT);
       if (*indexArray) {
          int32_t* pOutput = (int32_t*)PyArray_BYTES(*indexArray);
          IsMemberHashMK<int32_t>(size1, pInput1, size2, pInput2, pBoolOutput, pOutput, totalItemSize, hintSize, hashMode);
@@ -5171,11 +5171,11 @@ IsMember32(PyObject *self, PyObject *args)
    LOGGING("IsMember32 %s vs %s   size: %d  %d\n", NpyToString(arrayType1), NpyToString(arrayType2), sizeType1, sizeType2);
 
    switch (arrayType1) {
-   case NPY_INT32:
-      arrayType1 = NPY_INT32;
+   case NPY_INT:
+      arrayType1 = NPY_INT;
       break;
-   case NPY_UINT32:
-      arrayType1 = NPY_UINT32;
+   case NPY_UINT:
+      arrayType1 = NPY_UINT;
       break;
    case NPY_INT64:
    case NPY_LONGLONG:
@@ -5188,11 +5188,11 @@ IsMember32(PyObject *self, PyObject *args)
    }
 
    switch (arrayType2) {
-   case NPY_INT32:
-      arrayType2 = NPY_INT32;
+   case NPY_INT:
+      arrayType2 = NPY_INT;
       break;
-   case NPY_UINT32:
-      arrayType2 = NPY_UINT32;
+   case NPY_UINT:
+      arrayType2 = NPY_UINT;
       break;
    case NPY_INT64:
    case NPY_LONGLONG:
@@ -5260,7 +5260,7 @@ IsMember32(PyObject *self, PyObject *args)
             dtype = NPY_INT16;
          } else
          if (arraySize2 < 2000000000) {
-            dtype = NPY_INT32;
+            dtype = NPY_INT;
          }
          else {
             dtype = NPY_INT64;
@@ -5278,7 +5278,7 @@ IsMember32(PyObject *self, PyObject *args)
             case NPY_INT16:
                IsMemberHash32<int16_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int16_t*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
                break;
-            case NPY_INT32:
+            case NPY_INT:
                IsMemberHash32<int32_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int32_t*)pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode), hintSize);
                break;
             case NPY_INT64:
@@ -5628,7 +5628,7 @@ PyObject *MergeBinnedAndSorted(PyObject *self, PyObject *args)
       case NPY_INT16:
          success = MergePreBinned<int16_t>(ArrayLength(key1), (int16_t*)pKey1, pVal1, ArrayLength(key2), (int16_t*)pKey2, pVal2, (int16_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
-      case NPY_INT32:
+      case NPY_INT:
          success = MergePreBinned<int32_t>(ArrayLength(key1), (int32_t*)pKey1, pVal1, ArrayLength(key2), (int32_t*)pKey2, pVal2, (int32_t*)PyArray_BYTES(indexArray), totalUniqueSize, HASH_MODE_MASK, dtype1);
          break;
       case NPY_INT64:

--- a/src/HashLinear.h
+++ b/src/HashLinear.h
@@ -10,172 +10,172 @@ enum HASH_MODE {
 };
 
 struct UINT128 {
-   UINT64   _val1;
-   UINT64   _val2;
+   uint64_t   _val1;
+   uint64_t   _val2;
 } ;
 
 
 void* IsMemberHashMK32(
-   INT64 size1,
+   int64_t size1,
    void* pInput1,
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
-   INT32* pOutput,
-   INT8* pBooleanOutput,
-   INT64 sizeType,
-   INT64 hintSize,
+   int32_t* pOutput,
+   int8_t* pBooleanOutput,
+   int64_t sizeType,
+   int64_t hintSize,
    HASH_MODE hashMode);
 
 
-INT64 IsMemberHashCategorical(
-   INT64 size1,
+int64_t IsMemberHashCategorical(
+   int64_t size1,
    void* pInput1,
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
-   INT32* pOutput,
+   int32_t* pOutput,
    INT sizeType,
    HASH_MODE hashMode,
-   INT64 hintSize);
+   int64_t hintSize);
 
-INT64 IsMemberHashCategorical64(
-   INT64 size1,
+int64_t IsMemberHashCategorical64(
+   int64_t size1,
    void* pInput1,
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
-   INT64* pOutput,
+   int64_t* pOutput,
    INT sizeType,
    HASH_MODE hashMode,
-   INT64 hintSize);
+   int64_t hintSize);
 
 
 template<typename U>
 void* IsMemberHash32(
-   INT64 size1,
+   int64_t size1,
    void* pInput1,
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
    U* pOutput,
-   INT8* pBooleanOutput,
+   int8_t* pBooleanOutput,
    INT sizeType,
    HASH_MODE hashMode,
-   INT64 hintSize);
+   int64_t hintSize);
 
 void* IsMemberHash64(
-   INT64 size1,
+   int64_t size1,
    void* pInput1,
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
-   INT64* pOutput,
-   INT8* pBooleanOutput,
+   int64_t* pOutput,
+   int8_t* pBooleanOutput,
    INT sizeType,
    HASH_MODE hashMode,
-   INT64 hintSize);
+   int64_t hintSize);
 
-INT64 IsMemberCategoricalHashStringPre(
+int64_t IsMemberCategoricalHashStringPre(
    PyArrayObject** indexArray,
    PyArrayObject* inArr1,
-   INT64 size1,
-   INT64 strWidth1,
+   int64_t size1,
+   int64_t strWidth1,
    const char* pInput1,
-   INT64 size2,
-   INT64 strWidth2,
+   int64_t size2,
+   int64_t strWidth2,
    const char* pInput2,
    HASH_MODE hashMode,
-   INT64 hintSize,
-   BOOL isUnicode);
+   int64_t hintSize,
+   bool isUnicode);
 
 
 void IsMemberHashString32Pre(
    PyArrayObject** indexArray,
    PyArrayObject* inArr1,
-   INT64 size1,
-   INT64 strWidth1,
+   int64_t size1,
+   int64_t strWidth1,
    const char* pInput1,
-   INT64 size2,
-   INT64 strWidth2,
+   int64_t size2,
+   int64_t strWidth2,
    const char* pInput2,
-   INT8* pBooleanOutput,
+   int8_t* pBooleanOutput,
    HASH_MODE hashMode,
-   INT64 hintSize,
-   BOOL isUnicode);
+   int64_t hintSize,
+   bool isUnicode);
 
 void IsMemberHashMKPre(
    PyArrayObject** indexArray,
-   INT64 size1,
+   int64_t size1,
    void* pInput1,
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
-   INT8* pBooleanOutput,
-   INT64 totalItemSize,
-   INT64 hintSize,
+   int8_t* pBooleanOutput,
+   int64_t totalItemSize,
+   int64_t hintSize,
    HASH_MODE hashMode);
 
 
 
 void IsMemberHashString64(
-   INT64 size1,
-   INT64 strWidth1,
+   int64_t size1,
+   int64_t strWidth1,
    const char* pInput1,
-   INT64 size2,
-   INT64 strWidth2,
+   int64_t size2,
+   int64_t strWidth2,
    const char* pInput2,
-   INT64* pOutput,
-   INT8* pBooleanOutput,
+   int64_t* pOutput,
+   int8_t* pBooleanOutput,
    HASH_MODE hashMode,
-   INT64 hintSize,
-   BOOL isUnicode);
+   int64_t hintSize,
+   bool isUnicode);
 
 
 template<typename U, typename V>
 void FindLastMatchCategorical(
-   INT64    arraySize1,
-   INT64    arraySize2,
+   int64_t    arraySize1,
+   int64_t    arraySize2,
    U*       pKey1,
    U*       pKey2,
    V*       pVal1,
    V*       pVal2,
    U*       pLocationOutput,
-   INT64    totalUniqueSize);
+   int64_t    totalUniqueSize);
 
 
 template<typename KEY_TYPE>
-BOOL MergePreBinned(
-   INT64 size1,
+bool MergePreBinned(
+   int64_t size1,
    KEY_TYPE*    pKey1,
    void* pInVal1,
-   INT64 size2,
+   int64_t size2,
    KEY_TYPE*    pKey2,
    void* pInVal2,
    KEY_TYPE*    pOutput,
-   INT64 totalUniqueSize,
+   int64_t totalUniqueSize,
    HASH_MODE hashMode,
    INT dtype);
 
 
 
-BOOL AlignHashMK32(
-   INT64 size1,
+bool AlignHashMK32(
+   int64_t size1,
    void* pInput1,
    void* pInVal1,
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
    void* pInVal2,
-   INT32* pOutput,
-   INT64 totalItemSize,
+   int32_t* pOutput,
+   int64_t totalItemSize,
    HASH_MODE hashMode,
    INT dtype,
    bool isForward,
    bool allowExact);
 
-BOOL AlignHashMK64(
-   INT64 size1,
+bool AlignHashMK64(
+   int64_t size1,
    void* pInput1,
    void* pInVal1,
-   INT64 size2,
+   int64_t size2,
    void* pInput2,
    void* pInVal2,
-   INT64* pOutput,
-   INT64 totalItemSize,
+   int64_t* pOutput,
+   int64_t totalItemSize,
    HASH_MODE hashMode,
    INT dtype,
    bool isForward,
@@ -184,118 +184,118 @@ BOOL AlignHashMK64(
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
 template<typename INDEX_TYPE>
-UINT64 GroupByInternal(
+uint64_t GroupByInternal(
    void** pFirstArrayVoid,
    void** pHashTableAny,
-   INT64* hashTableSize,
+   int64_t* hashTableSize,
 
-   INT64 totalRows,
-   INT64 totalItemSize,
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,
    INDEX_TYPE* pIndexArray,
    HASH_MODE hashMode,
-   INT64   hintSize,
+   int64_t   hintSize,
    bool* pBoolFilter);
 
 //===================================================================================================
-// Declare callback for either INT32 or INT64
-typedef  UINT64(*GROUPBYCALL)(
-   INT64  partitionLength, // may be 0
-   INT64* pCutOffs,        // may be NULL
-   INT64 totalRows,
-   INT64 totalItemSize,
+// Declare callback for either int32_t or int64_t
+typedef  uint64_t(*GROUPBYCALL)(
+   int64_t  partitionLength, // may be 0
+   int64_t* pCutOffs,        // may be NULL
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,
    void* pIndexArray,
    PyArrayObject** pFirstArray,
    HASH_MODE hashMode,
-   INT64   hintSize,
+   int64_t   hintSize,
    bool* pBoolFilter);
 
 
-UINT64 GroupBy32(
-   INT64  partitionLength, // may be 0
-   INT64* pCutOffs,        // may be NULL
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t GroupBy32(
+   int64_t  partitionLength, // may be 0
+   int64_t* pCutOffs,        // may be NULL
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,
    void* pIndexArray,
    PyArrayObject** pFirstArray,
    HASH_MODE hashMode,
-   INT64   hintSize,
+   int64_t   hintSize,
    bool* pBoolFilter);
 
-UINT64 GroupBy64(
-   INT64  partitionLength, // may be 0
-   INT64* pCutOffs,        // may be NULL
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t GroupBy64(
+   int64_t  partitionLength, // may be 0
+   int64_t* pCutOffs,        // may be NULL
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,
    void* pIndexArray,
    PyArrayObject** pFirstArray,
    HASH_MODE hashMode,
-   INT64   hintSize,
+   int64_t   hintSize,
    bool* pBoolFilter);
 
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
-UINT64 GroupBy32Super(
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t GroupBy32Super(
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,
-   INT32* pIndexArray,
-   INT32* pNextArray,
-   INT32* pUniqueArray,
-   INT32* pUniqueCountArray,
+   int32_t* pIndexArray,
+   int32_t* pNextArray,
+   int32_t* pUniqueArray,
+   int32_t* pUniqueCountArray,
    HASH_MODE hashMode,
-   INT64   hintSize,
+   int64_t   hintSize,
    bool* pBoolFilter);
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
-UINT64 GroupBy64Super(
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t GroupBy64Super(
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
    int coreType,
-   INT64* pIndexArray,
-   INT64* pNextArray,
-   INT64* pUniqueArray,
-   INT64* pUniqueCountArray,
+   int64_t* pIndexArray,
+   int64_t* pNextArray,
+   int64_t* pUniqueArray,
+   int64_t* pUniqueCountArray,
    HASH_MODE hashMode,
-   INT64   hintSize,
+   int64_t   hintSize,
    bool* pBoolFilter);
 
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
-UINT64 Unique32(
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t Unique32(
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
 
-   INT32* pIndexArray,
-   INT32* pCountArray,
+   int32_t* pIndexArray,
+   int32_t* pCountArray,
    HASH_MODE hashMode,
-   INT64   hintSize,
+   int64_t   hintSize,
    bool* pBoolFilter);
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
-UINT64 Unique64(
-   INT64 totalRows,
-   INT64 totalItemSize,
+uint64_t Unique64(
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
 
-   INT64* pIndexArray,
-   INT64* pCountArray,
+   int64_t* pIndexArray,
+   int64_t* pCountArray,
    HASH_MODE hashMode,
-   INT64   hintSize,
+   int64_t   hintSize,
    bool* pBoolFilter);
 
 //-----------------------------------------------------------------------------------------
@@ -304,47 +304,47 @@ void MultiKeyRollingStep2Delete(
 
 //-----------------------------------------------------------------------------------------
 void* MultiKeyRollingStep2(
-   INT64 totalRows,
-   INT64 totalItemSize,
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
 
-   INT64* pIndexArray,
-   INT64* pRunningCountArray,
+   int64_t* pIndexArray,
+   int64_t* pRunningCountArray,
    HASH_MODE hashMode,
-   INT64 hintSize,
-   UINT64* numUnique,
+   int64_t hintSize,
+   uint64_t* numUnique,
    void* pHashLinearLast);
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
 void* MultiKeyHash32(
-   INT64 totalRows,
-   INT64 totalItemSize,
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
 
-   INT32* pIndexArray,
-   INT32* pRunningCountArray,
-   INT32* pPrevArray,
-   INT32* pNextArray,
-   INT32* pFirstArray,
+   int32_t* pIndexArray,
+   int32_t* pRunningCountArray,
+   int32_t* pPrevArray,
+   int32_t* pNextArray,
+   int32_t* pFirstArray,
    HASH_MODE hashMode,
-   INT64 hintSize,
+   int64_t hintSize,
    bool* pBoolFilter);
 
 //-----------------------------------------------------------------------------------------
 //  Based on the sizeType it will call different hash functions
 void* MultiKeyHash64(
-   INT64 totalRows,
-   INT64 totalItemSize,
+   int64_t totalRows,
+   int64_t totalItemSize,
    const char* pInput1,
 
-   INT64* pIndexArray,
-   INT64* pRunningCountArray,
-   INT64* pPrevArray,
-   INT64* pNextArray,
-   INT64* pFirstArray,
+   int64_t* pIndexArray,
+   int64_t* pRunningCountArray,
+   int64_t* pPrevArray,
+   int64_t* pNextArray,
+   int64_t* pFirstArray,
    HASH_MODE hashMode,
-   INT64 hintSize,
+   int64_t hintSize,
    bool* pBoolFilter);
 
 //---------------------------------------
@@ -362,8 +362,8 @@ void* MultiKeyHash64(
 
 
 //----------------------------------------
-// T: INT8,INT16,INT32,INT64, string?
-// U: INT8, INT16, INT32 or INT64  (indexing)
+// T: int8_t,int16_t,int32_t,int64_t, string?
+// U: int8_t, int16_t, int32_t or int64_t  (indexing)
 
 template<typename T, typename U>
 class CHashLinear {
@@ -435,19 +435,19 @@ public:
    void*       pHashTableAny;
 
    // Max number of unique values possible
-   INT64       NumEntries;
+   int64_t       NumEntries;
 
    // Actualy unique
-   UINT64      NumUnique;
+   uint64_t      NumUnique;
 
    // Number of collisions
-   UINT64      NumCollisions;
+   uint64_t      NumCollisions;
 
    // Hashsize chosen based on input size
-   UINT64      HashSize;
+   uint64_t      HashSize;
 
    // to determine if hash location has been visited
-   UINT64*     pBitFields;
+   uint64_t*     pBitFields;
 
    // Remember the size we allocated for bitfields
    size_t      BitAllocSize = 0;
@@ -458,11 +458,11 @@ public:
 
    const U     BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
 
-   BOOL        Deallocate = TRUE;
+   bool        Deallocate = TRUE;
 
 public:
    // Parallel hashing does not want memory deallocated so it will set deallocate to FALSE
-   CHashLinear(HASH_MODE hashMode = HASH_MODE_PRIME, BOOL deallocate=TRUE) {
+   CHashLinear(HASH_MODE hashMode = HASH_MODE_PRIME, bool deallocate=TRUE) {
       pHashTableAny = NULL;
       pBitFields = NULL;
 
@@ -482,19 +482,19 @@ public:
       FreeMemory(FALSE);
    }
 
-   void FreeMemory(BOOL forceDeallocate);
+   void FreeMemory(bool forceDeallocate);
 
-   void AllocAndZeroBitFields(UINT64 hashSize);
+   void AllocAndZeroBitFields(uint64_t hashSize);
    char* AllocHashTable(size_t allocSize);
 
    void* AllocMemory(
-      INT64 numberOfEntries,
-      INT64 sizeofStruct,
-      INT64 sizeofExtraArray,
-      BOOL  isFloat);
+      int64_t numberOfEntries,
+      int64_t sizeofStruct,
+      int64_t sizeofExtraArray,
+      bool  isFloat);
 
    void MakeHash(
-      INT64 numberOfEntries,
+      int64_t numberOfEntries,
       T* pHashList);
 
 
@@ -502,62 +502,62 @@ public:
    //----------------------------------------------
    //-----------------------------------------------
    void MakeHashLocationFloat(
-      INT64 arraySize,
+      int64_t arraySize,
       T*    pHashList,
-      INT64 hintSize);
+      int64_t hintSize);
 
    //----------------------------------------------
-   INT64 IsMemberFloatCategorical(
-      INT64 arraySize,
+   int64_t IsMemberFloatCategorical(
+      int64_t arraySize,
       T*    pHashList,
       U*    pLocationOutput);
 
 
    //-----------------------------------------------
-   UINT64 GroupByFloat(
-      INT64 totalRows,
-      INT64 totalItemSize,
+   uint64_t GroupByFloat(
+      int64_t totalRows,
+      int64_t totalItemSize,
       T* pInput,
       int coreType,
       // Return values
       U* pIndexArray,
       U* &pFirstArray,
       HASH_MODE hashMode,
-      INT64 hintSize,
+      int64_t hintSize,
       bool* pBoolFilter);
 
 
    //-----------------------------------------------
-   UINT64 GroupByItemSize(
-      INT64 totalRows,
-      INT64 totalItemSize,
+   uint64_t GroupByItemSize(
+      int64_t totalRows,
+      int64_t totalItemSize,
       T* pInput,
       int coreType,
       // Return values
       U* pIndexArray,
       U* &pFirstArray,
       HASH_MODE hashMode,
-      INT64 hintSize,
+      int64_t hintSize,
       bool* pBoolFilter);
 
    //-----------------------------------------------
-   UINT64 GroupBy(
-      INT64 totalRows,
-      INT64 totalItemSize,
+   uint64_t GroupBy(
+      int64_t totalRows,
+      int64_t totalItemSize,
       const char* pInput,
       int coreType,
       // Return values
       U* pIndexArray,
       U* &pFirstArray,
       HASH_MODE hashMode,
-      INT64 hintSize,
+      int64_t hintSize,
       bool* pBoolFilter);
 
 
    //-----------------------------------------------
-   UINT64 GroupBySuper(
-      INT64 totalRows,
-      INT64 totalItemSize,
+   uint64_t GroupBySuper(
+      int64_t totalRows,
+      int64_t totalItemSize,
       const char* pInput,
 
       int coreType,
@@ -568,14 +568,14 @@ public:
       U* pUniqueArray,
       U* pUniqueCountArray,
       HASH_MODE hashMode,
-      INT64 hintSize,
+      int64_t hintSize,
       bool* pBoolFilter);
 
 
    //-----------------------------------------------
-   UINT64 Unique(
-      INT64 totalRows,
-      INT64 totalItemSize,
+   uint64_t Unique(
+      int64_t totalRows,
+      int64_t totalItemSize,
       const char* pInput,
 
       // Return values
@@ -584,24 +584,24 @@ public:
       U* pCountArray,
 
       HASH_MODE hashMode,
-      INT64 hintSize,
+      int64_t hintSize,
       bool* pBoolFilter);
 
    //-----------------------------------------------
    void MultiKeyRolling(
-      INT64 totalRows,
-      INT64 totalItemSize,
+      int64_t totalRows,
+      int64_t totalItemSize,
       const char* pInput,
 
       // Return values
       U* pIndexArray,
       U* pRunningCountArray,
       HASH_MODE hashMode,
-      INT64 hintSize);
+      int64_t hintSize);
       
   void MakeHashLocationMultiKey(
-      INT64 totalRows,
-      INT64 totalItemSize,
+      int64_t totalRows,
+      int64_t totalItemSize,
       const char* pInput1,
 
       U* pIndexArray,
@@ -610,127 +610,127 @@ public:
       U* pNextArray,
       U* pFirstArray,
       HASH_MODE hashMode,
-      INT64 hintSize,
+      int64_t hintSize,
       bool* pBoolFilter);
 
    //----------------------------------------------
    void MakeHashLocationString(
-      INT64 arraySize,
+      int64_t arraySize,
       const char* pHashList,
-      INT64 strWidth,
-      INT64 hintSize,
-      BOOL  isUnicode);
+      int64_t strWidth,
+      int64_t hintSize,
+      bool  isUnicode);
 
    void InternalSetLocationString(
       U  i,
       HashLocation* pLocation,
       const char* strValue,
-      INT64 strWidth,
-      UINT64 hash);
+      int64_t strWidth,
+      uint64_t hash);
 
    void InternalSetLocationUnicode(
       U  i,
       HashLocation* pLocation,
       const char* strValue,
-      INT64 strWidth,
-      UINT64 hash);
+      int64_t strWidth,
+      uint64_t hash);
 
    void InternalGetLocationUnicode(
-      INT64  i,
+      int64_t  i,
       HashLocation* pLocation,
-      INT8* pBooleanOutput,
+      int8_t* pBooleanOutput,
       U*    pLocationOutput,
       const char* strValue,
-      INT64 strWidth,
-      UINT64 hash);
+      int64_t strWidth,
+      uint64_t hash);
 
    void InternalGetLocationString(
-      INT64  i,
+      int64_t  i,
       HashLocation* pLocation,
-      INT8* pBooleanOutput,
+      int8_t* pBooleanOutput,
       U*    pLocationOutput,
       const char* strValue,
-      INT64 strWidth,
-      UINT64 hash);
+      int64_t strWidth,
+      uint64_t hash);
 
    void InternalGetLocationUnicode2(
-      INT64  i,
+      int64_t  i,
       HashLocation* pLocation,
-      INT8* pBooleanOutput,
+      int8_t* pBooleanOutput,
       U*    pLocationOutput,
       const char* strValue,
-      INT64 strWidth,
-      INT64 strWidth2,
-      UINT64 hash);
+      int64_t strWidth,
+      int64_t strWidth2,
+      uint64_t hash);
 
    void InternalGetLocationString2(
-      INT64  i,
+      int64_t  i,
       HashLocation* pLocation,
-      INT8* pBooleanOutput,
+      int8_t* pBooleanOutput,
       U*    pLocationOutput,
       const char* strValue,
-      INT64 strWidth,
-      INT64 strWidth2,
-      UINT64 hash);
+      int64_t strWidth,
+      int64_t strWidth2,
+      uint64_t hash);
 
    void IsMemberString(
-      INT64 arraySize,
-      INT64 strWidth1,
-      INT64 strWidth2,
+      int64_t arraySize,
+      int64_t strWidth1,
+      int64_t strWidth2,
       const char* pHashList,
-      INT8* pBooleanOutput,
+      int8_t* pBooleanOutput,
       U*    pLocationOutput,
-      BOOL  isUnicode);
+      bool  isUnicode);
 
 
    void InternalGetLocationStringCategorical(
-      INT64  i,
+      int64_t  i,
       HashLocation* pLocation,
       U*    pLocationOutput,
       const char* strValue,
-      INT64 strWidth,
-      UINT64 hash,
-      INT64* missed);
+      int64_t strWidth,
+      uint64_t hash,
+      int64_t* missed);
 
    void InternalGetLocationString2Categorical(
-      INT64  i,
+      int64_t  i,
       HashLocation* pLocation,
       U*    pLocationOutput,
       const char* strValue,
-      INT64 strWidth,
-      INT64 strWidth2,
-      UINT64 hash,
-      INT64 *missed);
+      int64_t strWidth,
+      int64_t strWidth2,
+      uint64_t hash,
+      int64_t *missed);
 
    //----------------------------------------------
    //----------------------------------------------
    //-----------------------------------------------
    void MakeHashLocationMK(
-      INT64 arraySize,
+      int64_t arraySize,
       T*    pInput,
-      INT64 totalItemSize,
-      INT64 hintSize);
+      int64_t totalItemSize,
+      int64_t hintSize);
 
 
    void MakeHashLocation(
-      INT64 arraySize,
+      int64_t arraySize,
       T*    pHashList,
-      INT64 hintSize);
+      int64_t hintSize);
 
    void InternalSetLocation(
       U  i,
       HashLocation* pLocation,
       T  item,
-      UINT64 hash);
+      uint64_t hash);
 
    //----------------------------------------------
    void InternalGetLocation(
       U  i,
       HashLocation* pLocation,
-      INT8* pBooleanOutput,
+      int8_t* pBooleanOutput,
       U* pLocationOutput,
       T  item,
-      UINT64 hash);
+      uint64_t hash);
 
 
    //----------------------------------------------
@@ -739,13 +739,13 @@ public:
       HashLocation* pLocation,
       U* pLocationOutput,
       T  item,
-      UINT64 hash,
-      INT64* missed);
+      uint64_t hash,
+      int64_t* missed);
 
 
    //----------------------------------------------
-   INT64 IsMemberCategorical(
-      INT64 arraySize,
+   int64_t IsMemberCategorical(
+      int64_t arraySize,
       T*    pHashList,
       U*    pLocationOutput);
 
@@ -753,72 +753,72 @@ public:
 
    //-----------------------------------------------
    template<typename V> void FindLastMatchMK(
-      INT64 arraySize1,
-      INT64 arraySize2,
+      int64_t arraySize1,
+      int64_t arraySize2,
       T*    pKey1,
       T*    pKey2,
       V*    pVal1,
       V*    pVal2,
       U*    pLocationOutput,
-      INT64 totalItemSize,
+      int64_t totalItemSize,
       bool allowExact);
 
    template<typename V> void FindNextMatchMK(
-      INT64 arraySize1,
-      INT64 arraySize2,
+      int64_t arraySize1,
+      int64_t arraySize2,
       T*    pKey1,
       T*    pKey2,
       V*    pVal1,
       V*    pVal2,
       U*    pLocationOutput,
-      INT64 totalItemSize,
+      int64_t totalItemSize,
       bool allowExact);
    //-----------------------------------------------
    //-----------------------------------------------
 
 
    void MakeHashFindNth(
-      INT64 arraySize,
+      int64_t arraySize,
       T*    pHashList,
 
-      // optional FOR BOOLEAN OR INDEX MASK
-      INT64 size2,
+      // optional FOR boolEAN OR INDEX MASK
+      int64_t size2,
       U*    pInput2,
 
-      INT8* pBooleanOutput,
-      INT64 n);
+      int8_t* pBooleanOutput,
+      int64_t n);
 
 
    void MakeHashFindNthFloat(
-      INT64 arraySize,
+      int64_t arraySize,
       T*    pHashList,
 
-      // optional FOR BOOLEAN OR INDEX MASK
-      INT64 size2,
+      // optional FOR boolEAN OR INDEX MASK
+      int64_t size2,
       U*    pInput2,
 
-      INT8* pBooleanOutput,
-      INT64 n);
+      int8_t* pBooleanOutput,
+      int64_t n);
 
 
    void InternalSetFindNth(
       U  i,
       FindNthEntry* pLocation,
-      INT8* pBooleanOutput,
-      INT64 n,
+      int8_t* pBooleanOutput,
+      int64_t n,
       T  item,
-      UINT64 hash);
+      uint64_t hash);
 
    //-----------------------------------------------
    //-----------------------------------------------
 
-   INT64 GetHashSize(INT64 numberOfEntries);
+   int64_t GetHashSize(int64_t numberOfEntries);
 
    //--------------------------------------------
    // Returns 1 if bit set otherwise 0
-   inline int IsBitSet(INT64 position) {
+   inline int IsBitSet(int64_t position) {
 
-      UINT64 index = position >> 6;
+      uint64_t index = position >> 6;
       if (pBitFields[index] & (1LL << (position & 63))) {
          return 1;
       }
@@ -830,17 +830,17 @@ public:
 
    //--------------------------------------------
    // set the bit to 1
-   inline void SetBit(INT64 position) {
+   inline void SetBit(int64_t position) {
 
-      INT64 index = position >> 6;
+      int64_t index = position >> 6;
       pBitFields[index] |= (1LL << (position & 63));
    }
 
    //--------------------------------------------
    // set the bit to 0
-   inline void ClearBit(INT64 position) {
+   inline void ClearBit(int64_t position) {
 
-      INT64 index = position >> 6;
+      int64_t index = position >> 6;
       pBitFields[index] &= ~(1LL << (position & 63));
    }
 };
@@ -848,43 +848,43 @@ public:
 
 
 template<typename T, typename U>
-static INT64 IsMemberStringCategorical(
+static int64_t IsMemberStringCategorical(
    void* pHashLinearVoid,
-   INT64 arraySize,
-   INT64 strWidth1,
-   INT64 strWidth2,
+   int64_t arraySize,
+   int64_t strWidth1,
+   int64_t strWidth2,
    const char* pHashList,
    void*    pLocationOutputU,
-   BOOL isUnicode);
+   bool isUnicode);
 
 
 //----------------------------------------------
 template<typename T, typename U>
 static void IsMemberMK(
    void* pHashLinearVoid,
-   INT64 arraySize,
+   int64_t arraySize,
    T*    pInput,
    T*    pInput2,
-   INT8* pBooleanOutput,
+   int8_t* pBooleanOutput,
    void* pLocationOutput,
-   INT64 totalItemSize);
+   int64_t totalItemSize);
 
 //----------------------------------------------
 template<typename T, typename U>
 static void IsMember(
    void* pHashLinearVoid,
-   INT64 arraySize,
+   int64_t arraySize,
    void* pHashList,
-   INT8* pBooleanOutput,
+   int8_t* pBooleanOutput,
    void* pLocationOutputU);
 
 //----------------------------------------------
 template<typename T, typename U>
 static void IsMemberFloat(
    void* pHashLinearVoid,
-   INT64 arraySize,
+   int64_t arraySize,
    void* pHashList,
-   INT8* pBooleanOutput,
+   int8_t* pBooleanOutput,
    void* pLocationOutputU);
 
 

--- a/src/HashLinear.h
+++ b/src/HashLinear.h
@@ -33,7 +33,7 @@ int64_t IsMemberHashCategorical(
    int64_t size2,
    void* pInput2,
    int32_t* pOutput,
-   INT sizeType,
+   int32_t sizeType,
    HASH_MODE hashMode,
    int64_t hintSize);
 
@@ -43,7 +43,7 @@ int64_t IsMemberHashCategorical64(
    int64_t size2,
    void* pInput2,
    int64_t* pOutput,
-   INT sizeType,
+   int32_t sizeType,
    HASH_MODE hashMode,
    int64_t hintSize);
 
@@ -56,7 +56,7 @@ void* IsMemberHash32(
    void* pInput2,
    U* pOutput,
    int8_t* pBooleanOutput,
-   INT sizeType,
+   int32_t sizeType,
    HASH_MODE hashMode,
    int64_t hintSize);
 
@@ -67,7 +67,7 @@ void* IsMemberHash64(
    void* pInput2,
    int64_t* pOutput,
    int8_t* pBooleanOutput,
-   INT sizeType,
+   int32_t sizeType,
    HASH_MODE hashMode,
    int64_t hintSize);
 
@@ -149,7 +149,7 @@ bool MergePreBinned(
    KEY_TYPE*    pOutput,
    int64_t totalUniqueSize,
    HASH_MODE hashMode,
-   INT dtype);
+   int32_t dtype);
 
 
 
@@ -163,7 +163,7 @@ bool AlignHashMK32(
    int32_t* pOutput,
    int64_t totalItemSize,
    HASH_MODE hashMode,
-   INT dtype,
+   int32_t dtype,
    bool isForward,
    bool allowExact);
 
@@ -177,7 +177,7 @@ bool AlignHashMK64(
    int64_t* pOutput,
    int64_t totalItemSize,
    HASH_MODE hashMode,
-   INT dtype,
+   int32_t dtype,
    bool isForward,
    bool allowExact);
 
@@ -458,11 +458,11 @@ public:
 
    const U     BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
 
-   bool        Deallocate = TRUE;
+   bool        Deallocate = true;
 
 public:
-   // Parallel hashing does not want memory deallocated so it will set deallocate to FALSE
-   CHashLinear(HASH_MODE hashMode = HASH_MODE_PRIME, bool deallocate=TRUE) {
+   // Parallel hashing does not want memory deallocated so it will set deallocate to false
+   CHashLinear(HASH_MODE hashMode = HASH_MODE_PRIME, bool deallocate=true) {
       pHashTableAny = NULL;
       pBitFields = NULL;
 
@@ -479,7 +479,7 @@ public:
 
    ~CHashLinear() {
 
-      FreeMemory(FALSE);
+      FreeMemory(false);
    }
 
    void FreeMemory(bool forceDeallocate);

--- a/src/Hook.cpp
+++ b/src/Hook.cpp
@@ -35,7 +35,7 @@ struct stMATH_HOOK {
    NUMBER_FUNC       SuperMethod;
 
    // Offset from PyNumberMethods
-   INT64             Offset;
+   int64_t             Offset;
 };
 
 // forward reference
@@ -43,14 +43,14 @@ extern stMATH_HOOK  g_MathHook[];
 
 static
 PyObject *
-RiptideTernaryMathFunction(PyObject *self, PyObject *arg1, PyObject *arg2, INT64 index) {
+RiptideTernaryMathFunction(PyObject *self, PyObject *arg1, PyObject *arg2, int64_t index) {
    LOGGING("in ternary math function %lld %s\n", index, self->ob_type->tp_name);
    // third param is optional and is for applying a modulus after the result
    if (arg2 == Py_None) {
       // TODO: intercept a value of 2 to apply square
       if (PyLong_Check(arg1)) {
          int overflow = 0;
-         INT64 power = PyLong_AsLongLongAndOverflow(arg1, &overflow);
+         int64_t power = PyLong_AsLongLongAndOverflow(arg1, &overflow);
          if (power == 1) {
             Py_INCREF(self);
             return self;
@@ -84,7 +84,7 @@ RiptideTernaryMathFunction(PyObject *self, PyObject *arg1, PyObject *arg2, INT64
 
 static
 PyObject *
-RiptideTernaryMathFunctionInplace(PyObject *self, PyObject *arg1, PyObject *arg2, INT64 index) {
+RiptideTernaryMathFunctionInplace(PyObject *self, PyObject *arg1, PyObject *arg2, int64_t index) {
    LOGGING("in ternary math inplace function %lld %s\n", index, self->ob_type->tp_name);
    PyObject* result = BasicMathTwoInputsFromNumber(self, arg1, self, g_MathHook[index].MathOp);
    if (arg2 == Py_None) {
@@ -98,9 +98,9 @@ RiptideTernaryMathFunctionInplace(PyObject *self, PyObject *arg1, PyObject *arg2
 
 static
 PyObject *
-RiptideUnaryMathFunction(PyObject *self, INT64 index) {
+RiptideUnaryMathFunction(PyObject *self, int64_t index) {
    LOGGING("in unary math function %lld %s\n", index, self->ob_type->tp_name);
-   PyObject* result = BasicMathOneInputFromNumber((PyArrayObject*)self, g_MathHook[index].MathOp, FALSE);
+   PyObject* result = BasicMathOneInputFromNumber((PyArrayObject*)self, g_MathHook[index].MathOp, false);
    if (result != Py_None) {
       return result;
    }
@@ -110,7 +110,7 @@ RiptideUnaryMathFunction(PyObject *self, INT64 index) {
 
 static
 PyObject *
-RiptideBinaryMathFunction(PyObject *self, PyObject *right, INT64 index) {
+RiptideBinaryMathFunction(PyObject *self, PyObject *right, int64_t index) {
    //
    // Assumes two inputs, the left always a FastArray
    LOGGING("in binary math function %lld %s\n", index, self->ob_type->tp_name);
@@ -125,7 +125,7 @@ RiptideBinaryMathFunction(PyObject *self, PyObject *right, INT64 index) {
 
 static
 PyObject *
-RiptideBinaryMathFunctionInplace(PyObject *self, PyObject *right, INT64 index) {
+RiptideBinaryMathFunctionInplace(PyObject *self, PyObject *right, int64_t index) {
    //
    // Assumes two inputs, the left always a FastArray and the operation is inplace
    LOGGING("in binary math function inplace %lld %s\n", index, self->ob_type->tp_name);
@@ -259,7 +259,7 @@ static const MATH_OPERATION COMP_TABLE[6] = {
    MATH_OPERATION::CMP_GTE };
 
 static richcmpfunc   g_CompareFunc = NULL;
-static INT64         g_ishooked = 0;
+static int64_t         g_ishooked = 0;
 
 //-----------------------------------------------------------------------------------
 // Called when comparisons on arrays
@@ -303,14 +303,14 @@ BasicMathHook(PyObject *self, PyObject *args) {
 
       if (numbermethods) {
          g_ishooked = 1;
-         BOOL hookNumpy = FALSE;
+         bool hookNumpy = false;
 
          // Hook python comparison functions
          g_CompareFunc = fastArrayClass->ob_type->tp_richcompare;
          fastArrayClass->ob_type->tp_richcompare = CompareFunction;
 
-         INT64 i = 0;
-         while (TRUE) {
+         int64_t i = 0;
+         while (true) {
             if (g_MathHook[i].MathOp == MATH_OPERATION::LAST) break;
 
             // Use the offset to get to the function ptr for this method

--- a/src/MathThreads.cpp
+++ b/src/MathThreads.cpp
@@ -72,7 +72,7 @@ WaitAddress g_WaitAddress=NULL;
 //   * BSD syscalls like __psynch_cvwait (and other __psynch functions). These are not externally documented -- need to look in github.com/apple/darwin-libpthread to see how things work.
 //
 #if defined(RT_OS_WINDOWS)
-uint32_t WINAPI WorkerThreadFunction(LPVOID lpParam)
+DWORD WINAPI WorkerThreadFunction(LPVOID lpParam)
 #else
 void *
 WorkerThreadFunction(void *lpParam)

--- a/src/MathThreads.h
+++ b/src/MathThreads.h
@@ -41,8 +41,8 @@ extern pthread_cond_t  g_WakeupCond;
 //WINAPI
 //WaitOnAddress(
 //   _In_reads_bytes_(AddressSize) volatile void * Address,
-//   _In_reads_bytes_(AddressSize) PVOID CompareAddress,
-//   _In_ SIZE_T AddressSize,
+//   _In_reads_bytes_(AddressSize) void* CompareAddress,
+//   _In_ size_t AddressSize,
 //   _In_opt_ DWORD dwMilliseconds
 //);
 //
@@ -50,22 +50,22 @@ extern pthread_cond_t  g_WakeupCond;
 //void
 //WINAPI
 //WakeByAddressSingle(
-//   _In_ PVOID Address
+//   _In_ void* Address
 //);
 //
 //
 //void
 //WINAPI
 //WakeByAddressAll(
-//   _In_ PVOID Address
+//   _In_ void* Address
 //);
 
 //-------------------------------------------------------------------
 //
 // global scope
-typedef void(WINAPI *WakeSingleAddress)(PVOID);
-typedef void(WINAPI *WakeAllAddress)(PVOID);
-typedef bool(WINAPI *WaitAddress)(volatile void*, PVOID, SIZE_T, DWORD);
+typedef void(WINAPI *WakeSingleAddress)(void*);
+typedef void(WINAPI *WakeAllAddress)(void*);
+typedef bool(WINAPI *WaitAddress)(volatile void*, void*, size_t, uint32_t);
 
 extern WakeSingleAddress g_WakeSingleAddress;
 extern WakeAllAddress g_WakeAllAddress;
@@ -352,12 +352,12 @@ struct stWorkerRing {
          if (maxThreadsToWake < 5) {
             // In windows faster to wake single if just a few threads
             for (int i = 0; i < maxThreadsToWake; i++) {
-               g_WakeSingleAddress((PVOID)&WorkIndex);
+               g_WakeSingleAddress((void*)&WorkIndex);
             }
          }
          else {
             // In windows the more threads we wake up, the longer it takes to return from this OS call
-            g_WakeAllAddress((PVOID)&WorkIndex);
+            g_WakeAllAddress((void*)&WorkIndex);
          }
       }
 
@@ -384,7 +384,7 @@ struct stWorkerRing {
 };
 
 WakeSingleAddress InitWakeCalls();
-//DWORD WINAPI WorkerThreadFunction(LPVOID lpParam);
+//DWORD WINAPI WorkerThreadFunction(void* lpParam);
 
 
 

--- a/src/MathThreads.h
+++ b/src/MathThreads.h
@@ -37,24 +37,24 @@ extern pthread_cond_t  g_WakeupCond;
 
 
 //--------------------------------------------------------------------
-//BOOL
+//bool
 //WINAPI
 //WaitOnAddress(
-//   _In_reads_bytes_(AddressSize) volatile VOID * Address,
+//   _In_reads_bytes_(AddressSize) volatile void * Address,
 //   _In_reads_bytes_(AddressSize) PVOID CompareAddress,
 //   _In_ SIZE_T AddressSize,
 //   _In_opt_ DWORD dwMilliseconds
 //);
 //
 //
-//VOID
+//void
 //WINAPI
 //WakeByAddressSingle(
 //   _In_ PVOID Address
 //);
 //
 //
-//VOID
+//void
 //WINAPI
 //WakeByAddressAll(
 //   _In_ PVOID Address
@@ -63,9 +63,9 @@ extern pthread_cond_t  g_WakeupCond;
 //-------------------------------------------------------------------
 //
 // global scope
-typedef VOID(WINAPI *WakeSingleAddress)(PVOID);
-typedef VOID(WINAPI *WakeAllAddress)(PVOID);
-typedef BOOL(WINAPI *WaitAddress)(volatile VOID*, PVOID, SIZE_T, DWORD);
+typedef void(WINAPI *WakeSingleAddress)(PVOID);
+typedef void(WINAPI *WakeAllAddress)(PVOID);
+typedef bool(WINAPI *WaitAddress)(volatile void*, PVOID, SIZE_T, DWORD);
 
 extern WakeSingleAddress g_WakeSingleAddress;
 extern WakeAllAddress g_WakeAllAddress;
@@ -75,20 +75,20 @@ extern WaitAddress g_WaitAddress;
 extern FUNCTION_LIST*   g_FunctionListArray[];
 
 // Callback routine from worker thread
-typedef BOOL(*DOWORK_CALLBACK)(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex);
+typedef bool(*DOWORK_CALLBACK)(struct stMATH_WORKER_ITEM* pstWorkerItem, int32_t core, int64_t workIndex);
 
 // Callback routine from multithreaded worker thread (items just count up from 0,1,2,...)
-typedef BOOL(*MTWORK_CALLBACK)(void* callbackArg, int core, INT64 workIndex);
+typedef bool(*MTWORK_CALLBACK)(void* callbackArg, int32_t core, int64_t workIndex);
 
 // Callback routine from multithreaded chunk thread (0, 65536, 130000, etc.)
-typedef BOOL(*MTCHUNK_CALLBACK)(void* callbackArg, int core, INT64 start, INT64 length);
+typedef bool(*MTCHUNK_CALLBACK)(void* callbackArg, int32_t core, int64_t start, int64_t length);
 
 // For auto binning we need to divide bins up amongst multiple thread
 struct stBinCount {
    // Valid if ... > BinLow && <= BinHigh
-   INT64 BinLow;
-   INT64 BinHigh;
-   INT64 BinNum;
+   int64_t BinLow;
+   int64_t BinHigh;
+   int64_t BinNum;
    void* pUserMemory;
 };
 
@@ -98,41 +98,41 @@ struct OLD_CALLBACK {
 
    // Args to call
    union {
-      VOID*             pDataInBase1;
-      VOID*             pValues;
+      void*             pDataInBase1;
+      void*             pValues;
    };
 
    union {
-      VOID*             pDataInBase2;
-      VOID*             pIndex;
-      VOID*             pToSort;
+      void*             pDataInBase2;
+      void*             pIndex;
+      void*             pToSort;
    };
 
-   VOID*             pDataInBase3;
+   void*             pDataInBase3;
 
    //-------------------------------------------------
    union {
-      VOID*             pDataOutBase1;
-      VOID*             pWorkSpace;
+      void*             pDataOutBase1;
+      void*             pWorkSpace;
    };
 
    // Total number of array elements
    union {
-      //INT64             TotalElements;
-      INT64             IndexSize;
+      //int64_t             TotalElements;
+      int64_t             IndexSize;
 
       // strlen is for sorting strings
-      INT64             StrLen;
+      int64_t             StrLen;
    };
 
    union {
-      INT32             ScalarMode;
-      INT32             MergeBlocks;
+      int32_t             ScalarMode;
+      int32_t             MergeBlocks;
    };
 
    union {
-      INT64             TotalElements2;
-      INT64             ValSize;
+      int64_t             TotalElements2;
+      int64_t             ValSize;
    };
 
    // Default value to fill
@@ -177,9 +177,9 @@ struct stMATH_WORKER_ITEM {
    // sum:        52      xx      30 us     xx
 
    // Items larger than this might be worked on in parallel
-   static const INT64 WORK_ITEM_CHUNK = 0x4000;
-   static const INT64 WORK_ITEM_BIG = (WORK_ITEM_CHUNK * 2);
-   static const INT64 WORK_ITEM_MASK = (WORK_ITEM_CHUNK - 1);
+   static const int64_t WORK_ITEM_CHUNK = 0x4000;
+   static const int64_t WORK_ITEM_BIG = (WORK_ITEM_CHUNK * 2);
+   static const int64_t WORK_ITEM_MASK = (WORK_ITEM_CHUNK - 1);
 
    // The callback to the thread routine that does work
    // with the argument to pass
@@ -187,7 +187,7 @@ struct stMATH_WORKER_ITEM {
    void*             WorkCallbackArg;
 
    // How many threads to wake up (atomic decrement)
-   INT64             ThreadWakeup;
+   int64_t             ThreadWakeup;
 
    // Used when calling MultiThreadedWork
    union {
@@ -196,34 +196,34 @@ struct stMATH_WORKER_ITEM {
    };
 
    // TotalElements is used on asymmetric last block
-   INT64             TotalElements;
+   int64_t             TotalElements;
 
    // How many elements per block to work on
-   INT64             BlockSize;
+   int64_t             BlockSize;
 
 
    // The last block to work on
-   volatile INT64    BlockLast;
+   volatile int64_t    BlockLast;
 
    //-------------------------------------------------
    // The next block (atomic)
    // Incremented
    // If BlockNext > BlockLast -- no work to be done
-   volatile INT64    BlockNext;
+   volatile int64_t    BlockNext;
 
 
    //-----------------------------------------------
    // Atomic access
    // When BlocksCompleted == BlockLast , the job is completed
-   INT64             BlocksCompleted;
+   int64_t             BlocksCompleted;
 
 
    // Get rid of this
    OLD_CALLBACK      OldCallback;
 
    //==============================================================
-   FORCE_INLINE INT64 GetWorkBlock() {
-      INT64 val=  InterlockedIncrement64(&BlockNext);
+   FORCE_INLINE int64_t GetWorkBlock() {
+      int64_t val=  InterlockedIncrement64(&BlockNext);
       return val - 1;
    }
 
@@ -237,8 +237,8 @@ struct stMATH_WORKER_ITEM {
    // Called by routines that work by index 
    // returns 0 on failure
    // else returns length of workblock
-   FORCE_INLINE INT64 GetNextWorkIndex(INT64* workBlock) {
-      INT64 wBlock = *workBlock = GetWorkBlock();
+   FORCE_INLINE int64_t GetNextWorkIndex(int64_t* workBlock) {
+      int64_t wBlock = *workBlock = GetWorkBlock();
 
       //printf("working on block %llu\n", wBlock);
 
@@ -254,15 +254,15 @@ struct stMATH_WORKER_ITEM {
    // Called by routines that work on chunks/blocks of memory
    // returns 0 on failure
    // else returns length of workblock
-   FORCE_INLINE INT64 GetNextWorkBlock(INT64* workBlock) {
+   FORCE_INLINE int64_t GetNextWorkBlock(int64_t* workBlock) {
 
-      INT64 wBlock = *workBlock = GetWorkBlock();
+      int64_t wBlock = *workBlock = GetWorkBlock();
 
       //printf("working on block %llu\n", wBlock);
 
       // Make sure something to work on
       if (wBlock < BlockLast) {
-         INT64  lenWorkBlock ;
+         int64_t  lenWorkBlock ;
          lenWorkBlock = BlockSize;
 
          // Check if this is the last workblock
@@ -287,7 +287,7 @@ struct stMATH_WORKER_ITEM {
    // Returns TRUE if it did some work
    // Returns FALSE if it did no work 
    // If core is -1, it is the main thread
-   FORCE_INLINE BOOL DoWork(int core, INT64 workIndex) {
+   FORCE_INLINE bool DoWork(int core, int64_t workIndex) {
 
       return DoWorkCallback(this, core, workIndex);
    }
@@ -298,22 +298,22 @@ struct stMATH_WORKER_ITEM {
 //-----------------------------------------------------------
 // allocated on 64 byte alignment
 struct stWorkerRing {
-   static const INT64   RING_BUFFER_SIZE = 1024;
-   static const INT64   RING_BUFFER_MASK = 1023;
+   static const int64_t   RING_BUFFER_SIZE = 1024;
+   static const int64_t   RING_BUFFER_MASK = 1023;
 
-   volatile INT64       WorkIndex ;
-   volatile INT64       WorkIndexCompleted ;
+   volatile int64_t       WorkIndex ;
+   volatile int64_t       WorkIndexCompleted ;
 
    // incremented when worker thread start
-   volatile INT64       WorkThread ;
-   INT32                Reserved32;
-   INT32                SleepTime ;
+   volatile int64_t       WorkThread ;
+   int32_t                Reserved32;
+   int32_t                SleepTime ;
 
-   INT32                NumaNode;
-   INT32                Cancelled;
+   int32_t                NumaNode;
+   int32_t                Cancelled;
 
    // Change this value to wake up less workers
-   INT32                FutexWakeCount;
+   int32_t                FutexWakeCount;
 
    stMATH_WORKER_ITEM   WorkerQueue[RING_BUFFER_SIZE];
 
@@ -340,7 +340,7 @@ struct stWorkerRing {
       return  &WorkerQueue[(WorkIndex - 1) & RING_BUFFER_MASK];
    }
 
-   FORCE_INLINE void SetWorkItem(INT32 maxThreadsToWake) {
+   FORCE_INLINE void SetWorkItem(int32_t maxThreadsToWake) {
       // This routine will wakup threads on Windows and Linux
       // Once we increment other threads will notice
       InterlockedIncrement64(&WorkIndex);

--- a/src/MathWorker.cpp
+++ b/src/MathWorker.cpp
@@ -371,7 +371,7 @@ extern "C" {
    
    #else
    #warning No thread-affinity support implemented for this OS. This does not prevent riptide from running but overall performance may be reduced.
-      return FALSE;
+      return false;
       
    #endif   // defined(RT_OS_LINUX) || defined(RT_OS_FREEBSD)
    }

--- a/src/MathWorker.cpp
+++ b/src/MathWorker.cpp
@@ -300,12 +300,12 @@ extern "C" {
    }
 
 
-   VOID Sleep(DWORD dwMilliseconds) {
+   void Sleep(unsigned int dwMilliseconds) {
       usleep(dwMilliseconds * 1000);
    }
 
    bool CloseHandle(THANDLE hObject) {
-      return TRUE;
+      return true;
    }
 
    pid_t GetCurrentThread() {
@@ -367,7 +367,7 @@ extern "C" {
       }
 
       //CPU_ISSET = 0xFF;
-      return TRUE;
+      return true;
    
    #else
    #warning No thread-affinity support implemented for this OS. This does not prevent riptide from running but overall performance may be reduced.
@@ -377,19 +377,19 @@ extern "C" {
    }
 
 
-   HANDLE GetCurrentProcess(VOID) {
+   HANDLE GetCurrentProcess() {
       return NULL;
    }
 
-   DWORD  GetLastError(VOID) {
+   unsigned int  GetLastError() {
       return 0;
    }
 
-   HANDLE CreateThread(VOID* lpThreadAttributes, SIZE_T dwStackSize, LPTHREAD_START_ROUTINE lpStartAddress, LPVOID lpParameter, DWORD dwCreationFlags, LPDWORD lpThreadId) {
+   HANDLE CreateThread(void* lpThreadAttributes, size_t dwStackSize, LPTHREAD_START_ROUTINE lpStartAddress, void* lpParameter, unsigned int dwCreationFlags, uint32_t* lpThreadId) {
       return NULL;
    }
 
-   HMODULE LoadLibraryW(const WCHAR* lpLibFileName) {
+   HMODULE LoadLibraryW(const wchar_t* lpLibFileName) {
       return NULL;
    }
 
@@ -443,7 +443,7 @@ int GetProcCount() {
 
    uint64_t mask1;
    uint64_t mask2;
-   INT count;
+   int32_t count;
 
    count = 0;
    GetProcessAffinityMask(proc, &mask1, &mask2);

--- a/src/MathWorker.cpp
+++ b/src/MathWorker.cpp
@@ -46,20 +46,18 @@ TODO
 #  define MEM_STATIC static  /* this version may generate warnings for unused static functions; disable the relevant warning */
 #endif
 
-typedef unsigned int U32;
-
 typedef struct {
-   U32 f1c;
-   U32 f1d;
-   U32 f7b;
-   U32 f7c;
+   uint32_t f1c;
+   uint32_t f1d;
+   uint32_t f7b;
+   uint32_t f7c;
 } ZSTD_cpuid_t;
 
 MEM_STATIC ZSTD_cpuid_t ZSTD_cpuid(void) {
-   U32 f1c = 0;
-   U32 f1d = 0;
-   U32 f7b = 0;
-   U32 f7c = 0;
+   uint32_t f1c = 0;
+   uint32_t f1d = 0;
+   uint32_t f7b = 0;
+   uint32_t f7c = 0;
 #ifdef _MSC_VER
    int reg[4];
    __cpuid((int*)reg, 0);
@@ -67,13 +65,13 @@ MEM_STATIC ZSTD_cpuid_t ZSTD_cpuid(void) {
       int const n = reg[0];
       if (n >= 1) {
          __cpuid((int*)reg, 1);
-         f1c = (U32)reg[2];
-         f1d = (U32)reg[3];
+         f1c = (uint32_t)reg[2];
+         f1d = (uint32_t)reg[3];
       }
       if (n >= 7) {
          __cpuidex((int*)reg, 7, 0);
-         f7b = (U32)reg[1];
-         f7c = (U32)reg[2];
+         f7b = (uint32_t)reg[1];
+         f7c = (uint32_t)reg[2];
       }
    }
 #elif defined(__i386__) && defined(__PIC__) && !defined(__clang__) && defined(__GNUC__)
@@ -81,7 +79,7 @@ MEM_STATIC ZSTD_cpuid_t ZSTD_cpuid(void) {
    * reserves ebx for use of its pic register so we must specially
    * handle the save and restore to avoid clobbering the register
    */
-   U32 n;
+   uint32_t n;
    __asm__(
       "pushl %%ebx\n\t"
       "cpuid\n\t"
@@ -90,7 +88,7 @@ MEM_STATIC ZSTD_cpuid_t ZSTD_cpuid(void) {
       : "a"(0)
       : "ecx", "edx");
    if (n >= 1) {
-      U32 f1a;
+      uint32_t f1a;
       __asm__(
          "pushl %%ebx\n\t"
          "cpuid\n\t"
@@ -109,14 +107,14 @@ MEM_STATIC ZSTD_cpuid_t ZSTD_cpuid(void) {
          : "edx");
    }
 #elif defined(__x86_64__) || defined(_M_X64) || defined(__i386__)
-   U32 n;
+   uint32_t n;
    __asm__("cpuid" : "=a"(n) : "a"(0) : "ebx", "ecx", "edx");
    if (n >= 1) {
-      U32 f1a;
+      uint32_t f1a;
       __asm__("cpuid" : "=a"(f1a), "=c"(f1c), "=d"(f1d) : "a"(1) : "ebx");
    }
    if (n >= 7) {
-      U32 f7a;
+      uint32_t f7a;
       __asm__("cpuid"
          : "=a"(f7a), "=b"(f7b), "=c"(f7c)
          : "a"(7), "c"(0)
@@ -306,7 +304,7 @@ extern "C" {
       usleep(dwMilliseconds * 1000);
    }
 
-   BOOL CloseHandle(THANDLE hObject) {
+   bool CloseHandle(THANDLE hObject) {
       return TRUE;
    }
 
@@ -314,11 +312,11 @@ extern "C" {
       return gettid();
    }
 
-   UINT64 SetThreadAffinityMask(pid_t hThread, UINT64 dwThreadAffinityMask) {
+   uint64_t SetThreadAffinityMask(pid_t hThread, uint64_t dwThreadAffinityMask) {
    #if defined(RT_OS_LINUX) || defined(RT_OS_FREEBSD)
       cpu_set_t cpuset;
 
-      UINT64 bitpos = 1;
+      uint64_t bitpos = 1;
       int count = 0;
 
       while (!(bitpos & dwThreadAffinityMask)) {
@@ -346,7 +344,7 @@ extern "C" {
       return 0;
    }
 
-   BOOL GetProcessAffinityMask(HANDLE hProcess, UINT64* lpProcessAffinityMask, UINT64* lpSystemAffinityMask) {
+   bool GetProcessAffinityMask(HANDLE hProcess, uint64_t* lpProcessAffinityMask, uint64_t* lpSystemAffinityMask) {
    #if defined(RT_OS_LINUX) || defined(RT_OS_FREEBSD)
       cpu_set_t cpuset;
       sched_getaffinity(getpid(), sizeof(cpuset), &cpuset);
@@ -354,7 +352,7 @@ extern "C" {
       *lpProcessAffinityMask = 0;
       *lpSystemAffinityMask = 0;
 
-      UINT64 bitpos = 1;
+      uint64_t bitpos = 1;
       for (int i = 0; i < 63; i++) {
          if (CPU_ISSET(i, &cpuset)) {
             *lpProcessAffinityMask |= bitpos;
@@ -443,8 +441,8 @@ int GetProcCount() {
 
    HANDLE proc = GetCurrentProcess();
 
-   UINT64 mask1;
-   UINT64 mask2;
+   uint64_t mask1;
+   uint64_t mask2;
    INT count;
 
    count = 0;

--- a/src/MathWorker.h
+++ b/src/MathWorker.h
@@ -14,7 +14,7 @@ typedef HINSTANCE HMODULE;
 typedef wchar_t WCHAR;    // wc,   16-bit UNICODE character
 
 extern "C" {
-   typedef int* (WINAPI *FARPROC)();
+   typedef ptrdiff_t (WINAPI *FARPROC)();
    typedef unsigned int(WINAPI *PTHREAD_START_ROUTINE)(void* lpThreadParameter);
    typedef PTHREAD_START_ROUTINE LPTHREAD_START_ROUTINE;
 

--- a/src/MathWorker.h
+++ b/src/MathWorker.h
@@ -14,7 +14,7 @@ typedef HINSTANCE HMODULE;
 typedef wchar_t WCHAR;    // wc,   16-bit UNICODE character
 
 extern "C" {
-   typedef long long (WINAPI *FARPROC)();
+   typedef INT_PTR (WINAPI *FARPROC)();
    typedef unsigned int(WINAPI *PTHREAD_START_ROUTINE)(void* lpThreadParameter);
    typedef PTHREAD_START_ROUTINE LPTHREAD_START_ROUTINE;
 

--- a/src/MathWorker.h
+++ b/src/MathWorker.h
@@ -30,10 +30,10 @@ extern "C" {
    extern int GetProcCount();
 
    //VOID WINAPI Sleep(DWORD dwMilliseconds);
-   //BOOL WINAPI CloseHandle(HANDLE hObject);
+   //bool WINAPI CloseHandle(HANDLE hObject);
    //HANDLE WINAPI GetCurrentThread(VOID);
-   //UINT64 WINAPI SetThreadAffinityMask(HANDLE hThread, UINT64 dwThreadAffinityMask);
-   //BOOL WINAPI GetProcessAffinityMask(HANDLE hProcess, UINT64* lpProcessAffinityMask, UINT64* lpSystemAffinityMask);
+   //uint64_t WINAPI SetThreadAffinityMask(HANDLE hThread, uint64_t dwThreadAffinityMask);
+   //bool WINAPI GetProcessAffinityMask(HANDLE hProcess, uint64_t* lpProcessAffinityMask, uint64_t* lpSystemAffinityMask);
    //HANDLE WINAPI GetCurrentProcess(VOID);
    //DWORD WINAPI GetLastError(VOID);
 
@@ -47,11 +47,11 @@ extern "C" {
 
    int GetProcCount();
    VOID Sleep(DWORD dwMilliseconds);
-   BOOL CloseHandle(THANDLE hObject);
+   bool CloseHandle(THANDLE hObject);
 
-   UINT64 SetThreadAffinityMask(pid_t hThread, UINT64 dwThreadAffinityMask);
+   uint64_t SetThreadAffinityMask(pid_t hThread, uint64_t dwThreadAffinityMask);
 
-   BOOL GetProcessAffinityMask(HANDLE hProcess, UINT64* lpProcessAffinityMask, UINT64* lpSystemAffinityMask);
+   bool GetProcessAffinityMask(HANDLE hProcess, uint64_t* lpProcessAffinityMask, uint64_t* lpSystemAffinityMask);
    pid_t GetCurrentThread();
 
    HANDLE GetCurrentProcess(VOID);
@@ -78,18 +78,18 @@ THANDLE StartThread(stWorkerRing* pWorkerRing);
 class CMathWorker {
 
 public:
-   static const INT64 WORK_ITEM_CHUNK = stMATH_WORKER_ITEM::WORK_ITEM_CHUNK;
-   static const INT64 WORK_ITEM_BIG = stMATH_WORKER_ITEM::WORK_ITEM_BIG;
-   static const INT64 WORK_ITEM_MASK = stMATH_WORKER_ITEM::WORK_ITEM_MASK;
-   static const INT MAX_WORKER_HANDLES = 64;
+   static const int64_t WORK_ITEM_CHUNK = stMATH_WORKER_ITEM::WORK_ITEM_CHUNK;
+   static const int64_t WORK_ITEM_BIG = stMATH_WORKER_ITEM::WORK_ITEM_BIG;
+   static const int64_t WORK_ITEM_MASK = stMATH_WORKER_ITEM::WORK_ITEM_MASK;
+   static const int32_t MAX_WORKER_HANDLES = 64;
 
-   INT   WorkerThreadCount;
+   int32_t   WorkerThreadCount;
 
    // Set to true to stop threading
-   BOOL  NoThreading;
+   bool  NoThreading;
 
    // Set to true to stop allocating from a cache
-   BOOL  NoCaching;
+   bool  NoCaching;
 
    //------------------------------------------------------------------------------
    // Data Members 
@@ -128,14 +128,14 @@ public:
 
    //------------------------------------------------------------------------------
    // Returns number of worker threads + main thread
-   INT GetNumCores() {
+   int32_t GetNumCores() {
       // include main python thread
       return WorkerThreadCount + 1;
    }
 
    //---------------------------------
    // Changes how many threads wake up in Linux
-   INT SetFutexWakeup(int howManyToWake) {
+   int32_t SetFutexWakeup(int howManyToWake) {
       if (howManyToWake < 1) {
          // On Windows seem to need at least 1
          howManyToWake = 1;
@@ -152,7 +152,7 @@ public:
       return previousVal;
    }
 
-   INT GetFutexWakeup() {
+   int32_t GetFutexWakeup() {
       return pWorkerRing->FutexWakeCount;
    }
 
@@ -168,9 +168,9 @@ public:
 
       // Pin the main thread to a numa node?
       // TODO: work
-      //UINT64 mask = ((UINT64)1 << WorkerThreadCount);//core number starts from 0
-      // UINT64 ret = SetThreadAffinityMask(GetCurrentThread(), (UINT64)0xFFFF);
-      // SetThreadAffinityMask(GetCurrentThread(), (UINT64)0xFFFFFFFF);
+      //uint64_t mask = ((uint64_t)1 << WorkerThreadCount);//core number starts from 0
+      // uint64_t ret = SetThreadAffinityMask(GetCurrentThread(), (uint64_t)0xFFFF);
+      // SetThreadAffinityMask(GetCurrentThread(), (uint64_t)0xFFFFFFFF);
 
    }
 
@@ -186,13 +186,13 @@ public:
 
    //------------------------------------------------------------------------------
    //  Concurrent callback from multiple threads
-   static BOOL MultiThreadedCounterCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
+   static bool MultiThreadedCounterCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
       // -1 is the first core
       core = core + 1;
-      BOOL didSomeWork = FALSE;
+      bool didSomeWork = FALSE;
 
-      INT64 index;
-      INT64 workBlock;
+      int64_t index;
+      int64_t workBlock;
 
       // As long as there is work to do
       while ((index = pstWorkerItem->GetNextWorkIndex(&workBlock)) > 0) {
@@ -213,7 +213,7 @@ public:
    //-----------------------------------------------------------
    // Automatically handles threading vs no threading
    // Uses counters that start at 0 and go up from 1
-   void DoMultiThreadedWork(int numItems, MTWORK_CALLBACK  doMTWorkCallback, void* workCallbackArg, INT32 threadWakeup=0)
+   void DoMultiThreadedWork(int numItems, MTWORK_CALLBACK  doMTWorkCallback, void* workCallbackArg, int32_t threadWakeup=0)
    {
       // See if we get a work item (threading might be off)
       stMATH_WORKER_ITEM* pWorkItem = GetWorkItemCount(numItems);
@@ -244,19 +244,19 @@ public:
    //------------------------------------------------------------------------------
    //  Concurrent callback from multiple threads
    //  Based on chunk size, each workIndex gets (0, 65536, 130000, etc.)
-   // callback sig: typedef BOOL(*MTCHUNK_CALLBACK)(void* callbackArg, int core, INT64 start, INT64 length);
+   // callback sig: typedef bool(*MTCHUNK_CALLBACK)(void* callbackArg, int core, int64_t start, int64_t length);
 
-   static BOOL MultiThreadedChunkCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
+   static bool MultiThreadedChunkCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
       // -1 is the first core
       core = core + 1;
-      BOOL didSomeWork = FALSE;
+      bool didSomeWork = FALSE;
 
-      INT64 lenX;
-      INT64 workBlock;
+      int64_t lenX;
+      int64_t workBlock;
 
       // As long as there is work to do
       while ((lenX = pstWorkerItem->GetNextWorkBlock(&workBlock)) > 0) {
-         INT64 start = pstWorkerItem->BlockSize * workBlock;
+         int64_t start = pstWorkerItem->BlockSize * workBlock;
 
          pstWorkerItem->MTChunkCallback(pstWorkerItem->WorkCallbackArg, core, start, lenX);
 
@@ -273,7 +273,7 @@ public:
    // Automatically handles threading vs no threading
    // Used to divide up single array of data into chunks or sections
    // Returns TRUE if actually did multithreaded work, otherwise FALSE
-   BOOL DoMultiThreadedChunkWork(INT64 lengthData, MTCHUNK_CALLBACK  doMTChunkCallback, void* workCallbackArg, INT32 threadWakeup=0)
+   bool DoMultiThreadedChunkWork(int64_t lengthData, MTCHUNK_CALLBACK  doMTChunkCallback, void* workCallbackArg, int32_t threadWakeup=0)
    {
       // See if we get a work item (threading might be off)
       stMATH_WORKER_ITEM* pWorkItem = GetWorkItem(lengthData);
@@ -313,10 +313,10 @@ public:
    //
    // numCores often passed to DoMultiThreadedWork(numCores,...)
    ///
-   INT64 SegmentBins(INT64 bins, INT64 maxCores, stBinCount** ppstBinCount) {
+   int64_t SegmentBins(int64_t bins, int64_t maxCores, stBinCount** ppstBinCount) {
       // TODO: general purpose routine for this
-      INT numCores = GetFutexWakeup();
-      INT64 cores = numCores;
+      int32_t numCores = GetFutexWakeup();
+      int64_t cores = numCores;
 
       // Check if we are clamping the core count
       if (maxCores > 0 && cores > maxCores) {
@@ -330,13 +330,13 @@ public:
       stBinCount* pstBinCount = (stBinCount*)WORKSPACE_ALLOC(cores * sizeof(stBinCount));
 
       if (cores > 0) {
-         INT64 dividend = bins / cores;
-         INT64 remainder = bins % cores;
+         int64_t dividend = bins / cores;
+         int64_t remainder = bins % cores;
 
-         INT64 low = 0;
-         INT64 high = 0;
+         int64_t low = 0;
+         int64_t high = 0;
 
-         for (INT64 i = 0; i < cores; i++) {
+         for (int64_t i = 0; i < cores; i++) {
 
             // Calculate band range
             high = low + dividend;
@@ -365,7 +365,7 @@ public:
    //------------------------------------------------------------------------------
    // Returns NULL if work item is too small or threading turned off
    // Otherwise returns a work item
-   stMATH_WORKER_ITEM* GetWorkItemCount(INT64 len) {
+   stMATH_WORKER_ITEM* GetWorkItemCount(int64_t len) {
       // If it is a small work item, process it immediately
       if (NoThreading) {
          return NULL;
@@ -380,7 +380,7 @@ public:
    //------------------------------------------------------------------------------
    // Returns NULL if work item is too small or threading turned off
    // Otherwise returns a work item
-   stMATH_WORKER_ITEM* GetWorkItem(INT64 len) {
+   stMATH_WORKER_ITEM* GetWorkItem(int64_t len) {
       // If it is a small work item, process it immediately
       if (len < WORK_ITEM_BIG || NoThreading) {
          return NULL;
@@ -395,14 +395,14 @@ public:
    // Called from main thread
    void WorkMain(
       stMATH_WORKER_ITEM* pWorkItem, 
-      INT64 len, 
-      INT32  threadWakeup,
-      INT64 BlockSize= WORK_ITEM_CHUNK, 
+      int64_t len, 
+      int32_t  threadWakeup,
+      int64_t BlockSize= WORK_ITEM_CHUNK, 
       bool bGenericMode=TRUE) {
 
       pWorkItem->TotalElements = len;
 
-      const INT32   maxWakeup = GetFutexWakeup();
+      const int32_t   maxWakeup = GetFutexWakeup();
 
       MATHLOGGING("wakeup max:%d  requested:%d\n", maxWakeup, threadWakeup);
       // Only windows uses ThreadWakup
@@ -437,7 +437,7 @@ public:
 
       // Tell all worker threads about this new work item (futex or wakeall)
       // TODO: Consider waking a different number of threads based on complexity
-      UINT64 currentTSC = __rdtsc();
+      uint64_t currentTSC = __rdtsc();
       pWorkerRing->SetWorkItem(threadWakeup);
 
       MATHLOGGING("Took %lld cycles to wakeup\n", __rdtsc()-currentTSC);
@@ -468,15 +468,15 @@ public:
 
    //=================================================================================================================
 
-   static BOOL AnyScatterGather(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
-      BOOL didSomeWork = FALSE;
+   static bool AnyScatterGather(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
+      bool didSomeWork = FALSE;
       OLD_CALLBACK* OldCallback = &pstWorkerItem->OldCallback;
 
 
-      INT64 typeSizeIn = OldCallback->FunctionList->InputItemSize;
+      int64_t typeSizeIn = OldCallback->FunctionList->InputItemSize;
       char* pDataInX = (char *)OldCallback->pDataInBase1;
-      INT64 lenX;
-      INT64 workBlock;
+      int64_t lenX;
+      int64_t workBlock;
 
       // Get the workspace calculation for this column
       stScatterGatherFunc* pstScatterGatherFunc = &((stScatterGatherFunc*)(OldCallback->pThreadWorkSpace))[core + 1];
@@ -489,7 +489,7 @@ public:
          // workBlock is length of work
          THREADLOGGING("[%d][%llu] Zero started working on %lld\n", core, workIndex, workBlock);
 
-         INT64 offsetAdj = pstWorkerItem->BlockSize * workBlock * typeSizeIn;
+         int64_t offsetAdj = pstWorkerItem->BlockSize * workBlock * typeSizeIn;
 
          OldCallback->FunctionList->AnyScatterGatherCall(pDataInX + offsetAdj, lenX, pstScatterGatherFunc);
 
@@ -506,12 +506,12 @@ public:
 
    }
 
-   static BOOL AnyGroupby(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
-      BOOL didSomeWork = FALSE;
+   static bool AnyGroupby(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
+      bool didSomeWork = FALSE;
       GROUPBY_FUNC groupByCall = (GROUPBY_FUNC)(pstWorkerItem->WorkCallbackArg);
 
-      INT64 index;
-      INT64 workBlock;
+      int64_t index;
+      int64_t workBlock;
 
       THREADLOGGING("[%d] DoWork start loop\n", core);
 
@@ -539,27 +539,27 @@ public:
    }
 
 
-   static BOOL AnyTwoCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
-      BOOL didSomeWork = FALSE;
+   static bool AnyTwoCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
+      bool didSomeWork = FALSE;
       OLD_CALLBACK* OldCallback = &pstWorkerItem->OldCallback;
 
-      INT64 strideSizeIn = OldCallback->FunctionList->InputItemSize;
-      INT64 strideSizeOut = OldCallback->FunctionList->OutputItemSize;
+      int64_t strideSizeIn = OldCallback->FunctionList->InputItemSize;
+      int64_t strideSizeOut = OldCallback->FunctionList->OutputItemSize;
 
       char* pDataInX = (char *)OldCallback->pDataInBase1;
       char* pDataInX2 = (char *)OldCallback->pDataInBase2;
       char* pDataOutX = (char*)OldCallback->pDataOutBase1;
-      INT64 lenX;
-      INT64 workBlock;
+      int64_t lenX;
+      int64_t workBlock;
 
       // As long as there is work to do
       while ((lenX = pstWorkerItem->GetNextWorkBlock(&workBlock)) > 0) {
 
 
          // Calculate how much to adjust the pointers to get to the data for this work block
-         INT64 offsetAdj = pstWorkerItem->BlockSize * workBlock * strideSizeIn;
-         INT64 outputAdj = pstWorkerItem->BlockSize * workBlock * strideSizeOut;
-         //INT64 outputAdj = offsetAdj;
+         int64_t offsetAdj = pstWorkerItem->BlockSize * workBlock * strideSizeIn;
+         int64_t outputAdj = pstWorkerItem->BlockSize * workBlock * strideSizeOut;
+         //int64_t outputAdj = offsetAdj;
 
          // Check if the outputtype is different
          //if (FunctionList->NumpyOutputType == NPY_BOOL) {
@@ -624,7 +624,7 @@ public:
 
    //------------------------------------------------------------------------------
    // 
-   void WorkGroupByCall(GROUPBY_FUNC groupByCall, void* pstData, INT64 tupleSize) {
+   void WorkGroupByCall(GROUPBY_FUNC groupByCall, void* pstData, int64_t tupleSize) {
       // If it is a small work item, process it immediately
       if ( tupleSize < 2 || NoThreading) {
 
@@ -649,8 +649,8 @@ public:
    void WorkScatterGatherCall(
       FUNCTION_LIST* anyScatterGatherCall, 
       void* pDataIn, 
-      INT64 len, 
-      INT64 func, 
+      int64_t len, 
+      int64_t func, 
       stScatterGatherFunc* pstScatterGatherFunc) {
 
       // If it is a small work item, process it immediately
@@ -663,8 +663,8 @@ public:
       stMATH_WORKER_ITEM* pWorkItem = pWorkerRing->GetWorkItem();
       pWorkItem->DoWorkCallback = AnyScatterGather;
 
-      INT numCores = WorkerThreadCount + 1;
-      INT64 sizeToAlloc = numCores * sizeof(stScatterGatherFunc);
+      int32_t numCores = WorkerThreadCount + 1;
+      int64_t sizeToAlloc = numCores * sizeof(stScatterGatherFunc);
       PVOID pWorkSpace = WORKSPACE_ALLOC(sizeToAlloc);
 
       if (pWorkSpace) {
@@ -695,7 +695,7 @@ public:
 
          // Gather the results from all cores
          if (func == REDUCE_MIN || func == REDUCE_NANMIN || func == REDUCE_MAX || func == REDUCE_NANMAX) {
-            INT calcs = 0;
+            int32_t calcs = 0;
             // Collect all the results...
             for (int i = 0; i < numCores; i++) {
                pstScatterGatherFunc->lenOut += pZeroArray[i].lenOut;
@@ -739,7 +739,7 @@ public:
 
    ////------------------------------------------------------------------------------
    //// 
-   //void WorkOneStubCall(FUNCTION_LIST* anyOneStubCall, void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+   //void WorkOneStubCall(FUNCTION_LIST* anyOneStubCall, void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
    //   // If it is a small work item, process it immediately
    //   if (len < WORK_ITEM_BIG || NoThreading) {

--- a/src/MathWorker.h
+++ b/src/MathWorker.h
@@ -14,7 +14,7 @@ typedef HINSTANCE HMODULE;
 typedef wchar_t WCHAR;    // wc,   16-bit UNICODE character
 
 extern "C" {
-   typedef ptrdiff_t (WINAPI *FARPROC)();
+   typedef long long (WINAPI *FARPROC)();
    typedef unsigned int(WINAPI *PTHREAD_START_ROUTINE)(void* lpThreadParameter);
    typedef PTHREAD_START_ROUTINE LPTHREAD_START_ROUTINE;
 

--- a/src/MathWorker.h
+++ b/src/MathWorker.h
@@ -15,7 +15,7 @@ typedef wchar_t WCHAR;    // wc,   16-bit UNICODE character
 
 extern "C" {
    typedef INT_PTR (WINAPI *FARPROC)();
-   typedef DWORD(WINAPI *PTHREAD_START_ROUTINE)(void* lpThreadParameter);
+   typedef DWORD(WINAPI *PTHREAD_START_ROUTINE)(LPVOID lpThreadParameter);
    typedef PTHREAD_START_ROUTINE LPTHREAD_START_ROUTINE;
 
 

--- a/src/MathWorker.h
+++ b/src/MathWorker.h
@@ -15,7 +15,7 @@ typedef wchar_t WCHAR;    // wc,   16-bit UNICODE character
 
 extern "C" {
    typedef INT_PTR (WINAPI *FARPROC)();
-   typedef unsigned int(WINAPI *PTHREAD_START_ROUTINE)(void* lpThreadParameter);
+   typedef DWORD(WINAPI *PTHREAD_START_ROUTINE)(void* lpThreadParameter);
    typedef PTHREAD_START_ROUTINE LPTHREAD_START_ROUTINE;
 
 

--- a/src/Merge.cpp
+++ b/src/Merge.cpp
@@ -204,7 +204,7 @@ int64_t BooleanCount(PyArrayObject* aIndex, int64_t** ppChunkCount, int64_t stri
 
       // This is the routine that will be called back from multiple threads
       // t64_t(*MTCHUNK_CALLBACK)(void* callbackArg, int core, int64_t start, int64_t length);
-      auto lambdaBSCallback = [](void* callbackArgT, int core, int64_t start, int64_t length) -> BOOL {
+      auto lambdaBSCallback = [](void* callbackArgT, int core, int64_t start, int64_t length) -> bool {
          BSCallbackStruct* callbackArg = (BSCallbackStruct*)callbackArgT;
 
          const int8_t* pBooleanMask = callbackArg->pBooleanMask;
@@ -226,7 +226,7 @@ int64_t BooleanCount(PyArrayObject* aIndex, int64_t** ppChunkCount, int64_t stri
       stBSCallback.pBooleanMask = pBooleanMask;
       stBSCallback.strideBoolean = strideBoolean;
 
-      BOOL didMtWork = g_cMathWorker->DoMultiThreadedChunkWork(lengthBool, lambdaBSCallback, &stBSCallback);
+      bool didMtWork = g_cMathWorker->DoMultiThreadedChunkWork(lengthBool, lambdaBSCallback, &stBSCallback);
 
       *ppChunkCount = pChunkCount;
       // if multithreading turned off...
@@ -241,7 +241,7 @@ int64_t BooleanCount(PyArrayObject* aIndex, int64_t** ppChunkCount, int64_t stri
 //---------------------------------------------------------------------------
 // Input:
 // Arg1: numpy array aValues (can be any array)
-// Arg2: numpy array aIndex (must be BOOL)
+// Arg2: numpy array aIndex (must be bool)
 //
 PyObject*
 BooleanIndexInternal(
@@ -255,8 +255,8 @@ BooleanIndexInternal(
 
    int ndimValue=0;
    int ndimBoolean=0;
-   INT64 strideValue=0;
-   INT64 strideBoolean=0;
+   int64_t strideValue=0;
+   int64_t strideBoolean=0;
 
    int result1 = GetStridesAndContig(aValues, ndimValue, strideValue);
    int result2 = GetStridesAndContig(aIndex, ndimBoolean, strideBoolean);
@@ -334,7 +334,7 @@ BooleanIndexInternal(
          //-----------------------------------------------
          //-----------------------------------------------
          // This is the routine that will be called back from multiple threads
-         auto lambdaBICallback2 = [](void* callbackArgT, int core, int64_t start, int64_t length) -> BOOL {
+         auto lambdaBICallback2 = [](void* callbackArgT, int core, int64_t start, int64_t length) -> bool {
             BICallbackStruct* callbackArg = (BICallbackStruct*)callbackArgT;
 
             int8_t* pBooleanMask = callbackArg->pBooleanMask;
@@ -627,7 +627,7 @@ BooleanIndexInternal(
 //---------------------------------------------------------------------------
 // Input:
 // Arg1: numpy array aValues (can be anything)
-// Arg2: numpy array aIndex (must be BOOL)
+// Arg2: numpy array aIndex (must be bool)
 //
 PyObject*
 BooleanIndex(PyObject* self, PyObject* args)
@@ -649,7 +649,7 @@ BooleanIndex(PyObject* self, PyObject* args)
 
 //---------------------------------------------------------------------------
 // Input:
-// Arg1: numpy array aIndex (must be BOOL)
+// Arg1: numpy array aIndex (must be bool)
 // Returns: how many true values there are
 // NOTE: faster than calling sum
 PyObject*
@@ -671,15 +671,15 @@ BooleanSum(PyObject* self, PyObject* args)
    }
 
    int ndimBoolean;
-   INT64 strideBoolean;
+   int64_t strideBoolean;
 
    int result1 = GetStridesAndContig(aIndex, ndimBoolean, strideBoolean);
 
-   INT64* pChunkCount = NULL;
-   INT64 chunks = BooleanCount(aIndex, &pChunkCount, strideBoolean);
+   int64_t* pChunkCount = NULL;
+   int64_t chunks = BooleanCount(aIndex, &pChunkCount, strideBoolean);
 
-   INT64 totalTrue = 0;
-   for (INT64 i = 0; i < chunks; i++) {
+   int64_t totalTrue = 0;
+   for (int64_t i = 0; i < chunks; i++) {
       totalTrue += pChunkCount[i];
    }
 
@@ -967,7 +967,7 @@ struct MBGET_CALLBACK {
 //---------------------------------------------------------
 // Used by GetItem
 //  Concurrent callback from multiple threads
-static BOOL GetItemCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
+static bool GetItemCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
 
    int64_t didSomeWork = 0;
    MBGET_CALLBACK* Callback = &stMBGCallback; // (MBGET_CALLBACK*)&pstWorkerItem->WorkCallbackArg;
@@ -1170,8 +1170,8 @@ MBGet(PyObject* self, PyObject* args)
 
    int ndimValue;
    int ndimIndex;
-   INT64 strideValue=0;
-   INT64 strideIndex=0;
+   int64_t strideValue=0;
+   int64_t strideIndex=0;
 
    int result1 = GetStridesAndContig(aValues, ndimValue, strideValue);
    int result2 = GetStridesAndContig(aIndex, ndimIndex, strideIndex);
@@ -1220,8 +1220,8 @@ MBGet(PyObject* self, PyObject* args)
 
             // Check if a default value was passed in as third parameter
             if (defaultValue != Py_None) {
-               BOOL result;
-               INT64 itemSize;
+               bool result;
+               int64_t itemSize;
                void* pTempData = NULL;
                // Try to convert the scalar
                result = ConvertScalarObject(defaultValue, &tempDefault, numpyValuesType, &pTempData, &itemSize);
@@ -1286,7 +1286,7 @@ MBGet(PyObject* self, PyObject* args)
 //===============================================================================
 // checks for kwargs 'both'
 // if exists, and is True return True
-BOOL GetKwargBoth(PyObject* kwargs) {
+bool GetKwargBoth(PyObject* kwargs) {
    // Check for cutoffs kwarg to see if going into parallel mode
    if (kwargs && PyDict_Check(kwargs)) {
       PyObject* pBoth = NULL;
@@ -1328,34 +1328,34 @@ BooleanToFancy(PyObject* self, PyObject* args, PyObject* kwargs)
    }
 
    int ndimBoolean;
-   INT64 strideBoolean;
+   int64_t strideBoolean;
 
    int result1 = GetStridesAndContig(aIndex, ndimBoolean, strideBoolean);
 
    // if bothMode is set, will return fancy index for both True and False
-   BOOL     bothMode = GetKwargBoth(kwargs);
+   bool     bothMode = GetKwargBoth(kwargs);
 
-   INT64* pChunkCount = NULL;
-   INT64* pChunkCountFalse = NULL;
-   INT64    chunks = BooleanCount(aIndex, &pChunkCount, strideBoolean);
-   INT64    indexLength = ArrayLength(aIndex);
+   int64_t* pChunkCount = NULL;
+   int64_t* pChunkCountFalse = NULL;
+   int64_t    chunks = BooleanCount(aIndex, &pChunkCount, strideBoolean);
+   int64_t    indexLength = ArrayLength(aIndex);
 
-   INT64    totalTrue = 0;
+   int64_t    totalTrue = 0;
 
    if (bothMode) {
       // now count up the chunks
       // TJD: April 2019 note -- when the chunk size is between 65536 and 128000
       // it is really one chunk, but the code still works
-      INT64 chunkSize = g_cMathWorker->WORK_ITEM_CHUNK;
-      INT64 chunks = (indexLength + (chunkSize - 1)) / chunkSize;
+      int64_t chunkSize = g_cMathWorker->WORK_ITEM_CHUNK;
+      int64_t chunks = (indexLength + (chunkSize - 1)) / chunkSize;
 
       // Also need false count
-      pChunkCountFalse = (INT64*)WORKSPACE_ALLOC(chunks * sizeof(INT64));
-      INT64 totalFalse = 0;
+      pChunkCountFalse = (int64_t*)WORKSPACE_ALLOC(chunks * sizeof(int64_t));
+      int64_t totalFalse = 0;
 
       // Store the offset
-      for (INT64 i = 0; i < chunks; i++) {
-         INT64 temp = totalFalse;
+      for (int64_t i = 0; i < chunks; i++) {
+         int64_t temp = totalFalse;
 
          // check for last chunk
          totalFalse += (chunkSize - pChunkCount[i]);
@@ -1368,8 +1368,8 @@ BooleanToFancy(PyObject* self, PyObject* args, PyObject* kwargs)
    }
 
    // Store the offset
-   for (INT64 i = 0; i < chunks; i++) {
-      INT64 temp = totalTrue;
+   for (int64_t i = 0; i < chunks; i++) {
+      int64_t temp = totalTrue;
       totalTrue += pChunkCount[i];
 
       // reassign to the cumulative sum so we know the offset
@@ -1398,35 +1398,35 @@ BooleanToFancy(PyObject* self, PyObject* args, PyObject* kwargs)
    if (returnArray) {
       // MT callback
       struct BTFCallbackStruct {
-         INT64* pChunkCount;
-         INT64* pChunkCountFalse;
-         INT8* pBooleanMask;
+         int64_t* pChunkCount;
+         int64_t* pChunkCountFalse;
+         int8_t* pBooleanMask;
          void* pValuesOut;
-         INT64    totalTrue;
+         int64_t    totalTrue;
          int      dtype;
-         BOOL     bothMode;
+         bool     bothMode;
       };
 
       // This is the routine that will be called back from multiple threads
-      auto lambdaCallback = [](void* callbackArgT, int core, INT64 start, INT64 length) -> BOOL {
+      auto lambdaCallback = [](void* callbackArgT, int core, int64_t start, int64_t length) -> bool {
          BTFCallbackStruct* callbackArg = (BTFCallbackStruct*)callbackArgT;
 
-         INT64  chunkCount = callbackArg->pChunkCount[start / g_cMathWorker->WORK_ITEM_CHUNK];
-         INT8* pBooleanMask = callbackArg->pBooleanMask;
-         BOOL   bothMode = callbackArg->bothMode;
+         int64_t  chunkCount = callbackArg->pChunkCount[start / g_cMathWorker->WORK_ITEM_CHUNK];
+         int8_t* pBooleanMask = callbackArg->pBooleanMask;
+         bool   bothMode = callbackArg->bothMode;
 
          if (bothMode) {
-            INT64  chunkCountFalse = callbackArg->pChunkCountFalse[start / g_cMathWorker->WORK_ITEM_CHUNK];
+            int64_t  chunkCountFalse = callbackArg->pChunkCountFalse[start / g_cMathWorker->WORK_ITEM_CHUNK];
             //printf("[%lld] ccf %lld  length %lld\n", start, chunkCountFalse, length);
 
             if (callbackArg->dtype == NPY_INT64) {
-               INT64* pOut = (INT64*)callbackArg->pValuesOut;
+               int64_t* pOut = (int64_t*)callbackArg->pValuesOut;
                pOut = pOut + chunkCount;
 
-               INT64* pOutFalse = (INT64*)callbackArg->pValuesOut;
+               int64_t* pOutFalse = (int64_t*)callbackArg->pValuesOut;
                pOutFalse = pOutFalse + callbackArg->totalTrue + chunkCountFalse;
 
-               for (INT64 i = start; i < (start + length); i++) {
+               for (int64_t i = start; i < (start + length); i++) {
                   if (pBooleanMask[i]) {
                      *pOut++ = i;
                   }
@@ -1436,18 +1436,18 @@ BooleanToFancy(PyObject* self, PyObject* args, PyObject* kwargs)
                }
             }
             else {
-               INT32* pOut = (INT32*)callbackArg->pValuesOut;
+               int32_t* pOut = (int32_t*)callbackArg->pValuesOut;
                pOut = pOut + chunkCount;
 
-               INT32* pOutFalse = (INT32*)callbackArg->pValuesOut;
+               int32_t* pOutFalse = (int32_t*)callbackArg->pValuesOut;
                pOutFalse = pOutFalse + callbackArg->totalTrue + chunkCountFalse;
 
-               for (INT64 i = start; i < (start + length); i++) {
+               for (int64_t i = start; i < (start + length); i++) {
                   if (pBooleanMask[i]) {
-                     *pOut++ = (INT32)i;
+                     *pOut++ = (int32_t)i;
                   }
                   else {
-                     *pOutFalse++ = (INT32)i;
+                     *pOutFalse++ = (int32_t)i;
                   }
                }
 
@@ -1456,22 +1456,22 @@ BooleanToFancy(PyObject* self, PyObject* args, PyObject* kwargs)
          else {
 
             if (callbackArg->dtype == NPY_INT64) {
-               INT64* pOut = (INT64*)callbackArg->pValuesOut;
+               int64_t* pOut = (int64_t*)callbackArg->pValuesOut;
                pOut = pOut + chunkCount;
 
-               for (INT64 i = start; i < (start + length); i++) {
+               for (int64_t i = start; i < (start + length); i++) {
                   if (pBooleanMask[i]) {
                      *pOut++ = i;
                   }
                }
             }
             else {
-               INT32* pOut = (INT32*)callbackArg->pValuesOut;
+               int32_t* pOut = (int32_t*)callbackArg->pValuesOut;
                pOut = pOut + chunkCount;
 
-               for (INT64 i = start; i < (start + length); i++) {
+               for (int64_t i = start; i < (start + length); i++) {
                   if (pBooleanMask[i]) {
-                     *pOut++ = (INT32)i;
+                     *pOut++ = (int32_t)i;
                   }
                }
 
@@ -1484,8 +1484,8 @@ BooleanToFancy(PyObject* self, PyObject* args, PyObject* kwargs)
       BTFCallbackStruct stBTFCallback;
       stBTFCallback.pChunkCount = pChunkCount;
       stBTFCallback.pChunkCountFalse = pChunkCountFalse;
-      stBTFCallback.pBooleanMask = (INT8*)PyArray_BYTES(aIndex);
-      stBTFCallback.pValuesOut = (INT64*)PyArray_BYTES(returnArray);
+      stBTFCallback.pBooleanMask = (int8_t*)PyArray_BYTES(aIndex);
+      stBTFCallback.pValuesOut = (int64_t*)PyArray_BYTES(returnArray);
       stBTFCallback.dtype = dtype;
       stBTFCallback.totalTrue = totalTrue;
       stBTFCallback.bothMode = bothMode;
@@ -1557,46 +1557,46 @@ BooleanToFancy(PyObject* self, PyObject* args, PyObject* kwargs)
 //
 
 struct stReIndex {
-   INT64* pUCutOffs;
-   INT64* pICutOffs;
-   INT32* pUKey;
+   int64_t* pUCutOffs;
+   int64_t* pICutOffs;
+   int32_t* pUKey;
    void* pIKey;
 
-   INT64       ikey_length;
-   INT64       uikey_length;
-   INT64       u_cutoffs_length;
+   int64_t       ikey_length;
+   int64_t       uikey_length;
+   int64_t       u_cutoffs_length;
 
 };
 
 //
 // t is the partition/cutoff index
 template<typename KEYTYPE>
-BOOL ReIndexGroupsMT(void* preindexV, int core, INT64 t) {
+bool ReIndexGroupsMT(void* preindexV, int core, int64_t t) {
    stReIndex* preindex = (stReIndex*)preindexV;
 
-   INT64* pUCutOffs = preindex->pUCutOffs;
-   INT64* pICutOffs = preindex->pICutOffs;
-   INT32* pUKey = preindex->pUKey;
+   int64_t* pUCutOffs = preindex->pUCutOffs;
+   int64_t* pICutOffs = preindex->pICutOffs;
+   int32_t* pUKey = preindex->pUKey;
    KEYTYPE* pIKey = (KEYTYPE*)preindex->pIKey;
 
    // Base 1 loop
-   INT64    starti = 0;
-   INT64    start = 0;
+   int64_t    starti = 0;
+   int64_t    start = 0;
    if (t > 0) {
       starti = pICutOffs[t - 1];
       start = pUCutOffs[t - 1];
    }
 
-   INT64   stopi = pICutOffs[t];
-   INT32* pUniques = &pUKey[start];
+   int64_t   stopi = pICutOffs[t];
+   int32_t* pUniques = &pUKey[start];
 
    // Check for out of bounds when indexing uniques
-   INT64   uKeyLength = preindex->uikey_length - start;
+   int64_t   uKeyLength = preindex->uikey_length - start;
    if (uKeyLength < 0) uKeyLength = 0;
 
    LOGGING("Start %lld  Stop %lld  Len:%lld\n", starti, stopi, preindex->ikey_length);
 
-   for (INT64 j = starti; j < stopi; j++) {
+   for (int64_t j = starti; j < stopi; j++) {
       KEYTYPE index = pIKey[j];
       if (index <= 0 || index > uKeyLength) {
          // preserve filtered out or mark as filtered if out of range
@@ -1651,13 +1651,13 @@ ReIndexGroups(PyObject* self, PyObject* args)
       return NULL;
    }
 
-   INT64 u_cutoffs_length = ArrayLength(u_cutoffs);
+   int64_t u_cutoffs_length = ArrayLength(u_cutoffs);
 
    stReIndex preindex;
 
-   preindex.pUCutOffs = (INT64*)PyArray_BYTES(u_cutoffs);
-   preindex.pICutOffs = (INT64*)PyArray_BYTES(i_cutoffs);
-   preindex.pUKey = (INT32*)PyArray_BYTES(uikey);
+   preindex.pUCutOffs = (int64_t*)PyArray_BYTES(u_cutoffs);
+   preindex.pICutOffs = (int64_t*)PyArray_BYTES(i_cutoffs);
+   preindex.pUKey = (int32_t*)PyArray_BYTES(uikey);
    preindex.pIKey = PyArray_BYTES(ikey);
 
    preindex.ikey_length = ArrayLength(ikey);
@@ -1666,16 +1666,16 @@ ReIndexGroups(PyObject* self, PyObject* args)
 
    switch (PyArray_ITEMSIZE(ikey)) {
    case 1:
-      g_cMathWorker->DoMultiThreadedWork((int)u_cutoffs_length, ReIndexGroupsMT<INT8>, &preindex);
+      g_cMathWorker->DoMultiThreadedWork((int)u_cutoffs_length, ReIndexGroupsMT<int8_t>, &preindex);
       break;
    case 2:
-      g_cMathWorker->DoMultiThreadedWork((int)u_cutoffs_length, ReIndexGroupsMT<INT16>, &preindex);
+      g_cMathWorker->DoMultiThreadedWork((int)u_cutoffs_length, ReIndexGroupsMT<int16_t>, &preindex);
       break;
    case 4:
-      g_cMathWorker->DoMultiThreadedWork((int)u_cutoffs_length, ReIndexGroupsMT<INT32>, &preindex);
+      g_cMathWorker->DoMultiThreadedWork((int)u_cutoffs_length, ReIndexGroupsMT<int32_t>, &preindex);
       break;
    case 8:
-      g_cMathWorker->DoMultiThreadedWork((int)u_cutoffs_length, ReIndexGroupsMT<INT64>, &preindex);
+      g_cMathWorker->DoMultiThreadedWork((int)u_cutoffs_length, ReIndexGroupsMT<int64_t>, &preindex);
       break;
    default:
       PyErr_Format(PyExc_ValueError, "ikey must be int8/16/32/64");
@@ -1691,21 +1691,21 @@ ReIndexGroups(PyObject* self, PyObject* args)
 struct stReverseIndex {
    void* pIKey;
    void* pOutKey;
-   INT64       ikey_length;
+   int64_t       ikey_length;
 };
 
 
 // This routine is parallelized
 // Algo: out[in[i]] = i
 template<typename KEYTYPE>
-BOOL ReverseShuffleMT(void* preindexV, int core, INT64 start, INT64 length) {
+bool ReverseShuffleMT(void* preindexV, int core, int64_t start, int64_t length) {
    stReverseIndex* preindex = (stReverseIndex*)preindexV;
 
    KEYTYPE* pIn = (KEYTYPE*)preindex->pIKey;
    KEYTYPE* pOut = (KEYTYPE*)preindex->pOutKey;
-   INT64 maxindex = preindex->ikey_length;
+   int64_t maxindex = preindex->ikey_length;
 
-   for (INT64 i = start; i < (start + length); i++) {
+   for (int64_t i = start; i < (start + length); i++) {
       KEYTYPE index = pIn[i];
       if (index >= 0 && index < maxindex) {
          pOut[index] = (KEYTYPE)i;
@@ -1754,21 +1754,21 @@ ReverseShuffle(PyObject* self, PyObject* args)
       preindex.pIKey = PyArray_BYTES(ikey);
       preindex.pOutKey = PyArray_BYTES(pReturnArray);
 
-      INT64 arrlength = ArrayLength(ikey);
+      int64_t arrlength = ArrayLength(ikey);
       preindex.ikey_length = arrlength;
 
       switch (PyArray_ITEMSIZE(ikey)) {
       case 1:
-         g_cMathWorker->DoMultiThreadedChunkWork(arrlength, ReverseShuffleMT<INT8>, &preindex);
+         g_cMathWorker->DoMultiThreadedChunkWork(arrlength, ReverseShuffleMT<int8_t>, &preindex);
          break;
       case 2:
-         g_cMathWorker->DoMultiThreadedChunkWork(arrlength, ReverseShuffleMT<INT16>, &preindex);
+         g_cMathWorker->DoMultiThreadedChunkWork(arrlength, ReverseShuffleMT<int16_t>, &preindex);
          break;
       case 4:
-         g_cMathWorker->DoMultiThreadedChunkWork(arrlength, ReverseShuffleMT<INT32>, &preindex);
+         g_cMathWorker->DoMultiThreadedChunkWork(arrlength, ReverseShuffleMT<int32_t>, &preindex);
          break;
       case 8:
-         g_cMathWorker->DoMultiThreadedChunkWork(arrlength, ReverseShuffleMT<INT64>, &preindex);
+         g_cMathWorker->DoMultiThreadedChunkWork(arrlength, ReverseShuffleMT<int64_t>, &preindex);
          break;
       default:
          PyErr_Format(PyExc_ValueError, "ReverseShuffle: ikey must be int8/16/32/64");
@@ -1843,13 +1843,13 @@ MergeBinnedCutoffs(PyObject *self, PyObject *args) {
 
       if (PyArray_TYPE(mask) == NPY_BOOL) {
 
-         INT64 itemSizeOut = PyArray_ITEMSIZE(arr);
-         INT64 itemSizeIn = PyArray_ITEMSIZE(inValues);
+         int64_t itemSizeOut = PyArray_ITEMSIZE(arr);
+         int64_t itemSizeIn = PyArray_ITEMSIZE(inValues);
 
          // check for strides... ?
-         INT64 arrayLength = ArrayLength(arr);
+         int64_t arrayLength = ArrayLength(arr);
          if (arrayLength == ArrayLength(mask) && itemSizeOut == PyArray_STRIDE(arr, 0)) {
-            INT64 valLength = ArrayLength(inValues);
+            int64_t valLength = ArrayLength(inValues);
 
             if (arrayLength == valLength) {
                int outDType = PyArray_TYPE(arr);
@@ -1863,9 +1863,9 @@ MergeBinnedCutoffs(PyObject *self, PyObject *args) {
                      MASK_CONVERT_SAFE maskSafe;
                      char* pIn;
                      char* pOut;
-                     INT64 itemSizeOut;
-                     INT64 itemSizeIn;
-                     INT8* pMask;
+                     int64_t itemSizeOut;
+                     int64_t itemSizeIn;
+                     int8_t* pMask;
                      void* pBadInput1;
                      void* pBadOutput1;
 
@@ -1874,11 +1874,11 @@ MergeBinnedCutoffs(PyObject *self, PyObject *args) {
                   MASK_CALLBACK_STRUCT stMask;
 
                   // This is the routine that will be called back from multiple threads
-                  auto lambdaMaskCallback = [](void* callbackArgT, int core, INT64 start, INT64 length) -> BOOL {
+                  auto lambdaMaskCallback = [](void* callbackArgT, int core, int64_t start, int64_t length) -> bool {
                      MASK_CALLBACK_STRUCT* callbackArg = (MASK_CALLBACK_STRUCT*)callbackArgT;
 
                      //printf("[%d] Mask %lld %lld\n", core, start, length);
-                     //maskSafe(pIn, pOut, (INT8*)pMask, length, pBadInput1, pBadOutput1);
+                     //maskSafe(pIn, pOut, (int8_t*)pMask, length, pBadInput1, pBadOutput1);
                      // Auto adjust pointers
                      callbackArg->maskSafe(
                         callbackArg->pIn + (start * callbackArg->itemSizeIn),
@@ -1898,7 +1898,7 @@ MergeBinnedCutoffs(PyObject *self, PyObject *args) {
 
                   stMask.pIn = (char*)PyArray_BYTES(inValues, 0);
                   stMask.pOut = (char*)PyArray_BYTES(arr, 0);
-                  stMask.pMask = (INT8*)PyArray_BYTES(mask, 0);
+                  stMask.pMask = (int8_t*)PyArray_BYTES(mask, 0);
                   stMask.maskSafe = maskSafe;
 
                   g_cMathWorker->DoMultiThreadedChunkWork(arrayLength, lambdaMaskCallback, &stMask);

--- a/src/Merge.cpp
+++ b/src/Merge.cpp
@@ -15,23 +15,6 @@
 //#define LOGGING printf
 #define LOGGING(...)
 
-#if defined(_WIN32) && !defined(__GNUC__)
-
-#define CASE_NPY_INT32      CASE_NPY_INT32:       case NPY_INT
-#define CASE_NPY_UINT32     CASE_NPY_UINT32:      case NPY_UINT
-#define CASE_NPY_INT64      CASE_NPY_INT64
-#define CASE_NPY_UINT64     CASE_NPY_UINT64
-#define CASE_NPY_FLOAT64    case NPY_DOUBLE:     case NPY_LONGDOUBLE
-
-#else
-
-#define CASE_NPY_INT32      CASE_NPY_INT32
-#define CASE_NPY_UINT32     CASE_NPY_UINT32
-#define CASE_NPY_INT64      CASE_NPY_INT64:    case NPY_LONGLONG
-#define CASE_NPY_UINT64     CASE_NPY_UINT64:   case NPY_ULONGLONG
-#define CASE_NPY_FLOAT64    case NPY_DOUBLE
-#endif
-
 /**
  * Count the number of 'True' (nonzero) 1-byte bool values in an array,
  * using an AVX2-based implementation.
@@ -773,12 +756,11 @@ static void GetItemUInt(void* aValues, void* aIndex, void* aDataOut, int64_t val
    if (sizeof(VALUE) == strideValue && sizeof(INDEX) == strideIndex) {
       while (pDataOut != pDataOutEnd) {
          const INDEX index = *pIndex;
-         *pDataOut =
             *pDataOut =
             // Make sure the item is in range
             index < valLength
             ? pValues[index]
-            : defaultVal;
+              : defaultVal;
          pIndex++;
          pDataOut++;
       }

--- a/src/Merge.cpp
+++ b/src/Merge.cpp
@@ -17,16 +17,16 @@
 
 #if defined(_WIN32) && !defined(__GNUC__)
 
-#define CASE_NPY_INT32      case NPY_INT32:       case NPY_INT
-#define CASE_NPY_UINT32     case NPY_UINT32:      case NPY_UINT
+#define CASE_NPY_INT      case NPY_INT:       case NPY_INT
+#define CASE_NPY_UINT     case NPY_UINT:      case NPY_UINT
 #define CASE_NPY_INT64      case NPY_INT64
 #define CASE_NPY_UINT64     case NPY_UINT64
 #define CASE_NPY_FLOAT64    case NPY_DOUBLE:     case NPY_LONGDOUBLE
 
 #else
 
-#define CASE_NPY_INT32      case NPY_INT32
-#define CASE_NPY_UINT32     case NPY_UINT32
+#define CASE_NPY_INT      case NPY_INT
+#define CASE_NPY_UINT     case NPY_UINT
 #define CASE_NPY_INT64      case NPY_INT64:    case NPY_LONGLONG
 #define CASE_NPY_UINT64     case NPY_UINT64:   case NPY_ULONGLONG
 #define CASE_NPY_FLOAT64    case NPY_DOUBLE
@@ -1062,7 +1062,7 @@ static GETITEM_FUNC GetItemFunction(int64_t itemSize, int indexType) {
       }
       break;
 
-   CASE_NPY_INT32:
+   CASE_NPY_INT:
       switch (itemSize) {
       case 1:  return GetItemInt<int8_t, int32_t>;
       case 2:  return GetItemInt<int16_t, int32_t>;
@@ -1072,7 +1072,7 @@ static GETITEM_FUNC GetItemFunction(int64_t itemSize, int indexType) {
       default: return GetItemIntVariable<int32_t>;
       }
       break;
-   CASE_NPY_UINT32:
+   CASE_NPY_UINT:
       switch (itemSize) {
       case 1:  return GetItemUInt<int8_t, int32_t>;
       case 2:  return GetItemUInt<int16_t, int32_t>;
@@ -1381,7 +1381,7 @@ BooleanToFancy(PyObject* self, PyObject* args, PyObject* kwargs)
    int dtype = NPY_INT64;
    // INT32 or INT64
    if (indexLength < 2000000000) {
-      dtype = NPY_INT32;
+      dtype = NPY_INT;
    }
 
    if (bothMode) {

--- a/src/Merge.cpp
+++ b/src/Merge.cpp
@@ -17,16 +17,16 @@
 
 #if defined(_WIN32) && !defined(__GNUC__)
 
-#define CASE_NPY_INT      case NPY_INT:       case NPY_INT
-#define CASE_NPY_UINT     case NPY_UINT:      case NPY_UINT
+#define CASE_NPY_INT32      case NPY_INT32:       case NPY_INT
+#define CASE_NPY_UINT32     case NPY_UINT32:      case NPY_UINT
 #define CASE_NPY_INT64      case NPY_INT64
 #define CASE_NPY_UINT64     case NPY_UINT64
 #define CASE_NPY_FLOAT64    case NPY_DOUBLE:     case NPY_LONGDOUBLE
 
 #else
 
-#define CASE_NPY_INT      case NPY_INT
-#define CASE_NPY_UINT     case NPY_UINT
+#define CASE_NPY_INT32      case NPY_INT32
+#define CASE_NPY_UINT32     case NPY_UINT32
 #define CASE_NPY_INT64      case NPY_INT64:    case NPY_LONGLONG
 #define CASE_NPY_UINT64     case NPY_UINT64:   case NPY_ULONGLONG
 #define CASE_NPY_FLOAT64    case NPY_DOUBLE
@@ -1062,7 +1062,7 @@ static GETITEM_FUNC GetItemFunction(int64_t itemSize, int indexType) {
       }
       break;
 
-   CASE_NPY_INT:
+   CASE_NPY_INT32:
       switch (itemSize) {
       case 1:  return GetItemInt<int8_t, int32_t>;
       case 2:  return GetItemInt<int16_t, int32_t>;
@@ -1072,7 +1072,7 @@ static GETITEM_FUNC GetItemFunction(int64_t itemSize, int indexType) {
       default: return GetItemIntVariable<int32_t>;
       }
       break;
-   CASE_NPY_UINT:
+   CASE_NPY_UINT32:
       switch (itemSize) {
       case 1:  return GetItemUInt<int8_t, int32_t>;
       case 2:  return GetItemUInt<int16_t, int32_t>;
@@ -1381,7 +1381,7 @@ BooleanToFancy(PyObject* self, PyObject* args, PyObject* kwargs)
    int dtype = NPY_INT64;
    // INT32 or INT64
    if (indexLength < 2000000000) {
-      dtype = NPY_INT;
+      dtype = NPY_INT32;
    }
 
    if (bothMode) {

--- a/src/Merge.cpp
+++ b/src/Merge.cpp
@@ -17,18 +17,18 @@
 
 #if defined(_WIN32) && !defined(__GNUC__)
 
-#define CASE_NPY_INT32      case NPY_INT32:       case NPY_INT
-#define CASE_NPY_UINT32     case NPY_UINT32:      case NPY_UINT
-#define CASE_NPY_INT64      case NPY_INT64
-#define CASE_NPY_UINT64     case NPY_UINT64
+#define CASE_NPY_INT32      CASE_NPY_INT32:       case NPY_INT
+#define CASE_NPY_UINT32     CASE_NPY_UINT32:      case NPY_UINT
+#define CASE_NPY_INT64      CASE_NPY_INT64
+#define CASE_NPY_UINT64     CASE_NPY_UINT64
 #define CASE_NPY_FLOAT64    case NPY_DOUBLE:     case NPY_LONGDOUBLE
 
 #else
 
-#define CASE_NPY_INT32      case NPY_INT32
-#define CASE_NPY_UINT32     case NPY_UINT32
-#define CASE_NPY_INT64      case NPY_INT64:    case NPY_LONGLONG
-#define CASE_NPY_UINT64     case NPY_UINT64:   case NPY_ULONGLONG
+#define CASE_NPY_INT32      CASE_NPY_INT32
+#define CASE_NPY_UINT32     CASE_NPY_UINT32
+#define CASE_NPY_INT64      CASE_NPY_INT64:    case NPY_LONGLONG
+#define CASE_NPY_UINT64     CASE_NPY_UINT64:   case NPY_ULONGLONG
 #define CASE_NPY_FLOAT64    case NPY_DOUBLE
 #endif
 

--- a/src/Merge.cpp
+++ b/src/Merge.cpp
@@ -211,14 +211,14 @@ int64_t BooleanCount(PyArrayObject* aIndex, int64_t** ppChunkCount, int64_t stri
          int64_t* pChunkCount = callbackArg->pChunkCount;
 
          // Use the single-threaded implementation to sum the number of
-         // 1-byte boolean TRUE values in the current chunk.
+         // 1-byte boolean true values in the current chunk.
          // This means the current function is just responsible for parallelizing over the chunks
          // but doesn't do any real "math" itself.
          int64_t strides = callbackArg->strideBoolean;
          int64_t total = SumBooleanMask(&pBooleanMask[start * strides], length, strides);
 
          pChunkCount[start / g_cMathWorker->WORK_ITEM_CHUNK] = total;
-         return TRUE;
+         return true;
       };
 
       BSCallbackStruct stBSCallback;
@@ -598,7 +598,7 @@ BooleanIndexInternal(
                break;
                }
             }
-            return TRUE;
+            return true;
          };
 
          BICallbackStruct stBICallback;
@@ -1295,10 +1295,10 @@ bool GetKwargBoth(PyObject* kwargs) {
       pBoth = PyDict_GetItemString(kwargs, "both");
 
       if (pBoth != NULL && pBoth == Py_True) {
-         return TRUE;
+         return true;
       }
    }
-   return FALSE;
+   return false;
 }
 
 //---------------------------------------------------------------------------
@@ -1478,7 +1478,7 @@ BooleanToFancy(PyObject* self, PyObject* args, PyObject* kwargs)
             }
          }
 
-         return TRUE;
+         return true;
       };
 
       BTFCallbackStruct stBTFCallback;
@@ -1608,7 +1608,7 @@ bool ReIndexGroupsMT(void* preindexV, int core, int64_t t) {
       }
    }
 
-   return TRUE;
+   return true;
 }
 
 //---------------------------------------------------------------------------
@@ -1711,7 +1711,7 @@ bool ReverseShuffleMT(void* preindexV, int core, int64_t start, int64_t length) 
          pOut[index] = (KEYTYPE)i;
       }
    }
-   return TRUE;
+   return true;
 }
 
 //---------------------------------------------------------------------------
@@ -1888,7 +1888,7 @@ MergeBinnedCutoffs(PyObject *self, PyObject *args) {
                         callbackArg->pBadInput1,
                         callbackArg->pBadOutput1);
 
-                     return TRUE;
+                     return true;
                   };
 
                   stMask.itemSizeIn = itemSizeIn;

--- a/src/MultiKey.cpp
+++ b/src/MultiKey.cpp
@@ -326,7 +326,7 @@ public:
       pSuperArray = NULL;
       pBoolFilterObject = NULL;
       pBoolFilter = NULL;
-      bAllocated = FALSE;
+      bAllocated = false;
 
       tupleSize = PyTuple_GET_SIZE(args);
 
@@ -386,7 +386,7 @@ public:
             //printf("row width %llu   rows %llu\n", totalItemSize, totalRows);
 
             if (listSize > 1) {
-               bAllocated = TRUE;
+               bAllocated = true;
                // Make rows
                pSuperArray = RotateArrays(listSize, aInfo);
             }
@@ -759,13 +759,13 @@ bool GroupByPackFinal32(
       *ppSortArray = (PyObject*)sortArray;
       *ppFirstArray = (PyObject*)firstArray;
       *ppCountArray = (PyObject*)countArray;
-      return TRUE;
+      return true;
    }
 
    CHECK_MEMORY_ERROR(0);
 
    // known possible memory leak here
-   return FALSE;
+   return false;
 }
 
 
@@ -806,13 +806,13 @@ GroupByPack32(PyObject* self, PyObject* args) {
 
       int32_t* pNextArray = NULL;
 
-      bool bMustFree = FALSE;
+      bool bMustFree = false;
 
       int32_t* pGroupArray = NULL;
 
       if (!PyArray_Check(nextArray)) {
          // Next was not supplied and must be calculated
-         bMustFree = TRUE;
+         bMustFree = true;
 
          int64_t allocsize = sizeof(int32_t) * (numUnique + GB_BASE_INDEX);
          pGroupArray = (int32_t*)WORKSPACE_ALLOC(allocsize);
@@ -824,10 +824,11 @@ GroupByPack32(PyObject* self, PyObject* args) {
          case NPY_INT16:
             pNextArray = GroupByPackFixup32<int16_t>(numUnique, totalRows, pIndexArray, pGroupArray);
             break;
-         CASE_NPY_INT32:
+         case NPY_INT32:
             pNextArray = GroupByPackFixup32<int32_t>(numUnique, totalRows, pIndexArray, pGroupArray);
             break;
-         CASE_NPY_INT64:
+         case NPY_INT64:
+         case NPY_LONGLONG:
             pNextArray = GroupByPackFixup32<int64_t>(numUnique, totalRows, pIndexArray, pGroupArray);
             break;
          default:
@@ -847,7 +848,7 @@ GroupByPack32(PyObject* self, PyObject* args) {
       PyObject* firstArray = NULL;
       PyObject* countArray = NULL;
 
-      bool bResult = FALSE;
+      bool bResult = false;
 
       switch (numpyIndexType) {
       case NPY_INT8:
@@ -856,10 +857,11 @@ GroupByPack32(PyObject* self, PyObject* args) {
       case NPY_INT16:
          bResult = GroupByPackFinal32<int16_t>(numUnique, totalRows, pIndexArray, pNextArray, pGroupArray, &sortGroupArray, &firstArray, &countArray);
          break;
-      CASE_NPY_INT32:
+      case NPY_INT32:
          bResult = GroupByPackFinal32<int32_t>(numUnique, totalRows, pIndexArray, pNextArray, pGroupArray, &sortGroupArray, &firstArray, &countArray);
          break;
-      CASE_NPY_INT64:
+      case NPY_INT64:
+      case NPY_LONGLONG:
          bResult = GroupByPackFinal32<int64_t>(numUnique, totalRows, pIndexArray, pNextArray, pGroupArray, &sortGroupArray, &firstArray, &countArray);
          break;
       default:
@@ -909,7 +911,7 @@ PyObject *
 MultiKeyGroupBy32(PyObject *self, PyObject *args, PyObject *kwargs) {
 
    long hashMode = HASH_MODE::HASH_MODE_MASK;
-   bool parallelMode = FALSE;
+   bool parallelMode = false;
 
    if (!PyTuple_Check(args)) {
       PyErr_Format(PyExc_ValueError, "MultiKeyGroupBy32 arguments needs to be a tuple");
@@ -1389,7 +1391,7 @@ MultiKeyRolling(PyObject *self, PyObject *args)
 
       // Turn off caching because we want this to remain
       bool prevValue = g_cMathWorker->NoCaching;
-      g_cMathWorker->NoCaching = TRUE;
+      g_cMathWorker->NoCaching = true;
 
       void* pKeepRolling = 
       MultiKeyRollingStep2(
@@ -1710,10 +1712,10 @@ PyObject *MultiKeyAlign32(PyObject *self, PyObject *args)
       void* pVal1 = PyArray_BYTES(pvalArray1);
       void* pVal2 = PyArray_BYTES(pvalArray2);
       PyArrayObject* indexArray = (PyArrayObject*)Py_None;
-      bool isIndex32 = TRUE;
-      bool success = FALSE;
+      bool isIndex32 = true;
+      bool success = false;
       if (mkp1.totalRows > 2000000000 || mkp2.totalRows > 2000000000) {
-         isIndex32 = FALSE;
+         isIndex32 = false;
       }
       LOGGING("MultiKeyAlign32 total rows %lld %lld\n", mkp1.totalRows, mkp2.totalRows);
       try {
@@ -1819,10 +1821,11 @@ MAKE_I_GROUP2 GetMakeIGroup2(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup2<int16_t, int32_t>;
          break;
-      CASE_NPY_INT32:
+      case NPY_INT32:
          pBinFunc = MakeiGroup2<int32_t, int32_t>;
          break;
-      CASE_NPY_INT64:
+      case NPY_INT64:
+      case NPY_LONGLONG:
          pBinFunc = MakeiGroup2<int64_t, int32_t>;
          break;
       default:
@@ -1837,10 +1840,11 @@ MAKE_I_GROUP2 GetMakeIGroup2(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup2<int16_t, int64_t>;
          break;
-      CASE_NPY_INT32:
+      case NPY_INT32:
          pBinFunc = MakeiGroup2<int32_t, int64_t>;
          break;
-      CASE_NPY_INT64:
+      case NPY_INT64:
+      case NPY_LONGLONG:
          pBinFunc = MakeiGroup2<int64_t, int64_t>;
          break;
       default:
@@ -1928,10 +1932,11 @@ MAKE_I_GROUP GetMakeIGroup(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup<int16_t, int32_t>;
          break;
-      CASE_NPY_INT32:
+      case NPY_INT32:
          pBinFunc = MakeiGroup<int32_t, int32_t>;
          break;
-      CASE_NPY_INT64:
+      case NPY_INT64:
+      case NPY_LONGLONG:
          pBinFunc = MakeiGroup<int64_t, int32_t>;
          break;
       default:
@@ -1946,10 +1951,11 @@ MAKE_I_GROUP GetMakeIGroup(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup<int16_t, int64_t>;
          break;
-      CASE_NPY_INT32:
+      case NPY_INT32:
          pBinFunc = MakeiGroup<int32_t, int64_t>;
          break;
-      CASE_NPY_INT64:
+      case NPY_INT64:
+      case NPY_LONGLONG:
          pBinFunc = MakeiGroup<int64_t, int64_t>;
          break;
       default:
@@ -2088,7 +2094,7 @@ GroupFromBinCount(PyObject *self, PyObject *args)
                callbackArg->pstBinCount[t].BinHigh);
 
             LOGGING("[%d] %lld completed\n", core, workIndex);
-            return TRUE;
+            return true;
          };
 
          LOGGING("multithread makeigroup   %lld cores   %lld unique   %lld rows\n", cores, totalUnique, totalRows);
@@ -2170,10 +2176,11 @@ BIN_COUNT InternalGetBinFunc(int32_t iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = BinCountAlgo<int16_t, int32_t>;
          break;
-      CASE_NPY_INT32:
+      case NPY_INT32:
          pBinFunc = BinCountAlgo<int32_t, int32_t>;
          break;
-      CASE_NPY_INT64:
+      case NPY_INT64:
+      case NPY_LONGLONG:
          pBinFunc = BinCountAlgo<int64_t, int32_t>;
          break;
       default:
@@ -2188,10 +2195,11 @@ BIN_COUNT InternalGetBinFunc(int32_t iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = BinCountAlgo<int16_t, int64_t>;
          break;
-      CASE_NPY_INT32:
+      case NPY_INT32:
          pBinFunc = BinCountAlgo<int32_t, int64_t>;
          break;
-      CASE_NPY_INT64:
+      case NPY_INT64:
+      case NPY_LONGLONG:
          pBinFunc = BinCountAlgo<int64_t, int64_t>;
          break;
       default:
@@ -2272,7 +2280,7 @@ int64_t InternalBinCount(
          callbackArg->uniqueRows);
 
       LOGGING("[%d] %lld completed\n", core, workIndex);
-      return TRUE;
+      return true;
    };
 
    LOGGING("multithread bincount   %lld cores   %lld unique   %lld rows\n", cores, unique_rows, totalRows);
@@ -2515,7 +2523,7 @@ BinCount(PyObject *self, PyObject *args, PyObject* kwargs)
                         callbackArg->unique_rows);
 
                      LOGGING("[%d] %lld completed\n", core, workIndex);
-                     return TRUE;
+                     return true;
                   };
 
                   LOGGING("multithread makeigroup2   %lld cores   %lld unique   %lld rows\n", cores, unique_rows, totalRows);

--- a/src/MultiKey.cpp
+++ b/src/MultiKey.cpp
@@ -824,11 +824,11 @@ GroupByPack32(PyObject* self, PyObject* args) {
          case NPY_INT16:
             pNextArray = GroupByPackFixup32<int16_t>(numUnique, totalRows, pIndexArray, pGroupArray);
             break;
-         case NPY_INT32:
+         CASE_NPY_INT32:
             pNextArray = GroupByPackFixup32<int32_t>(numUnique, totalRows, pIndexArray, pGroupArray);
             break;
-         case NPY_INT64:
-         case NPY_LONGLONG:
+         CASE_NPY_INT64:
+         
             pNextArray = GroupByPackFixup32<int64_t>(numUnique, totalRows, pIndexArray, pGroupArray);
             break;
          default:
@@ -857,11 +857,11 @@ GroupByPack32(PyObject* self, PyObject* args) {
       case NPY_INT16:
          bResult = GroupByPackFinal32<int16_t>(numUnique, totalRows, pIndexArray, pNextArray, pGroupArray, &sortGroupArray, &firstArray, &countArray);
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          bResult = GroupByPackFinal32<int32_t>(numUnique, totalRows, pIndexArray, pNextArray, pGroupArray, &sortGroupArray, &firstArray, &countArray);
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          bResult = GroupByPackFinal32<int64_t>(numUnique, totalRows, pIndexArray, pNextArray, pGroupArray, &sortGroupArray, &firstArray, &countArray);
          break;
       default:
@@ -1821,11 +1821,11 @@ MAKE_I_GROUP2 GetMakeIGroup2(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup2<int16_t, int32_t>;
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          pBinFunc = MakeiGroup2<int32_t, int32_t>;
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          pBinFunc = MakeiGroup2<int64_t, int32_t>;
          break;
       default:
@@ -1840,11 +1840,11 @@ MAKE_I_GROUP2 GetMakeIGroup2(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup2<int16_t, int64_t>;
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          pBinFunc = MakeiGroup2<int32_t, int64_t>;
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          pBinFunc = MakeiGroup2<int64_t, int64_t>;
          break;
       default:
@@ -1932,11 +1932,11 @@ MAKE_I_GROUP GetMakeIGroup(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup<int16_t, int32_t>;
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          pBinFunc = MakeiGroup<int32_t, int32_t>;
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          pBinFunc = MakeiGroup<int64_t, int32_t>;
          break;
       default:
@@ -1951,11 +1951,11 @@ MAKE_I_GROUP GetMakeIGroup(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup<int16_t, int64_t>;
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          pBinFunc = MakeiGroup<int32_t, int64_t>;
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          pBinFunc = MakeiGroup<int64_t, int64_t>;
          break;
       default:
@@ -2023,7 +2023,7 @@ GroupFromBinCount(PyObject *self, PyObject *args)
       // Generate the location for bin to write the next location
       // Effectively this is a cumsum
       switch (outdtype) {
-      case NPY_INT32:
+      CASE_NPY_INT32:
       {
          int32_t* pCount = (int32_t*)pnCountGroup;
          int32_t* pCumSum = (int32_t*)piFirstGroup;
@@ -2034,7 +2034,7 @@ GroupFromBinCount(PyObject *self, PyObject *args)
          }
       }
       break;
-      case NPY_INT64:
+      CASE_NPY_INT64:
       {
          int64_t* pCount = (int64_t*)pnCountGroup;
          int64_t* pCumSum = (int64_t*)piFirstGroup;
@@ -2176,11 +2176,11 @@ BIN_COUNT InternalGetBinFunc(int32_t iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = BinCountAlgo<int16_t, int32_t>;
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          pBinFunc = BinCountAlgo<int32_t, int32_t>;
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          pBinFunc = BinCountAlgo<int64_t, int32_t>;
          break;
       default:
@@ -2195,11 +2195,11 @@ BIN_COUNT InternalGetBinFunc(int32_t iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = BinCountAlgo<int16_t, int64_t>;
          break;
-      case NPY_INT32:
+      CASE_NPY_INT32:
          pBinFunc = BinCountAlgo<int32_t, int64_t>;
          break;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
          pBinFunc = BinCountAlgo<int64_t, int64_t>;
          break;
       default:

--- a/src/MultiKey.cpp
+++ b/src/MultiKey.cpp
@@ -618,9 +618,9 @@ bool GroupByPackFinal32(
 
    //-----------------------------------------------------
    // sortArray is iGroup in python land
-   PyArrayObject* sortArray =  AllocateNumpyArray(1, (npy_intp*)&totalRows, NPY_INT);
-   PyArrayObject* firstArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT);
-   PyArrayObject* countArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT);
+   PyArrayObject* sortArray =  AllocateNumpyArray(1, (npy_intp*)&totalRows, NPY_INT32);
+   PyArrayObject* firstArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT32);
+   PyArrayObject* countArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT32);
 
    if (sortArray && firstArray && countArray) {
 
@@ -824,7 +824,7 @@ GroupByPack32(PyObject* self, PyObject* args) {
          case NPY_INT16:
             pNextArray = GroupByPackFixup32<int16_t>(numUnique, totalRows, pIndexArray, pGroupArray);
             break;
-         case NPY_INT:
+         case NPY_INT32:
             pNextArray = GroupByPackFixup32<int32_t>(numUnique, totalRows, pIndexArray, pGroupArray);
             break;
          case NPY_INT64:
@@ -857,7 +857,7 @@ GroupByPack32(PyObject* self, PyObject* args) {
       case NPY_INT16:
          bResult = GroupByPackFinal32<int16_t>(numUnique, totalRows, pIndexArray, pNextArray, pGroupArray, &sortGroupArray, &firstArray, &countArray);
          break;
-      case NPY_INT:
+      case NPY_INT32:
          bResult = GroupByPackFinal32<int32_t>(numUnique, totalRows, pIndexArray, pNextArray, pGroupArray, &sortGroupArray, &firstArray, &countArray);
          break;
       case NPY_INT64:
@@ -936,7 +936,7 @@ MultiKeyGroupBy32(PyObject *self, PyObject *args, PyObject *kwargs) {
 
    try {
 
-      int32_t numpyIndexType = NPY_INT;
+      int32_t numpyIndexType = NPY_INT32;
 
       // Rotate the arrays
       CMultiKeyPrepare mkp(args);
@@ -988,7 +988,7 @@ MultiKeyGroupBy32(PyObject *self, PyObject *args, PyObject *kwargs) {
             GROUPBYCALL pGroupByCall = NULL;
             void* pIndexArray = PyArray_BYTES(indexArray);
 
-            if (numpyIndexType == NPY_INT) {
+            if (numpyIndexType == NPY_INT32) {
                pGroupByCall = GroupBy32;
             }
             else {
@@ -1075,7 +1075,7 @@ MultiKeyGroupBy32Super(PyObject *self, PyObject *args) {
 
    try {
 
-      int32_t numpyIndexType = NPY_INT;
+      int32_t numpyIndexType = NPY_INT32;
 
       CMultiKeyPrepare mkp(args);
 
@@ -1236,7 +1236,7 @@ MultiKeyUnique32(PyObject *self, PyObject *args) {
                      mkp.pBoolFilter);
 
                // We allocated for worst case, now copy over only the unique indexes
-               PyArrayObject* indexArray2 = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT);
+               PyArrayObject* indexArray2 = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT32);
                CHECK_MEMORY_ERROR(indexArray2);
 
                if (indexArray2 != NULL) {
@@ -1244,7 +1244,7 @@ MultiKeyUnique32(PyObject *self, PyObject *args) {
                   memcpy(pIndexArray2, pIndexArray, numUnique * sizeof(int32_t));
                }
 
-               PyArrayObject* countArray2 = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT);
+               PyArrayObject* countArray2 = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT32);
                CHECK_MEMORY_ERROR(countArray2);
 
                if (countArray2 != NULL) {
@@ -1437,15 +1437,15 @@ MultiKeyHash(PyObject *self, PyObject *args)
 
       PyArrayObject* firstObject = mkp.aInfo[0].pObject;
 
-      PyArrayObject* indexArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
-      PyArrayObject* runningCountArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
-      PyArrayObject* prevArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
-      PyArrayObject* nextArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
+      PyArrayObject* indexArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
+      PyArrayObject* runningCountArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
+      PyArrayObject* prevArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
+      PyArrayObject* nextArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
 
       // Second pass
-      PyArrayObject* firstArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
-      PyArrayObject* bktSizeArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
-      PyArrayObject* lastArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
+      PyArrayObject* firstArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
+      PyArrayObject* bktSizeArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
+      PyArrayObject* lastArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
 
       if (lastArray == NULL) {
          PyErr_Format(PyExc_ValueError, "MultiKeyHash out of memory    %llu", mkp.totalRows);
@@ -1720,7 +1720,7 @@ PyObject *MultiKeyAlign32(PyObject *self, PyObject *args)
       LOGGING("MultiKeyAlign32 total rows %lld %lld\n", mkp1.totalRows, mkp2.totalRows);
       try {
          if (isIndex32) {
-            indexArray = AllocateLikeNumpyArray(mkp1.aInfo[0].pObject, NPY_INT);
+            indexArray = AllocateLikeNumpyArray(mkp1.aInfo[0].pObject, NPY_INT32);
             if (!indexArray) return PyErr_Format(PyExc_BufferError, "MultiKeyAlign32");
             int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(indexArray);
             success = AlignHashMK32(mkp1.totalRows, mkp1.pSuperArray, pVal1, mkp2.totalRows, mkp2.pSuperArray, pVal2, pDataOut2, mkp1.totalItemSize, HASH_MODE_MASK, dtype1, isForward, allowExact);
@@ -1813,7 +1813,7 @@ MAKE_I_GROUP2 GetMakeIGroup2(int iKeyType, int outdtype) {
    //
    MAKE_I_GROUP2 pBinFunc = NULL;
 
-   if (outdtype == NPY_INT) {
+   if (outdtype == NPY_INT32) {
       switch (iKeyType) {
       case NPY_INT8:
          pBinFunc = MakeiGroup2<int8_t, int32_t>;
@@ -1821,7 +1821,7 @@ MAKE_I_GROUP2 GetMakeIGroup2(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup2<int16_t, int32_t>;
          break;
-      case NPY_INT:
+      case NPY_INT32:
          pBinFunc = MakeiGroup2<int32_t, int32_t>;
          break;
       case NPY_INT64:
@@ -1840,7 +1840,7 @@ MAKE_I_GROUP2 GetMakeIGroup2(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup2<int16_t, int64_t>;
          break;
-      case NPY_INT:
+      case NPY_INT32:
          pBinFunc = MakeiGroup2<int32_t, int64_t>;
          break;
       case NPY_INT64:
@@ -1924,7 +1924,7 @@ MAKE_I_GROUP GetMakeIGroup(int iKeyType, int outdtype) {
    //
    MAKE_I_GROUP pBinFunc = NULL;
 
-   if (outdtype == NPY_INT) {
+   if (outdtype == NPY_INT32) {
       switch (iKeyType) {
       case NPY_INT8:
          pBinFunc = MakeiGroup<int8_t, int32_t>;
@@ -1932,7 +1932,7 @@ MAKE_I_GROUP GetMakeIGroup(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup<int16_t, int32_t>;
          break;
-      case NPY_INT:
+      case NPY_INT32:
          pBinFunc = MakeiGroup<int32_t, int32_t>;
          break;
       case NPY_INT64:
@@ -1951,7 +1951,7 @@ MAKE_I_GROUP GetMakeIGroup(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup<int16_t, int64_t>;
          break;
-      case NPY_INT:
+      case NPY_INT32:
          pBinFunc = MakeiGroup<int32_t, int64_t>;
          break;
       case NPY_INT64:
@@ -1999,7 +1999,7 @@ GroupFromBinCount(PyObject *self, PyObject *args)
    PyArrayObject* outiFirstGroup = NULL;
 
    // Check for totalRows > 2100000000 and switch to int64_t
-   int outdtype = NPY_INT;
+   int outdtype = NPY_INT32;
 
    if (totalRows > 2000000000) {
       outdtype = NPY_INT64;
@@ -2023,7 +2023,7 @@ GroupFromBinCount(PyObject *self, PyObject *args)
       // Generate the location for bin to write the next location
       // Effectively this is a cumsum
       switch (outdtype) {
-      case NPY_INT:
+      case NPY_INT32:
       {
          int32_t* pCount = (int32_t*)pnCountGroup;
          int32_t* pCumSum = (int32_t*)piFirstGroup;
@@ -2168,7 +2168,7 @@ BIN_COUNT InternalGetBinFunc(int32_t iKeyType, int outdtype) {
    // Pick one of 8 bincount routines based on
    // ikey size and int32_t vs int64_t output
    //
-   if (outdtype == NPY_INT) {
+   if (outdtype == NPY_INT32) {
       switch (iKeyType) {
       case NPY_INT8:
          pBinFunc = BinCountAlgo<int8_t, int32_t>;
@@ -2176,7 +2176,7 @@ BIN_COUNT InternalGetBinFunc(int32_t iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = BinCountAlgo<int16_t, int32_t>;
          break;
-      case NPY_INT:
+      case NPY_INT32:
          pBinFunc = BinCountAlgo<int32_t, int32_t>;
          break;
       case NPY_INT64:
@@ -2195,7 +2195,7 @@ BIN_COUNT InternalGetBinFunc(int32_t iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = BinCountAlgo<int16_t, int64_t>;
          break;
-      case NPY_INT:
+      case NPY_INT32:
          pBinFunc = BinCountAlgo<int32_t, int64_t>;
          break;
       case NPY_INT64:
@@ -2345,7 +2345,7 @@ BinCount(PyObject *self, PyObject *args, PyObject* kwargs)
    PyArrayObject* outiFirstGroup = NULL;
 
    // Check for totalRows > 2100000000 and switch to int64_t
-   int outdtype = NPY_INT;
+   int outdtype = NPY_INT32;
 
    if (unique_rows == 0 || totalRows <=0) {
       PyErr_Format(PyExc_ValueError, "BinCount: unique or totalRows is zero, cannot calculate the bins.");
@@ -2401,7 +2401,7 @@ BinCount(PyObject *self, PyObject *args, PyObject* kwargs)
                // Count up what all the worker threads produced
                // This will produce nCountGroup
                // TODO: Could be counted in parallel for large uniques
-               if (outdtype == NPY_INT) {
+               if (outdtype == NPY_INT32) {
                   int32_t* pMaster = (int32_t*)pnCountGroup;
                   int32_t* pCount = (int32_t*)pMem;
 
@@ -2436,7 +2436,7 @@ BinCount(PyObject *self, PyObject *args, PyObject* kwargs)
                   void* piFirstGroup = PyArray_BYTES(outiFirstGroup);
                   void* piGroup = PyArray_BYTES(outiGroup);
 
-                  if (outdtype == NPY_INT) {
+                  if (outdtype == NPY_INT32) {
                      // Should be all ZEROS
                      int32_t lastvalue = 0;
                      int32_t* pCountArray2d = (int32_t*)pstBinCount[0].pUserMemory;

--- a/src/MultiKey.cpp
+++ b/src/MultiKey.cpp
@@ -618,9 +618,9 @@ bool GroupByPackFinal32(
 
    //-----------------------------------------------------
    // sortArray is iGroup in python land
-   PyArrayObject* sortArray =  AllocateNumpyArray(1, (npy_intp*)&totalRows, NPY_INT32);
-   PyArrayObject* firstArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT32);
-   PyArrayObject* countArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT32);
+   PyArrayObject* sortArray =  AllocateNumpyArray(1, (npy_intp*)&totalRows, NPY_INT);
+   PyArrayObject* firstArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT);
+   PyArrayObject* countArray = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT);
 
    if (sortArray && firstArray && countArray) {
 
@@ -824,7 +824,7 @@ GroupByPack32(PyObject* self, PyObject* args) {
          case NPY_INT16:
             pNextArray = GroupByPackFixup32<int16_t>(numUnique, totalRows, pIndexArray, pGroupArray);
             break;
-         case NPY_INT32:
+         case NPY_INT:
             pNextArray = GroupByPackFixup32<int32_t>(numUnique, totalRows, pIndexArray, pGroupArray);
             break;
          case NPY_INT64:
@@ -857,7 +857,7 @@ GroupByPack32(PyObject* self, PyObject* args) {
       case NPY_INT16:
          bResult = GroupByPackFinal32<int16_t>(numUnique, totalRows, pIndexArray, pNextArray, pGroupArray, &sortGroupArray, &firstArray, &countArray);
          break;
-      case NPY_INT32:
+      case NPY_INT:
          bResult = GroupByPackFinal32<int32_t>(numUnique, totalRows, pIndexArray, pNextArray, pGroupArray, &sortGroupArray, &firstArray, &countArray);
          break;
       case NPY_INT64:
@@ -936,7 +936,7 @@ MultiKeyGroupBy32(PyObject *self, PyObject *args, PyObject *kwargs) {
 
    try {
 
-      int32_t numpyIndexType = NPY_INT32;
+      int32_t numpyIndexType = NPY_INT;
 
       // Rotate the arrays
       CMultiKeyPrepare mkp(args);
@@ -988,7 +988,7 @@ MultiKeyGroupBy32(PyObject *self, PyObject *args, PyObject *kwargs) {
             GROUPBYCALL pGroupByCall = NULL;
             void* pIndexArray = PyArray_BYTES(indexArray);
 
-            if (numpyIndexType == NPY_INT32) {
+            if (numpyIndexType == NPY_INT) {
                pGroupByCall = GroupBy32;
             }
             else {
@@ -1075,7 +1075,7 @@ MultiKeyGroupBy32Super(PyObject *self, PyObject *args) {
 
    try {
 
-      int32_t numpyIndexType = NPY_INT32;
+      int32_t numpyIndexType = NPY_INT;
 
       CMultiKeyPrepare mkp(args);
 
@@ -1236,7 +1236,7 @@ MultiKeyUnique32(PyObject *self, PyObject *args) {
                      mkp.pBoolFilter);
 
                // We allocated for worst case, now copy over only the unique indexes
-               PyArrayObject* indexArray2 = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT32);
+               PyArrayObject* indexArray2 = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT);
                CHECK_MEMORY_ERROR(indexArray2);
 
                if (indexArray2 != NULL) {
@@ -1244,7 +1244,7 @@ MultiKeyUnique32(PyObject *self, PyObject *args) {
                   memcpy(pIndexArray2, pIndexArray, numUnique * sizeof(int32_t));
                }
 
-               PyArrayObject* countArray2 = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT32);
+               PyArrayObject* countArray2 = AllocateNumpyArray(1, (npy_intp*)&numUnique, NPY_INT);
                CHECK_MEMORY_ERROR(countArray2);
 
                if (countArray2 != NULL) {
@@ -1437,15 +1437,15 @@ MultiKeyHash(PyObject *self, PyObject *args)
 
       PyArrayObject* firstObject = mkp.aInfo[0].pObject;
 
-      PyArrayObject* indexArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
-      PyArrayObject* runningCountArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
-      PyArrayObject* prevArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
-      PyArrayObject* nextArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
+      PyArrayObject* indexArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
+      PyArrayObject* runningCountArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
+      PyArrayObject* prevArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
+      PyArrayObject* nextArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
 
       // Second pass
-      PyArrayObject* firstArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
-      PyArrayObject* bktSizeArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
-      PyArrayObject* lastArray = AllocateLikeNumpyArray(firstObject, NPY_INT32);
+      PyArrayObject* firstArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
+      PyArrayObject* bktSizeArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
+      PyArrayObject* lastArray = AllocateLikeNumpyArray(firstObject, NPY_INT);
 
       if (lastArray == NULL) {
          PyErr_Format(PyExc_ValueError, "MultiKeyHash out of memory    %llu", mkp.totalRows);
@@ -1720,7 +1720,7 @@ PyObject *MultiKeyAlign32(PyObject *self, PyObject *args)
       LOGGING("MultiKeyAlign32 total rows %lld %lld\n", mkp1.totalRows, mkp2.totalRows);
       try {
          if (isIndex32) {
-            indexArray = AllocateLikeNumpyArray(mkp1.aInfo[0].pObject, NPY_INT32);
+            indexArray = AllocateLikeNumpyArray(mkp1.aInfo[0].pObject, NPY_INT);
             if (!indexArray) return PyErr_Format(PyExc_BufferError, "MultiKeyAlign32");
             int32_t* pDataOut2 = (int32_t*)PyArray_BYTES(indexArray);
             success = AlignHashMK32(mkp1.totalRows, mkp1.pSuperArray, pVal1, mkp2.totalRows, mkp2.pSuperArray, pVal2, pDataOut2, mkp1.totalItemSize, HASH_MODE_MASK, dtype1, isForward, allowExact);
@@ -1813,7 +1813,7 @@ MAKE_I_GROUP2 GetMakeIGroup2(int iKeyType, int outdtype) {
    //
    MAKE_I_GROUP2 pBinFunc = NULL;
 
-   if (outdtype == NPY_INT32) {
+   if (outdtype == NPY_INT) {
       switch (iKeyType) {
       case NPY_INT8:
          pBinFunc = MakeiGroup2<int8_t, int32_t>;
@@ -1821,7 +1821,7 @@ MAKE_I_GROUP2 GetMakeIGroup2(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup2<int16_t, int32_t>;
          break;
-      case NPY_INT32:
+      case NPY_INT:
          pBinFunc = MakeiGroup2<int32_t, int32_t>;
          break;
       case NPY_INT64:
@@ -1840,7 +1840,7 @@ MAKE_I_GROUP2 GetMakeIGroup2(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup2<int16_t, int64_t>;
          break;
-      case NPY_INT32:
+      case NPY_INT:
          pBinFunc = MakeiGroup2<int32_t, int64_t>;
          break;
       case NPY_INT64:
@@ -1924,7 +1924,7 @@ MAKE_I_GROUP GetMakeIGroup(int iKeyType, int outdtype) {
    //
    MAKE_I_GROUP pBinFunc = NULL;
 
-   if (outdtype == NPY_INT32) {
+   if (outdtype == NPY_INT) {
       switch (iKeyType) {
       case NPY_INT8:
          pBinFunc = MakeiGroup<int8_t, int32_t>;
@@ -1932,7 +1932,7 @@ MAKE_I_GROUP GetMakeIGroup(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup<int16_t, int32_t>;
          break;
-      case NPY_INT32:
+      case NPY_INT:
          pBinFunc = MakeiGroup<int32_t, int32_t>;
          break;
       case NPY_INT64:
@@ -1951,7 +1951,7 @@ MAKE_I_GROUP GetMakeIGroup(int iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = MakeiGroup<int16_t, int64_t>;
          break;
-      case NPY_INT32:
+      case NPY_INT:
          pBinFunc = MakeiGroup<int32_t, int64_t>;
          break;
       case NPY_INT64:
@@ -1999,7 +1999,7 @@ GroupFromBinCount(PyObject *self, PyObject *args)
    PyArrayObject* outiFirstGroup = NULL;
 
    // Check for totalRows > 2100000000 and switch to int64_t
-   int outdtype = NPY_INT32;
+   int outdtype = NPY_INT;
 
    if (totalRows > 2000000000) {
       outdtype = NPY_INT64;
@@ -2023,7 +2023,7 @@ GroupFromBinCount(PyObject *self, PyObject *args)
       // Generate the location for bin to write the next location
       // Effectively this is a cumsum
       switch (outdtype) {
-      case NPY_INT32:
+      case NPY_INT:
       {
          int32_t* pCount = (int32_t*)pnCountGroup;
          int32_t* pCumSum = (int32_t*)piFirstGroup;
@@ -2168,7 +2168,7 @@ BIN_COUNT InternalGetBinFunc(int32_t iKeyType, int outdtype) {
    // Pick one of 8 bincount routines based on
    // ikey size and int32_t vs int64_t output
    //
-   if (outdtype == NPY_INT32) {
+   if (outdtype == NPY_INT) {
       switch (iKeyType) {
       case NPY_INT8:
          pBinFunc = BinCountAlgo<int8_t, int32_t>;
@@ -2176,7 +2176,7 @@ BIN_COUNT InternalGetBinFunc(int32_t iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = BinCountAlgo<int16_t, int32_t>;
          break;
-      case NPY_INT32:
+      case NPY_INT:
          pBinFunc = BinCountAlgo<int32_t, int32_t>;
          break;
       case NPY_INT64:
@@ -2195,7 +2195,7 @@ BIN_COUNT InternalGetBinFunc(int32_t iKeyType, int outdtype) {
       case NPY_INT16:
          pBinFunc = BinCountAlgo<int16_t, int64_t>;
          break;
-      case NPY_INT32:
+      case NPY_INT:
          pBinFunc = BinCountAlgo<int32_t, int64_t>;
          break;
       case NPY_INT64:
@@ -2345,7 +2345,7 @@ BinCount(PyObject *self, PyObject *args, PyObject* kwargs)
    PyArrayObject* outiFirstGroup = NULL;
 
    // Check for totalRows > 2100000000 and switch to int64_t
-   int outdtype = NPY_INT32;
+   int outdtype = NPY_INT;
 
    if (unique_rows == 0 || totalRows <=0) {
       PyErr_Format(PyExc_ValueError, "BinCount: unique or totalRows is zero, cannot calculate the bins.");
@@ -2401,7 +2401,7 @@ BinCount(PyObject *self, PyObject *args, PyObject* kwargs)
                // Count up what all the worker threads produced
                // This will produce nCountGroup
                // TODO: Could be counted in parallel for large uniques
-               if (outdtype == NPY_INT32) {
+               if (outdtype == NPY_INT) {
                   int32_t* pMaster = (int32_t*)pnCountGroup;
                   int32_t* pCount = (int32_t*)pMem;
 
@@ -2436,7 +2436,7 @@ BinCount(PyObject *self, PyObject *args, PyObject* kwargs)
                   void* piFirstGroup = PyArray_BYTES(outiFirstGroup);
                   void* piGroup = PyArray_BYTES(outiGroup);
 
-                  if (outdtype == NPY_INT32) {
+                  if (outdtype == NPY_INT) {
                      // Should be all ZEROS
                      int32_t lastvalue = 0;
                      int32_t* pCountArray2d = (int32_t*)pstBinCount[0].pUserMemory;

--- a/src/MultiKey.h
+++ b/src/MultiKey.h
@@ -47,8 +47,8 @@ extern ArrayInfo* BuildArrayInfo(
    PyObject* listObject,
    int64_t* pTupleSize,
    int64_t* pTotalItemSize,
-   bool checkrows = TRUE,
-   bool convert = TRUE);
+   bool checkrows = true,
+   bool convert = true);
 
 extern void FreeArrayInfo(ArrayInfo* pArrayInfo);
 

--- a/src/MultiKey.h
+++ b/src/MultiKey.h
@@ -11,15 +11,15 @@ struct ArrayInfo {
    char*       pData;
 
    // Width in bytes of one row
-   INT64       ItemSize;
+   int64_t       ItemSize;
 
    // total number of items
-   INT64       ArrayLength;
+   int64_t       ArrayLength;
 
-   INT64       NumBytes;
+   int64_t       NumBytes;
 
-   INT32       NumpyDType;
-   INT32       NDim;
+   int32_t       NumpyDType;
+   int32_t       NDim;
 
    // When calling ensure contiguous, we might make a copy
    // if so, pObject is the copy and must be deleted.  pOriginal was passed in
@@ -45,10 +45,10 @@ extern PyObject *MergeBinnedAndSorted(PyObject *self, PyObject *args);
 
 extern ArrayInfo* BuildArrayInfo(
    PyObject* listObject,
-   INT64* pTupleSize,
-   INT64* pTotalItemSize,
-   BOOL checkrows = TRUE,
-   BOOL convert = TRUE);
+   int64_t* pTupleSize,
+   int64_t* pTotalItemSize,
+   bool checkrows = TRUE,
+   bool convert = TRUE);
 
 extern void FreeArrayInfo(ArrayInfo* pArrayInfo);
 

--- a/src/Recycler.h
+++ b/src/Recycler.h
@@ -6,27 +6,27 @@
 
 // allocated on 64 byte alignment
 struct stRecycleItem {
-   INT16                type;          // numpy type -- up to maximum type
-   INT16                initRefCount;  // ref count when first put in q
-   INT32                ndim;          // number of dims
-   INT64                totalSize;     // total size
-   UINT64               tsc;           // time stamp counter
+   int16_t                type;          // numpy type -- up to maximum type
+   int16_t                initRefCount;  // ref count when first put in q
+   int32_t                ndim;          // number of dims
+   int64_t                totalSize;     // total size
+   uint64_t               tsc;           // time stamp counter
    void*                memoryAddress;
    PyArrayObject*       recycledArray;
 };
 
 
-static const INT64 RECYCLE_ENTRIES = 64;
-static const INT64 RECYCLE_MAXIMUM_TYPE = 14;
-static const INT64 RECYCLE_MAXIMUM_SEARCH = 4;
-static const INT64 RECYCLE_MASK = 3;
-static const INT64 RECYCLE_MIN_SIZE = 1;
+static const int64_t RECYCLE_ENTRIES = 64;
+static const int64_t RECYCLE_MAXIMUM_TYPE = 14;
+static const int64_t RECYCLE_MAXIMUM_SEARCH = 4;
+static const int64_t RECYCLE_MASK = 3;
+static const int64_t RECYCLE_MIN_SIZE = 1;
 
 struct stRecycleList {
    // Circular list, when Head==Tail no items
 
-   INT32             Head;
-   INT32             Tail;
+   int32_t             Head;
+   int32_t             Tail;
 
    stRecycleItem     Item[RECYCLE_MAXIMUM_SEARCH];
 };
@@ -41,11 +41,11 @@ PyObject *TryRecycleNumpy(PyObject *self, PyObject *args);
 PyObject *SetRecycleMode(PyObject *self, PyObject *args);
 
 
-PyArrayObject* RecycleFindArray(INT32 ndim, INT32 type, INT64 totalSize);
+PyArrayObject* RecycleFindArray(int32_t ndim, int32_t type, int64_t totalSize);
 
 void InitRecycler();
 
-BOOL RecycleNumpyInternal(PyArrayObject *inArr);
+bool RecycleNumpyInternal(PyArrayObject *inArr);
 
 void* WorkSpaceAllocLarge(size_t HashTableAllocSize);
 void WorkSpaceFreeAllocLarge(void* &pHashTableAny, size_t HashTableAllocSize);
@@ -53,4 +53,4 @@ void WorkSpaceFreeAllocLarge(void* &pHashTableAny, size_t HashTableAllocSize);
 void* WorkSpaceAllocSmall(size_t BitAllocSize);
 void WorkSpaceFreeAllocSmall(void* &pBitFields, size_t BitAllocSize);
 
-INT64 GarbageCollect(INT64 timespan, bool verbose);
+int64_t GarbageCollect(int64_t timespan, bool verbose);

--- a/src/Reduce.cpp
+++ b/src/Reduce.cpp
@@ -236,12 +236,16 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      CASE_NPY_INT32:  return non_vector<int32_t>;
-      CASE_NPY_INT64:  return non_vector<int64_t>;
+      case NPY_INT32:  return non_vector<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      CASE_NPY_UINT32: return non_vector<uint32_t>;
-      CASE_NPY_UINT64: return non_vector<uint64_t>;
+      case NPY_UINT32: return non_vector<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          return non_vector<uint64_t>;
       default:
          return nullptr;
       }
@@ -308,12 +312,16 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      CASE_NPY_INT32:  return non_vector<int32_t>;
-      CASE_NPY_INT64:  return non_vector<int64_t>;
+      case NPY_INT32:  return non_vector<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      CASE_NPY_UINT32: return non_vector<uint32_t>;
-      CASE_NPY_UINT64: return non_vector<uint64_t>;
+      case NPY_UINT32: return non_vector<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          return non_vector<uint64_t>;
       default:
          return nullptr;
       }
@@ -405,12 +413,16 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      CASE_NPY_INT32:  return non_vector<int32_t>;
-      CASE_NPY_INT64:  return non_vector<int64_t>;
+      case NPY_INT32:  return non_vector<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      CASE_NPY_UINT32: return non_vector<uint32_t>;
-      CASE_NPY_UINT64: return non_vector<uint64_t>;
+      case NPY_UINT32: return non_vector<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          return non_vector<uint64_t>;
       default:
          return nullptr;
       }
@@ -501,12 +513,16 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      CASE_NPY_INT32:  return non_vector<int32_t>;
-      CASE_NPY_INT64:  return non_vector<int64_t>;
+      case NPY_INT32:  return non_vector<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      CASE_NPY_UINT32: return non_vector<uint32_t>;
-      CASE_NPY_UINT64: return non_vector<uint64_t>;
+      case NPY_UINT32: return non_vector<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          return non_vector<uint64_t>;
       default:
          return nullptr;
       }
@@ -645,12 +661,16 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return avx2<int8_t, __m256i, __m128i>;
       case NPY_INT16:  return avx2<int16_t, __m256i, __m128i>;
-      CASE_NPY_INT32:  return avx2<int32_t, __m256i, __m128i>;
-      CASE_NPY_INT64:  return non_vector<int64_t>;
+      case NPY_INT32:  return avx2<int32_t, __m256i, __m128i>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      CASE_NPY_UINT32: return avx2<uint32_t, __m256i, __m128i>;
-      CASE_NPY_UINT64: return non_vector<uint64_t>;
+      case NPY_UINT32: return avx2<uint32_t, __m256i, __m128i>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          return non_vector<uint64_t>;
       default:
          return nullptr;
       }
@@ -743,7 +763,7 @@ class ReduceMin final
          m0 = MIN_OP(result, m0, m1);  m2 = MIN_OP(result, m2, m3);  m4 = MIN_OP(result, m4, m5);  m6 = MIN_OP(result, m6, m7);
          m0 = MIN_OP(result, m0, m2);  m4 = MIN_OP(result, m4, m6);  m0 = MIN_OP(result, m0, m4);
 
-         if (FALSE) {
+         if (false) {
             // Older path
             // Write 256 bits into memory
             __m256i temp;
@@ -889,7 +909,7 @@ class ReduceMin final
             m0 = MIN_OP(result, m0, m1);  m2 = MIN_OP(result, m2, m3);  m4 = MIN_OP(result, m4, m5);  m6 = MIN_OP(result, m6, m7);
             m0 = MIN_OP(result, m0, m2);  m4 = MIN_OP(result, m4, m6);  m0 = MIN_OP(result, m0, m4);
 
-            if (FALSE) {
+            if (false) {
                // Older path
                // Write 256 bits into memory
                __m256i temp;
@@ -999,12 +1019,16 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return avx2<int8_t, __m256i, __m128i>;
       case NPY_INT16:  return avx2<int16_t, __m256i, __m128i>;
-      CASE_NPY_INT32:  return avx2<int32_t, __m256i, __m128i>;
-      CASE_NPY_INT64:  return non_vector<int64_t>;
+      case NPY_INT32:  return avx2<int32_t, __m256i, __m128i>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      CASE_NPY_UINT32: return avx2<uint32_t, __m256i, __m128i>;
-      CASE_NPY_UINT64: return non_vector<uint64_t>;
+      case NPY_UINT32: return avx2<uint32_t, __m256i, __m128i>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          return non_vector<uint64_t>;
       default:
          return nullptr;
       }
@@ -1215,12 +1239,16 @@ public:
       case NPY_LONGDOUBLE: return non_vector<long double>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      CASE_NPY_INT32:  return non_vector<int32_t>;
-      CASE_NPY_INT64:  return non_vector<int64_t>;
+      case NPY_INT32:  return non_vector<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      CASE_NPY_UINT32: return non_vector<uint32_t>;
-      CASE_NPY_UINT64: return non_vector<uint64_t>;
+      case NPY_UINT32: return non_vector<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          return non_vector<uint64_t>;
 
       // bools are currently handled specially; we don't consider bool to have a nan/invalid value
       // so we utilize the normal reduction operation for it.
@@ -1436,12 +1464,16 @@ public:
       case NPY_LONGDOUBLE: return non_vector<long double>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      CASE_NPY_INT32:  return non_vector<int32_t>;
-      CASE_NPY_INT64:  return non_vector<int64_t>;
+      case NPY_INT32:  return non_vector<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      CASE_NPY_UINT32: return non_vector<uint32_t>;
-      CASE_NPY_UINT64: return non_vector<uint64_t>;
+      case NPY_UINT32: return non_vector<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          return non_vector<uint64_t>;
 
       // bools are currently handled specially; we don't consider bool to have a nan/invalid value
       // so we utilize the normal reduction operation for it.
@@ -1840,13 +1872,17 @@ public:
       case NPY_BOOL: // TODO: Call/return our fast SumBooleanMask() implementation.
       case NPY_INT8:   return ReduceAddSlow<int8_t>;
       case NPY_INT16:  return ReduceAddSlow<int16_t>;
-      CASE_NPY_INT32: return ReduceAddI32;
-      CASE_NPY_INT64: return ReduceAddI64;
+      case NPY_INT32: return ReduceAddI32;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+          return ReduceAddI64;
 
       case NPY_UINT8:   return ReduceAddSlow<uint8_t>;
       case NPY_UINT16:  return ReduceAddSlow<uint16_t>;
-      CASE_NPY_UINT32:  return ReduceAddSlow<uint32_t>;
-      CASE_NPY_UINT64: return ReduceAddU64;
+      case NPY_UINT32:  return ReduceAddSlow<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          return ReduceAddU64;
 
       default:
          return nullptr;
@@ -1895,13 +1931,17 @@ public:
       case NPY_BOOL: return non_vector<bool>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      CASE_NPY_INT32: return non_vector<int32_t>;
-      CASE_NPY_INT64: return non_vector<int64_t>;
+      case NPY_INT32: return non_vector<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+          return non_vector<int64_t>;
 
       case NPY_UINT8:   return non_vector<uint8_t>;
       case NPY_UINT16:  return non_vector<uint16_t>;
-      CASE_NPY_UINT32:  return non_vector<uint32_t>;
-      CASE_NPY_UINT64: return non_vector<uint64_t>;
+      case NPY_UINT32:  return non_vector<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          return non_vector<uint64_t>;
 
       default:
          return nullptr;
@@ -2059,13 +2099,17 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return ReduceVar<int8_t>;
       case NPY_INT16:  return ReduceVar<int16_t>;
-      CASE_NPY_INT32: return ReduceVar<int32_t>;
-      CASE_NPY_INT64: return ReduceVar<int64_t>;
+      case NPY_INT32: return ReduceVar<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+          return ReduceVar<int64_t>;
 
       case NPY_UINT8:   return ReduceVar<uint8_t>;
       case NPY_UINT16:  return ReduceVar<uint16_t>;
-      CASE_NPY_UINT32:  return ReduceVar<uint32_t>;
-      CASE_NPY_UINT64: return ReduceVar<uint64_t>;
+      case NPY_UINT32:  return ReduceVar<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          return ReduceVar<uint64_t>;
 
       default:
          return nullptr;
@@ -2118,13 +2162,17 @@ public:
       case NPY_BOOL:   return non_vector<bool>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      CASE_NPY_INT32: return non_vector<int32_t>;
-      CASE_NPY_INT64: return non_vector<int64_t>;
+      case NPY_INT32: return non_vector<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+          return non_vector<int64_t>;
 
       case NPY_UINT8:   return non_vector<uint8_t>;
       case NPY_UINT16:  return non_vector<uint16_t>;
-      CASE_NPY_UINT32:  return non_vector<uint32_t>;
-      CASE_NPY_UINT64: return non_vector<uint64_t>;
+      case NPY_UINT32:  return non_vector<uint32_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+          return non_vector<uint64_t>;
 
       default:
          return nullptr;
@@ -2435,13 +2483,15 @@ static PyObject* ReduceInternal(PyArrayObject* inArr1, REDUCE_FUNCTIONS func, co
       if (func == REDUCE_FUNCTIONS::REDUCE_SUM || func == REDUCE_FUNCTIONS::REDUCE_NANSUM) {
          // Check for overflow
          switch (numpyInType) {
-         CASE_NPY_UINT64:
+         case NPY_UINT64:
+         case NPY_ULONGLONG:
             if (sgFunc.resultOut > 18446744073709551615.0) {
                LOGGING("Returning overflow %lf  for func %lld\n", sgFunc.resultOut, func);
                return PyFloat_FromDouble(sgFunc.resultOut);
             }
             break;
-         CASE_NPY_INT64:
+         case NPY_INT64:
+         case NPY_LONGLONG:
             if (sgFunc.resultOut > 9223372036854775807.0 || sgFunc.resultOut < -9223372036854775808.0) {
                LOGGING("Returning overflow %lf  for func %lld\n", sgFunc.resultOut, func);
                return PyFloat_FromDouble(sgFunc.resultOut);
@@ -2452,7 +2502,8 @@ static PyObject* ReduceInternal(PyArrayObject* inArr1, REDUCE_FUNCTIONS func, co
       }
 
       switch (numpyInType) {
-      CASE_NPY_UINT64:
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
          LOGGING("Returning %llu  vs  %lf for func %lld\n", (uint64_t)sgFunc.resultOutInt64, sgFunc.resultOut, func);
          return PyLong_FromUnsignedLongLong(sgFunc.resultOutInt64);
 

--- a/src/Reduce.cpp
+++ b/src/Reduce.cpp
@@ -236,13 +236,13 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32:  return non_vector<int32_t>;
+      case NPY_INT:  return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return non_vector<uint32_t>;
+      case NPY_UINT: return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -312,13 +312,13 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32:  return non_vector<int32_t>;
+      case NPY_INT:  return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return non_vector<uint32_t>;
+      case NPY_UINT: return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -413,13 +413,13 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32:  return non_vector<int32_t>;
+      case NPY_INT:  return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return non_vector<uint32_t>;
+      case NPY_UINT: return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -513,13 +513,13 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32:  return non_vector<int32_t>;
+      case NPY_INT:  return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return non_vector<uint32_t>;
+      case NPY_UINT: return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -661,13 +661,13 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return avx2<int8_t, __m256i, __m128i>;
       case NPY_INT16:  return avx2<int16_t, __m256i, __m128i>;
-      case NPY_INT32:  return avx2<int32_t, __m256i, __m128i>;
+      case NPY_INT:  return avx2<int32_t, __m256i, __m128i>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return avx2<uint32_t, __m256i, __m128i>;
+      case NPY_UINT: return avx2<uint32_t, __m256i, __m128i>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -1019,13 +1019,13 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return avx2<int8_t, __m256i, __m128i>;
       case NPY_INT16:  return avx2<int16_t, __m256i, __m128i>;
-      case NPY_INT32:  return avx2<int32_t, __m256i, __m128i>;
+      case NPY_INT:  return avx2<int32_t, __m256i, __m128i>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return avx2<uint32_t, __m256i, __m128i>;
+      case NPY_UINT: return avx2<uint32_t, __m256i, __m128i>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -1239,13 +1239,13 @@ public:
       case NPY_LONGDOUBLE: return non_vector<long double>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32:  return non_vector<int32_t>;
+      case NPY_INT:  return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return non_vector<uint32_t>;
+      case NPY_UINT: return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -1464,13 +1464,13 @@ public:
       case NPY_LONGDOUBLE: return non_vector<long double>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32:  return non_vector<int32_t>;
+      case NPY_INT:  return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return non_vector<uint32_t>;
+      case NPY_UINT: return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -1872,14 +1872,14 @@ public:
       case NPY_BOOL: // TODO: Call/return our fast SumBooleanMask() implementation.
       case NPY_INT8:   return ReduceAddSlow<int8_t>;
       case NPY_INT16:  return ReduceAddSlow<int16_t>;
-      case NPY_INT32: return ReduceAddI32;
+      case NPY_INT: return ReduceAddI32;
       case NPY_INT64:
       case NPY_LONGLONG:
           return ReduceAddI64;
 
       case NPY_UINT8:   return ReduceAddSlow<uint8_t>;
       case NPY_UINT16:  return ReduceAddSlow<uint16_t>;
-      case NPY_UINT32:  return ReduceAddSlow<uint32_t>;
+      case NPY_UINT:  return ReduceAddSlow<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return ReduceAddU64;
@@ -1931,14 +1931,14 @@ public:
       case NPY_BOOL: return non_vector<bool>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32: return non_vector<int32_t>;
+      case NPY_INT: return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
           return non_vector<int64_t>;
 
       case NPY_UINT8:   return non_vector<uint8_t>;
       case NPY_UINT16:  return non_vector<uint16_t>;
-      case NPY_UINT32:  return non_vector<uint32_t>;
+      case NPY_UINT:  return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -2099,14 +2099,14 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return ReduceVar<int8_t>;
       case NPY_INT16:  return ReduceVar<int16_t>;
-      case NPY_INT32: return ReduceVar<int32_t>;
+      case NPY_INT: return ReduceVar<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
           return ReduceVar<int64_t>;
 
       case NPY_UINT8:   return ReduceVar<uint8_t>;
       case NPY_UINT16:  return ReduceVar<uint16_t>;
-      case NPY_UINT32:  return ReduceVar<uint32_t>;
+      case NPY_UINT:  return ReduceVar<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return ReduceVar<uint64_t>;
@@ -2162,14 +2162,14 @@ public:
       case NPY_BOOL:   return non_vector<bool>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32: return non_vector<int32_t>;
+      case NPY_INT: return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
           return non_vector<int64_t>;
 
       case NPY_UINT8:   return non_vector<uint8_t>;
       case NPY_UINT16:  return non_vector<uint16_t>;
-      case NPY_UINT32:  return non_vector<uint32_t>;
+      case NPY_UINT:  return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;

--- a/src/Reduce.cpp
+++ b/src/Reduce.cpp
@@ -35,21 +35,21 @@ static inline void STOREU(__m256* x, __m256 y) { _mm256_storeu_ps((float*)x, y);
 static inline void STOREU(__m256i* x, __m256i y) { _mm256_storeu_si256((__m256i*)x, y); }
 #endif
 
-static inline __m256i MIN_OP(INT8  z, __m256i x, __m256i y)  { return _mm256_min_epi8(x, y); }
-static inline __m256i MIN_OP(UINT8  z, __m256i x, __m256i y) { return _mm256_min_epu8(x, y); }
-static inline __m256i MIN_OP(UINT16 z, __m256i x, __m256i y) { return _mm256_min_epu16(x, y); }
-static inline __m256i MIN_OP(INT16 z, __m256i x, __m256i y)  { return _mm256_min_epi16(x, y); }
-static inline __m256i MIN_OP(INT32 z, __m256i x, __m256i y)  { return _mm256_min_epi32(x, y); }
-static inline __m256i MIN_OP(UINT32 z, __m256i x, __m256i y) { return _mm256_min_epu32(x, y); }
+static inline __m256i MIN_OP(int8_t  z, __m256i x, __m256i y)  { return _mm256_min_epi8(x, y); }
+static inline __m256i MIN_OP(uint8_t  z, __m256i x, __m256i y) { return _mm256_min_epu8(x, y); }
+static inline __m256i MIN_OP(uint16_t z, __m256i x, __m256i y) { return _mm256_min_epu16(x, y); }
+static inline __m256i MIN_OP(int16_t z, __m256i x, __m256i y)  { return _mm256_min_epi16(x, y); }
+static inline __m256i MIN_OP(int32_t z, __m256i x, __m256i y)  { return _mm256_min_epi32(x, y); }
+static inline __m256i MIN_OP(uint32_t z, __m256i x, __m256i y) { return _mm256_min_epu32(x, y); }
 static inline __m256  MIN_OP(float z, __m256 x, __m256 y)    { return _mm256_min_ps(x, y); }
 static inline __m256d MIN_OP(double z, __m256d x, __m256d y) { return _mm256_min_pd(x, y); }
 
-static inline __m256i MAX_OP(INT8  z, __m256i x, __m256i y) { return _mm256_max_epi8(x, y); }
-static inline __m256i MAX_OP(UINT8  z, __m256i x, __m256i y) { return _mm256_max_epu8(x, y); }
-static inline __m256i MAX_OP(UINT16 z, __m256i x, __m256i y) { return _mm256_max_epu16(x, y); }
-static inline __m256i MAX_OP(INT16 z, __m256i x, __m256i y) { return _mm256_max_epi16(x, y); }
-static inline __m256i MAX_OP(INT32 z, __m256i x, __m256i y) { return _mm256_max_epi32(x, y); }
-static inline __m256i MAX_OP(UINT32 z, __m256i x, __m256i y) { return _mm256_max_epu32(x, y); }
+static inline __m256i MAX_OP(int8_t  z, __m256i x, __m256i y) { return _mm256_max_epi8(x, y); }
+static inline __m256i MAX_OP(uint8_t  z, __m256i x, __m256i y) { return _mm256_max_epu8(x, y); }
+static inline __m256i MAX_OP(uint16_t z, __m256i x, __m256i y) { return _mm256_max_epu16(x, y); }
+static inline __m256i MAX_OP(int16_t z, __m256i x, __m256i y) { return _mm256_max_epi16(x, y); }
+static inline __m256i MAX_OP(int32_t z, __m256i x, __m256i y) { return _mm256_max_epi32(x, y); }
+static inline __m256i MAX_OP(uint32_t z, __m256i x, __m256i y) { return _mm256_max_epu32(x, y); }
 static inline __m256  MAX_OP(float z, __m256 x, __m256 y) { return _mm256_max_ps(x, y); }
 static inline __m256d MAX_OP(double z, __m256d x, __m256d y) { return _mm256_max_pd(x, y); }
 
@@ -110,21 +110,21 @@ static inline __m256d FMIN_OP(double z, __m256d x, __m256d y)
 }
 
 // 128 versions---
-static inline __m128i MIN_OP128(INT8  z, __m128i x, __m128i y) { return _mm_min_epi8(x, y); }
-static inline __m128i MIN_OP128(UINT8  z, __m128i x, __m128i y) { return _mm_min_epu8(x, y); }
-static inline __m128i MIN_OP128(UINT16 z, __m128i x, __m128i y) { return _mm_min_epu16(x, y); }
-static inline __m128i MIN_OP128(INT16 z, __m128i x, __m128i y) { return _mm_min_epi16(x, y); }
-static inline __m128i MIN_OP128(INT32 z, __m128i x, __m128i y) { return _mm_min_epi32(x, y); }
-static inline __m128i MIN_OP128(UINT32 z, __m128i x, __m128i y) { return _mm_min_epu32(x, y); }
+static inline __m128i MIN_OP128(int8_t  z, __m128i x, __m128i y) { return _mm_min_epi8(x, y); }
+static inline __m128i MIN_OP128(uint8_t  z, __m128i x, __m128i y) { return _mm_min_epu8(x, y); }
+static inline __m128i MIN_OP128(uint16_t z, __m128i x, __m128i y) { return _mm_min_epu16(x, y); }
+static inline __m128i MIN_OP128(int16_t z, __m128i x, __m128i y) { return _mm_min_epi16(x, y); }
+static inline __m128i MIN_OP128(int32_t z, __m128i x, __m128i y) { return _mm_min_epi32(x, y); }
+static inline __m128i MIN_OP128(uint32_t z, __m128i x, __m128i y) { return _mm_min_epu32(x, y); }
 static inline __m128  MIN_OP128(float z, __m128 x, __m128 y) { return _mm_min_ps(x, y); }
 static inline __m128d MIN_OP128(double z, __m128d x, __m128d y) { return _mm_min_pd(x, y); }
 
-static inline __m128i MAX_OP128(INT8  z, __m128i x, __m128i y) { return _mm_max_epi8(x, y); }
-static inline __m128i MAX_OP128(UINT8  z, __m128i x, __m128i y) { return _mm_max_epu8(x, y); }
-static inline __m128i MAX_OP128(UINT16 z, __m128i x, __m128i y) { return _mm_max_epu16(x, y); }
-static inline __m128i MAX_OP128(INT16 z, __m128i x, __m128i y) { return _mm_max_epi16(x, y); }
-static inline __m128i MAX_OP128(INT32 z, __m128i x, __m128i y) { return _mm_max_epi32(x, y); }
-static inline __m128i MAX_OP128(UINT32 z, __m128i x, __m128i y) { return _mm_max_epu32(x, y); }
+static inline __m128i MAX_OP128(int8_t  z, __m128i x, __m128i y) { return _mm_max_epi8(x, y); }
+static inline __m128i MAX_OP128(uint8_t  z, __m128i x, __m128i y) { return _mm_max_epu8(x, y); }
+static inline __m128i MAX_OP128(uint16_t z, __m128i x, __m128i y) { return _mm_max_epu16(x, y); }
+static inline __m128i MAX_OP128(int16_t z, __m128i x, __m128i y) { return _mm_max_epi16(x, y); }
+static inline __m128i MAX_OP128(int32_t z, __m128i x, __m128i y) { return _mm_max_epi32(x, y); }
+static inline __m128i MAX_OP128(uint32_t z, __m128i x, __m128i y) { return _mm_max_epu32(x, y); }
 static inline __m128  MAX_OP128(float z, __m128 x, __m128 y) { return _mm_max_ps(x, y); }
 static inline __m128d MAX_OP128(double z, __m128d x, __m128d y) { return _mm_max_pd(x, y); }
 
@@ -163,19 +163,19 @@ struct stArgScatterGatherFunc {
    NPY_TYPES inputType;
 
    // the core (if any) making this calculation
-   INT32 core;
+   int32_t core;
 
    // used for nans, how many non nan values
-   INT64 lenOut;
+   int64_t lenOut;
 
    // holds worst case
    long double resultOut;
 
    // index location output for argmin/argmax
-   INT64  resultOutArgInt64;
+   int64_t  resultOutArgInt64;
 };
 
-typedef INT64(*ARG_SCATTER_GATHER_FUNC)(void* pDataIn, INT64 len, INT64 fixup, stArgScatterGatherFunc* pstScatterGatherFunc);
+typedef int64_t(*ARG_SCATTER_GATHER_FUNC)(void* pDataIn, int64_t len, int64_t fixup, stArgScatterGatherFunc* pstScatterGatherFunc);
 
 
 //============================================================================================
@@ -186,7 +186,7 @@ class ReduceArgMax final
 {
    //--------------------------------------------------------------------------------------------
    template<typename T >
-   static INT64 non_vector(void* pDataIn, INT64 len, INT64 fixup, stArgScatterGatherFunc* pstScatterGatherFunc) {
+   static int64_t non_vector(void* pDataIn, int64_t len, int64_t fixup, stArgScatterGatherFunc* pstScatterGatherFunc) {
 
       T* pIn = (T*)pDataIn;
       T* pStart = pIn;
@@ -196,7 +196,7 @@ class ReduceArgMax final
 
       // Always set first item
       T result = *pIn++;
-      INT64 resultOutArgInt64 = 0;
+      int64_t resultOutArgInt64 = 0;
 
       while (pIn < pEnd) {
          // get the minimum
@@ -258,7 +258,7 @@ class ReduceArgMin final
    //--------------------------------------------------------------------------------------------
    // The result is the index location of the minimum value
    template<typename T >
-   static INT64 non_vector(void* pDataIn, INT64 len, INT64 fixup, stArgScatterGatherFunc* pstScatterGatherFunc) {
+   static int64_t non_vector(void* pDataIn, int64_t len, int64_t fixup, stArgScatterGatherFunc* pstScatterGatherFunc) {
 
       T* pIn = (T*)pDataIn;
       T* pStart = pIn;
@@ -268,7 +268,7 @@ class ReduceArgMin final
 
       // Always set first item
       T result = *pIn++;
-      INT64 resultOutArgInt64 = 0;
+      int64_t resultOutArgInt64 = 0;
 
       while (pIn < pEnd) {
          // get the minimum
@@ -333,14 +333,14 @@ class ReduceNanargmax final
    // There are no invalids for bool type (do not call this routine)
    // nan floats require using x==x and failing to detect
    template<typename T >
-   static INT64 non_vector(void* pDataIn, INT64 len, INT64 fixup, stArgScatterGatherFunc* pstScatterGatherFunc) {
+   static int64_t non_vector(void* pDataIn, int64_t len, int64_t fixup, stArgScatterGatherFunc* pstScatterGatherFunc) {
 
       T* pIn = (T*)pDataIn;
       const T* const pStart = pIn;
       const T* const pEnd = pIn + len;
 
       // Default to nothing found
-      INT64 resultOutArgInt64 = -1;
+      int64_t resultOutArgInt64 = -1;
       T result = 0;
 
       // TODO: Seems like we should have special support for T=bool below (so that values are clamped to 0/1,
@@ -430,14 +430,14 @@ class ReduceNanargmin final
    // There are no invalids for bool type (do not call this routine)
    // nan floats require using x==x and failing to detect
    template<typename T >
-   static INT64 non_vector(void* pDataIn, INT64 len, INT64 fixup, stArgScatterGatherFunc* pstScatterGatherFunc) {
+   static int64_t non_vector(void* pDataIn, int64_t len, int64_t fixup, stArgScatterGatherFunc* pstScatterGatherFunc) {
 
       T* pIn = (T*)pDataIn;
       const T* const pStart = pIn;
       const T* const pEnd = pIn + len;
 
       // Default to nothing found
-      INT64 resultOutArgInt64 = -1;
+      int64_t resultOutArgInt64 = -1;
       T result = 0;
 
       // TODO: Seems like we should have special support for T=bool below (so that values are clamped to 0/1,
@@ -522,7 +522,7 @@ class ReduceMax final
 {
    //--------------------------------------------------------------------------------------------
    template<typename T >
-   static double non_vector(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double non_vector(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       T* pIn = (T*)pDataIn;
       const T* const pEnd = pIn + len;
 
@@ -541,7 +541,7 @@ class ReduceMax final
       // Check for previous scattering.  If we are the first one
       if (pstScatterGatherFunc->lenOut == 0) {
          pstScatterGatherFunc->resultOut = (double)result;
-         pstScatterGatherFunc->resultOutInt64 = (INT64)result;
+         pstScatterGatherFunc->resultOutInt64 = (int64_t)result;
       }
       else {
          // in case of nan when calling max (instead of nanmax), preserve nans
@@ -550,7 +550,7 @@ class ReduceMax final
          }
 
          T previous = (T)(pstScatterGatherFunc->resultOutInt64);
-         pstScatterGatherFunc->resultOutInt64 = (INT64)(MAXF(previous, result));
+         pstScatterGatherFunc->resultOutInt64 = (int64_t)(MAXF(previous, result));
       }
       pstScatterGatherFunc->lenOut += len;
       return (double)pstScatterGatherFunc->resultOutInt64;
@@ -558,7 +558,7 @@ class ReduceMax final
 
    //--------------------------------------------------------------------------------------------
    template<typename T, typename U256, typename U128 >
-   static double avx2(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double avx2(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       T* pIn = (T*)pDataIn;
       T* pEnd;
 
@@ -569,8 +569,8 @@ class ReduceMax final
       // For float64 this is 32/ 4
       // for int16 this is 128 / 16
       // for int8  this is 256 / 32
-      static constexpr INT64 chunkSize = (sizeof(U256) * 8) / sizeof(T);
-      static constexpr INT64 perReg = sizeof(U256) / sizeof(T);
+      static constexpr int64_t chunkSize = (sizeof(U256) * 8) / sizeof(T);
+      static constexpr int64_t perReg = sizeof(U256) / sizeof(T);
 
       if (len >= chunkSize) {
          pEnd = &pIn[chunkSize * (len / chunkSize)];
@@ -622,12 +622,12 @@ class ReduceMax final
       // Check for previous scattering.  If we are the first one
       if (pstScatterGatherFunc->lenOut == 0) {
          pstScatterGatherFunc->resultOut = (double)result;
-         pstScatterGatherFunc->resultOutInt64 = (INT64)result;
+         pstScatterGatherFunc->resultOutInt64 = (int64_t)result;
       }
       else {
          pstScatterGatherFunc->resultOut = MAXF(pstScatterGatherFunc->resultOut, (double)result);
          T previous = (T)(pstScatterGatherFunc->resultOutInt64);
-         pstScatterGatherFunc->resultOutInt64 = (INT64)(MAXF(previous, result));
+         pstScatterGatherFunc->resultOutInt64 = (int64_t)(MAXF(previous, result));
       }
       pstScatterGatherFunc->lenOut += len;
       return pstScatterGatherFunc->resultOut;
@@ -666,7 +666,7 @@ class ReduceMin final
 {
    //--------------------------------------------------------------------------------------------
    template<typename T >
-   static double non_vector(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double non_vector(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       T* pIn = (T*)pDataIn;
       const T* const pEnd = pIn + len;
 
@@ -685,7 +685,7 @@ class ReduceMin final
       // Check for previous scattering.  If we are the first one
       if (pstScatterGatherFunc->lenOut == 0) {
          pstScatterGatherFunc->resultOut = (double)result;
-         pstScatterGatherFunc->resultOutInt64 = (INT64)result;
+         pstScatterGatherFunc->resultOutInt64 = (int64_t)result;
       }
       else {
          // in case of nan when calling min (instead of nanmin), preserve nans
@@ -693,7 +693,7 @@ class ReduceMin final
             pstScatterGatherFunc->resultOut = MINF(pstScatterGatherFunc->resultOut, (double)result);
          }
          T previous = (T)(pstScatterGatherFunc->resultOutInt64);
-         pstScatterGatherFunc->resultOutInt64 = (INT64)(MINF(previous, result));
+         pstScatterGatherFunc->resultOutInt64 = (int64_t)(MINF(previous, result));
       }
       pstScatterGatherFunc->lenOut += len;
       return (double)pstScatterGatherFunc->resultOutInt64;
@@ -702,7 +702,7 @@ class ReduceMin final
 
    //--------------------------------------------------------------------------------------------
    template<typename T, typename U256, typename U128 >
-   static double avx2(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double avx2(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       T* pIn = (T*)pDataIn;
       T* pEnd;
 
@@ -713,8 +713,8 @@ class ReduceMin final
       // For float64 this is 32/ 4
       // for int16 this is 128 / 16
       // for int8  this is 256 / 32
-      const INT64 chunkSize = (sizeof(U256) * 8) / sizeof(T);
-      const INT64 perReg = sizeof(U256) / sizeof(T);
+      const int64_t chunkSize = (sizeof(U256) * 8) / sizeof(T);
+      const int64_t perReg = sizeof(U256) / sizeof(T);
 
       //printf("hit this %lld %lld\n", len, chunkSize);
       if (len >= chunkSize) {
@@ -795,14 +795,14 @@ class ReduceMin final
       // Check for previous scattering.  If we are the first one
       if (pstScatterGatherFunc->lenOut == 0) {
          pstScatterGatherFunc->resultOut = (double)result;
-         pstScatterGatherFunc->resultOutInt64 = (INT64)result;
+         pstScatterGatherFunc->resultOutInt64 = (int64_t)result;
          //printf("minop 0  chunk: %lld    %lf %lf %lld\n", chunkSize, pstScatterGatherFunc->resultOut, (double)result, pstScatterGatherFunc->resultOutInt64);
       }
       else {
          //printf("minop !0 %lf %lf\n", pstScatterGatherFunc->resultOut, (double)result);
          pstScatterGatherFunc->resultOut = MINF(pstScatterGatherFunc->resultOut, (double)result);
          T previous = (T)(pstScatterGatherFunc->resultOutInt64);
-         pstScatterGatherFunc->resultOutInt64 = (INT64)(MINF(previous, result));
+         pstScatterGatherFunc->resultOutInt64 = (int64_t)(MINF(previous, result));
       }
       pstScatterGatherFunc->lenOut += len;
       return pstScatterGatherFunc->resultOut;
@@ -812,7 +812,7 @@ class ReduceMin final
    //--------------------------------------------------------------------------------------------
    // This routine only support floats
    template<typename T, typename U256, typename U128 >
-   static double avx2_nan_aware(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double avx2_nan_aware(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       T* pIn = (T*)pDataIn;
       T* pEnd;
 
@@ -821,8 +821,8 @@ class ReduceMin final
 
       // For float32 this is 64 /8 since sizeof(float) = 4
       // For float64 this is 32/ 4
-      const INT64 chunkSize = (sizeof(U256) * 8) / sizeof(T);
-      const INT64 perReg = sizeof(U256) / sizeof(T);
+      const int64_t chunkSize = (sizeof(U256) * 8) / sizeof(T);
+      const int64_t perReg = sizeof(U256) / sizeof(T);
 
       //printf("hit this %lld %lld\n", len, chunkSize);
       if (len >= chunkSize) {
@@ -956,7 +956,7 @@ class ReduceMin final
       // Check for previous scattering.  If we are the first one
       if (pstScatterGatherFunc->lenOut == 0) {
          pstScatterGatherFunc->resultOut = (double)result;
-         pstScatterGatherFunc->resultOutInt64 = (INT64)result;
+         pstScatterGatherFunc->resultOutInt64 = (int64_t)result;
          //printf("minop 0  chunk: %lld    %lf %lf %lld\n", chunkSize, pstScatterGatherFunc->resultOut, (double)result, pstScatterGatherFunc->resultOutInt64);
       }
       else {
@@ -964,7 +964,7 @@ class ReduceMin final
          if (result == result) {
             pstScatterGatherFunc->resultOut = MINF(pstScatterGatherFunc->resultOut, (double)result);
             T previous = (T)(pstScatterGatherFunc->resultOutInt64);
-            pstScatterGatherFunc->resultOutInt64 = (INT64)(MINF(previous, result));
+            pstScatterGatherFunc->resultOutInt64 = (int64_t)(MINF(previous, result));
          }
          else {
             // we know this if a float
@@ -1020,7 +1020,7 @@ class ReduceNanMin final
 {
    // Simple, non-vectorized implementation of the nanmin (fmin) reduction operation.
    template<typename T >
-   static double non_vector(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double non_vector(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       T* pIn = (T*)pDataIn;
       T* const pEnd = pIn + len;
 
@@ -1061,7 +1061,7 @@ class ReduceNanMin final
          // If not, this chunk of the array was the first result so we can just store the results.
          if (pstScatterGatherFunc->lenOut == 0) {
             pstScatterGatherFunc->resultOut = (double)result;
-            pstScatterGatherFunc->resultOutInt64 = (INT64)result;
+            pstScatterGatherFunc->resultOutInt64 = (int64_t)result;
 
             // Set 'lenOut' to 1. This field nominally stores the total number of non-NaN values
             // found in the array while performing the calculation; for the purposes of this reduction,
@@ -1073,7 +1073,7 @@ class ReduceNanMin final
             pstScatterGatherFunc->resultOut = (std::min)(pstScatterGatherFunc->resultOut, (double)result);
 
             T previous = (T)(pstScatterGatherFunc->resultOutInt64);
-            pstScatterGatherFunc->resultOutInt64 = (INT64)((std::min)(previous, result));
+            pstScatterGatherFunc->resultOutInt64 = (int64_t)((std::min)(previous, result));
          }
 
          return (double)pstScatterGatherFunc->resultOutInt64;
@@ -1087,14 +1087,14 @@ class ReduceNanMin final
 
    // AVX2-based implementation of the nanmin (fmin) reduction operation.
    template<typename T >
-   static double avx2(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double avx2(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       // TEMP: Call the non-vectorized version of this operation until a vectorized version can be implemented.
       return non_vector<T>(pDataIn, len, pstScatterGatherFunc);
    }
 
    //--------------------------------------------------------------------------------------------
    template<typename T, typename U256>
-   static double avx2(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double avx2(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       T* pIn = (T*)pDataIn;
       T* pEnd;
 
@@ -1106,8 +1106,8 @@ class ReduceNanMin final
       // For float64 this is 32/ 4
       // for int16 this is 128 / 16
       // for int8  this is 256 / 32
-      static constexpr INT64 chunkSize = (sizeof(U256) * 8) / sizeof(T);
-      static constexpr INT64 perReg = sizeof(U256) / sizeof(T);
+      static constexpr int64_t chunkSize = (sizeof(U256) * 8) / sizeof(T);
+      static constexpr int64_t perReg = sizeof(U256) / sizeof(T);
 
       //printf("hit this %lld %lld\n", len, chunkSize);
       if (len >= chunkSize) {
@@ -1178,7 +1178,7 @@ class ReduceNanMin final
          // If not, this chunk of the array was the first result so we can just store the results.
          if (pstScatterGatherFunc->lenOut == 0) {
             pstScatterGatherFunc->resultOut = (double)result;
-            pstScatterGatherFunc->resultOutInt64 = (INT64)result;
+            pstScatterGatherFunc->resultOutInt64 = (int64_t)result;
 
             // Set 'lenOut' to 1. This field nominally stores the total number of non-NaN values
             // found in the array while performing the calculation; for the purposes of this reduction,
@@ -1190,7 +1190,7 @@ class ReduceNanMin final
             pstScatterGatherFunc->resultOut = (std::min)(pstScatterGatherFunc->resultOut, (double)result);
 
             T previous = (T)(pstScatterGatherFunc->resultOutInt64);
-            pstScatterGatherFunc->resultOutInt64 = (INT64)((std::min)(previous, result));
+            pstScatterGatherFunc->resultOutInt64 = (int64_t)((std::min)(previous, result));
          }
 
          return (double)pstScatterGatherFunc->resultOutInt64;
@@ -1241,7 +1241,7 @@ class ReduceNanMax final
 {
    // Simple, non-vectorized implementation of the nanmax (fmax) reduction operation.
    template<typename T >
-   static double non_vector(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double non_vector(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       T* pIn = (T*)pDataIn;
       T* const pEnd = pIn + len;
 
@@ -1282,7 +1282,7 @@ class ReduceNanMax final
          // If not, this chunk of the array was the first result so we can just store the results.
          if (pstScatterGatherFunc->lenOut == 0) {
             pstScatterGatherFunc->resultOut = (double)result;
-            pstScatterGatherFunc->resultOutInt64 = (INT64)result;
+            pstScatterGatherFunc->resultOutInt64 = (int64_t)result;
 
             // Set 'lenOut' to 1. This field nominally stores the total number of non-NaN values
             // found in the array while performing the calculation; for the purposes of this reduction,
@@ -1294,7 +1294,7 @@ class ReduceNanMax final
             pstScatterGatherFunc->resultOut = (std::max)(pstScatterGatherFunc->resultOut, (double)result);
 
             T previous = (T)(pstScatterGatherFunc->resultOutInt64);
-            pstScatterGatherFunc->resultOutInt64 = (INT64)((std::max)(previous, result));
+            pstScatterGatherFunc->resultOutInt64 = (int64_t)((std::max)(previous, result));
          }
 
          return (double)pstScatterGatherFunc->resultOutInt64;
@@ -1308,14 +1308,14 @@ class ReduceNanMax final
 
    // AVX2-based implementation of the nanmax (fmax) reduction operation.
    template<typename T >
-   static double avx2(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double avx2(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       // TEMP: Call the non-vectorized version of this operation until a vectorized version can be implemented.
       return non_vector<T>(pDataIn, len, pstScatterGatherFunc);
    }
 
    //--------------------------------------------------------------------------------------------
    template<typename T, typename U256>
-   static double avx2(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double avx2(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       T* pIn = (T*)pDataIn;
       T* pEnd;
 
@@ -1327,8 +1327,8 @@ class ReduceNanMax final
       // For float64 this is 32/ 4
       // for int16 this is 128 / 16
       // for int8  this is 256 / 32
-      static constexpr INT64 chunkSize = (sizeof(U256) * 8) / sizeof(T);
-      static constexpr INT64 perReg = sizeof(U256) / sizeof(T);
+      static constexpr int64_t chunkSize = (sizeof(U256) * 8) / sizeof(T);
+      static constexpr int64_t perReg = sizeof(U256) / sizeof(T);
 
       //printf("hit this %lld %lld\n", len, chunkSize);
       if (len >= chunkSize) {
@@ -1399,7 +1399,7 @@ class ReduceNanMax final
          // If not, this chunk of the array was the first result so we can just store the results.
          if (pstScatterGatherFunc->lenOut == 0) {
             pstScatterGatherFunc->resultOut = (double)result;
-            pstScatterGatherFunc->resultOutInt64 = (INT64)result;
+            pstScatterGatherFunc->resultOutInt64 = (int64_t)result;
 
             // Set 'lenOut' to 1. This field nominally stores the total number of non-NaN values
             // found in the array while performing the calculation; for the purposes of this reduction,
@@ -1411,7 +1411,7 @@ class ReduceNanMax final
             pstScatterGatherFunc->resultOut = (std::max)(pstScatterGatherFunc->resultOut, (double)result);
 
             T previous = (T)(pstScatterGatherFunc->resultOutInt64);
-            pstScatterGatherFunc->resultOutInt64 = (INT64)((std::max)(previous, result));
+            pstScatterGatherFunc->resultOutInt64 = (int64_t)((std::max)(previous, result));
          }
 
          return (double)pstScatterGatherFunc->resultOutInt64;
@@ -1462,13 +1462,13 @@ class ReduceSum final
 {
    //--------------------------------------------------------------------------------------------
    template<typename T >
-   static double ReduceAddSlow(void* pDataIn, INT64 length, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double ReduceAddSlow(void* pDataIn, int64_t length, stScatterGatherFunc* pstScatterGatherFunc) {
       T* pIn = (T*)pDataIn;
       T* pEnd;
       double result = 0;
 
       if (pstScatterGatherFunc->inputType == NPY_BOOL) {
-         result = (double)SumBooleanMask((INT8*)pDataIn, length);
+         result = (double)SumBooleanMask((int8_t*)pDataIn, length);
       }
       else {
 
@@ -1486,14 +1486,14 @@ class ReduceSum final
       pstScatterGatherFunc->lenOut += length;
       //printf("float adding %lf to %lf\n", pstScatterGatherFunc->resultOut, result);
       pstScatterGatherFunc->resultOut += result;
-      pstScatterGatherFunc->resultOutInt64 += (INT64)result;
+      pstScatterGatherFunc->resultOutInt64 += (int64_t)result;
       return result;
 
    }
 
 
    //=============================================================================================
-   static double ReduceAddF32(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double ReduceAddF32(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       double result = 0;
       float* pIn = (float*)pDataIn;
       float* pEnd;
@@ -1541,16 +1541,16 @@ class ReduceSum final
       pstScatterGatherFunc->lenOut += len;
       //printf("float adding %lf to %lf\n", pstScatterGatherFunc->resultOut, result);
       pstScatterGatherFunc->resultOut += result;
-      pstScatterGatherFunc->resultOutInt64 += (INT64)result;
+      pstScatterGatherFunc->resultOutInt64 += (int64_t)result;
       return result;
 
    }
 
    //--------------------------------------------------------------------------------------------
-   static double ReduceAddI32(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double ReduceAddI32(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       double result = 0;
-      INT32* pIn = (INT32*)pDataIn;
-      INT32* pEnd;
+      int32_t* pIn = (int32_t*)pDataIn;
+      int32_t* pEnd;
       if (len >= 32) {
          pEnd = &pIn[32 * (len / 32)];
 
@@ -1600,7 +1600,7 @@ class ReduceSum final
       }
       pstScatterGatherFunc->lenOut += len;
       pstScatterGatherFunc->resultOut += result;
-      pstScatterGatherFunc->resultOutInt64 += (INT64)result;
+      pstScatterGatherFunc->resultOutInt64 += (int64_t)result;
 
       return result;
 
@@ -1608,7 +1608,7 @@ class ReduceSum final
 
 
    //--------------------------------------------------------------------------------------------
-   static double ReduceAddD64(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double ReduceAddD64(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       double result = 0;
       double* pIn = (double*)pDataIn;
       double* pEnd;
@@ -1662,7 +1662,7 @@ class ReduceSum final
       //printf("double adding %lf to %lf\n", pstScatterGatherFunc->resultOut, result);
       pstScatterGatherFunc->lenOut += len;
       pstScatterGatherFunc->resultOut += result;
-      pstScatterGatherFunc->resultOutInt64 += (INT64)result;
+      pstScatterGatherFunc->resultOutInt64 += (int64_t)result;
       return result;
 
    }
@@ -1671,10 +1671,10 @@ class ReduceSum final
    //--------------------------------------------------------
    // TODO: Make this a template
    /*
-   static double ReduceAddI64(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double ReduceAddI64(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       double result = 0;
-      INT64* pIn = (INT64*)pDataIn;
-      INT64* pEnd;
+      int64_t* pIn = (int64_t*)pDataIn;
+      int64_t* pEnd;
       if (len >= 32) {
          pEnd = &pIn[32 * (len / 32)];
 
@@ -1712,7 +1712,7 @@ class ReduceSum final
 
          _mm256_store_si256(&temp, m0);
 
-         INT64* pTemp = (INT64*)&temp;
+         int64_t* pTemp = (int64_t*)&temp;
          result = (double)pTemp[0];
          result += (double)pTemp[1];
          result += (double)pTemp[2];
@@ -1726,7 +1726,7 @@ class ReduceSum final
       }
       pstScatterGatherFunc->lenOut += len;
       pstScatterGatherFunc->resultOut += result;
-      pstScatterGatherFunc->resultOutInt64 += (INT64)result;
+      pstScatterGatherFunc->resultOutInt64 += (int64_t)result;
       //printf("reduceadd 1 sum %lld\n", pstScatterGatherFunc->resultOutInt64);
       //printf("reduceadd 1 sum %lf\n", pstScatterGatherFunc->resultOut);
       return result;
@@ -1736,7 +1736,7 @@ class ReduceSum final
 
    // Always returns a double which is U
    template <typename Input, typename Output>
-   static double ReduceAdd(void* pDataIn, INT64 length, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double ReduceAdd(void* pDataIn, int64_t length, stScatterGatherFunc* pstScatterGatherFunc) {
       Output result = 0;
       Input* pIn = (Input*)pDataIn;
       Input* pEnd = &pIn[length];
@@ -1745,10 +1745,10 @@ class ReduceSum final
          result += *pIn++;
       }
 
-      //printf("reduceadd sum %lld\n", (INT64)result);
+      //printf("reduceadd sum %lld\n", (int64_t)result);
       pstScatterGatherFunc->lenOut += length;
       pstScatterGatherFunc->resultOut += result;
-      pstScatterGatherFunc->resultOutInt64 += (INT64)result;
+      pstScatterGatherFunc->resultOutInt64 += (int64_t)result;
       return result;
 
    }
@@ -1756,11 +1756,11 @@ class ReduceSum final
 
    // Always returns a double
    // Double calculation in case of overflow
-   static double ReduceAddI64(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double ReduceAddI64(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       double resultd = 0;
-      INT64 result = 0;
-      INT64* pIn = (INT64*)pDataIn;
-      INT64* pEnd = &pIn[len];
+      int64_t result = 0;
+      int64_t* pIn = (int64_t*)pDataIn;
+      int64_t* pEnd = &pIn[len];
 
       if (len >= 4) {
          __m128i m0 = _mm_loadu_si128((__m128i*)pIn);
@@ -1781,7 +1781,7 @@ class ReduceSum final
          // Add horizontally
          __m128i result128;
          _mm_storeu_si128(&result128, m0);
-         INT64* pResults = (INT64*)&result128;
+         int64_t* pResults = (int64_t*)&result128;
          // collect the 2
          result = pResults[0] + pResults[1];
 
@@ -1808,22 +1808,22 @@ class ReduceSum final
    // Always returns a double
    // Double calculation in case of overflow
    
-   static double ReduceAddU64(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double ReduceAddU64(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       double resultd = 0;
-      UINT64 result = 0;
-      UINT64* pIn = (UINT64*)pDataIn;
-      UINT64* pEnd = &pIn[len];
+      uint64_t result = 0;
+      uint64_t* pIn = (uint64_t*)pDataIn;
+      uint64_t* pEnd = &pIn[len];
 
       while (pIn < pEnd) {
          // Calculate sum for integer and float
-         result += (UINT64)*pIn;
+         result += (uint64_t)*pIn;
          resultd += *pIn;
          ++pIn;
       }
 
       pstScatterGatherFunc->lenOut += len;
       pstScatterGatherFunc->resultOut += resultd;
-      *(UINT64*)&pstScatterGatherFunc->resultOutInt64 += result;
+      *(uint64_t*)&pstScatterGatherFunc->resultOutInt64 += result;
       return resultd;
    }
 
@@ -1864,12 +1864,12 @@ class ReduceNanSum final
 
    // Non-vectorized implementation of the nanmax (fmax) reduction.
    template<typename T>
-   static double non_vector(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double non_vector(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       double result = 0;
-      INT64 count = 0;
+      int64_t count = 0;
       T* pIn = (T*)pDataIn;
 
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          if (invalid_for_type<T>::is_valid(pIn[i])) {
             result += pIn[i];
             count += 1;
@@ -1877,7 +1877,7 @@ class ReduceNanSum final
       }
       pstScatterGatherFunc->lenOut += count;
       pstScatterGatherFunc->resultOut += result;
-      pstScatterGatherFunc->resultOutInt64 += (INT64)result;
+      pstScatterGatherFunc->resultOutInt64 += (int64_t)result;
       return result;
    }
 
@@ -1919,7 +1919,7 @@ class ReduceVariance final
    //-------------------------------------------------
    // Routine does not work on Linux: to be looked at
    template <typename T>
-   static double ReduceVar_TODO(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double ReduceVar_TODO(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       double mean = pstScatterGatherFunc->meanCalculation;
       double result = 0;
 
@@ -1934,9 +1934,9 @@ class ReduceVariance final
          __m256d m2 = _mm256_setzero_pd();
          __m256d m3 = _mm256_set1_pd(mean);
 
-         INT64 len2 = len & ~3;
+         int64_t len2 = len & ~3;
 
-         for (INT64 i = 0; i < len2; i += 4) {
+         for (int64_t i = 0; i < len2; i += 4) {
             // Load 8 floats or 4 doubles
             // TODO: Use C++ 'if constexpr' here; if T = typeof(double), we can load the first vector with _mm256_loadu_pd();
             //       If T = typeof(float), load+convert the data with _mm256_cvtps_pd(_mm_loadu_pd(static_cast<double*>(&pIn[i])))
@@ -1962,39 +1962,39 @@ class ReduceVariance final
 
       }
 
-      for (INT64 i = 0; i < (len & 3); i++) {
+      for (int64_t i = 0; i < (len & 3); i++) {
          double temp = (double)pIn[i] - mean;
          result += (temp * temp);
       }
 
       pstScatterGatherFunc->lenOut += len;
       pstScatterGatherFunc->resultOut += result;
-      pstScatterGatherFunc->resultOutInt64 += (INT64)result;
+      pstScatterGatherFunc->resultOutInt64 += (int64_t)result;
       return pstScatterGatherFunc->resultOut;
    }
 
    //----------------------------------
    // Multithreaded scatter gather calculation for variance core
    template <typename T>
-   static double ReduceVar(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double ReduceVar(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
 
       double mean = (double)pstScatterGatherFunc->meanCalculation;
       double result = 0;
 
       T* pIn = (T*)pDataIn;
 
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          double temp = (double)pIn[i] - mean;
          result += (temp * temp);
       }
       pstScatterGatherFunc->lenOut += len;
       pstScatterGatherFunc->resultOut += result;
-      pstScatterGatherFunc->resultOutInt64 += (INT64)result;
+      pstScatterGatherFunc->resultOutInt64 += (int64_t)result;
       return pstScatterGatherFunc->resultOut;
    }
 
    //--------------------------------------------------------------------------------------------
-   static double ReduceVarF32(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double ReduceVarF32(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       double mean = (double)pstScatterGatherFunc->meanCalculation;
       double result = 0;
 
@@ -2083,15 +2083,15 @@ class ReduceNanVariance final
    
    // Multithread-able scatter gather calculation for NAN variance core
    template <typename T>
-   static double non_vector(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double non_vector(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
 
       double mean = (double)pstScatterGatherFunc->meanCalculation;
       double result = 0;
-      INT64 count = 0;
+      int64_t count = 0;
 
       const T* const pIn = (T*)pDataIn;
 
-      for (INT64 i = 0; i < len; i++) {
+      for (int64_t i = 0; i < len; i++) {
          if (invalid_for_type<T>::is_valid(pIn[i])) {
             double temp = (double)pIn[i] - mean;
             result += (temp * temp);
@@ -2101,7 +2101,7 @@ class ReduceNanVariance final
 
       pstScatterGatherFunc->lenOut += count;
       pstScatterGatherFunc->resultOut += result;
-      pstScatterGatherFunc->resultOutInt64 += (INT64)result;
+      pstScatterGatherFunc->resultOutInt64 += (int64_t)result;
       return pstScatterGatherFunc->resultOut;
    }
 
@@ -2140,7 +2140,7 @@ public:
 class ReduceMean final
 {
    // Call SUM and then divide
-   static double wrapper(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double wrapper(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
 
       ReduceSum::GetScatterGatherFuncPtr((NPY_TYPES)pstScatterGatherFunc->inputType)(pDataIn, len, pstScatterGatherFunc);
       //printf("reduce mean dividing %lf by %lf\n", pstScatterGatherFunc->resultOut, (double)pstScatterGatherFunc->lenOut);
@@ -2170,7 +2170,7 @@ public:
  */
 class ReduceNanMean final
 {
-   static double wrapper(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double wrapper(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       ReduceNanSum::GetScatterGatherFuncPtr((NPY_TYPES)pstScatterGatherFunc->inputType)(pDataIn, len, pstScatterGatherFunc);
       //printf("Dviding %lf by %lf\n", pstScatterGatherFunc->resultOut, (double)pstScatterGatherFunc->lenOut);
       if (pstScatterGatherFunc->lenOut > 1) {
@@ -2199,7 +2199,7 @@ public:
  */
 class ReduceStdDev final
 {
-   static double wrapper(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double wrapper(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       const double variance = ReduceVariance::GetScatterGatherFuncPtr((NPY_TYPES)pstScatterGatherFunc->inputType)(pDataIn, len, pstScatterGatherFunc);
       return sqrt(variance);
    }
@@ -2220,7 +2220,7 @@ public:
  */
 class ReduceNanStdDev final
 {
-   static double wrapper(void* pDataIn, INT64 len, stScatterGatherFunc* pstScatterGatherFunc) {
+   static double wrapper(void* pDataIn, int64_t len, stScatterGatherFunc* pstScatterGatherFunc) {
       const double variance = ReduceNanVariance::GetScatterGatherFuncPtr((NPY_TYPES)pstScatterGatherFunc->inputType)(pDataIn, len, pstScatterGatherFunc);
       return sqrt(variance);
    }
@@ -2311,7 +2311,7 @@ static ANY_SCATTER_GATHER_FUNC  GetReduceFuncPtr(const NPY_TYPES inputType, cons
 // Arg3: ddof (delta degrees of freedom)
 // Returns: None on failure, else float
 //
-static PyObject* ReduceInternal(PyArrayObject* inArr1, REDUCE_FUNCTIONS func, const INT64 ddof = 1) {
+static PyObject* ReduceInternal(PyArrayObject* inArr1, REDUCE_FUNCTIONS func, const int64_t ddof = 1) {
 
    const NPY_TYPES numpyInType = (NPY_TYPES)ObjectToDtype(inArr1);
 
@@ -2327,7 +2327,7 @@ static PyObject* ReduceInternal(PyArrayObject* inArr1, REDUCE_FUNCTIONS func, co
    void* pDataIn = PyArray_BYTES(inArr1);
    int         ndim = PyArray_NDIM(inArr1);
    npy_intp* dims = PyArray_DIMS(inArr1);
-   INT64       len = CalcArrayLength(ndim, dims);
+   int64_t       len = CalcArrayLength(ndim, dims);
 
    if (len == 0) {
       // punt to numpy, often raises a ValueError
@@ -2362,7 +2362,7 @@ static PyObject* ReduceInternal(PyArrayObject* inArr1, REDUCE_FUNCTIONS func, co
    }
 
 
-   stScatterGatherFunc sgFunc = { (INT32)numpyInType, 0, 0, 0, 0, 0 };
+   stScatterGatherFunc sgFunc = { (int32_t)numpyInType, 0, 0, 0, 0, 0 };
 
    FUNCTION_LIST fl{};
    fl.AnyScatterGatherCall = pFunction;
@@ -2384,7 +2384,7 @@ static PyObject* ReduceInternal(PyArrayObject* inArr1, REDUCE_FUNCTIONS func, co
 
       if (sgFunc.lenOut > 0) {
          sgFunc.resultOut = sgFunc.resultOut / (double)sgFunc.lenOut;
-         sgFunc.resultOutInt64 = (INT64)sgFunc.resultOut;
+         sgFunc.resultOutInt64 = (int64_t)sgFunc.resultOut;
       }
       else {
          sgFunc.resultOut = 0;
@@ -2453,7 +2453,7 @@ static PyObject* ReduceInternal(PyArrayObject* inArr1, REDUCE_FUNCTIONS func, co
 
       switch (numpyInType) {
       CASE_NPY_UINT64:
-         LOGGING("Returning %llu  vs  %lf for func %lld\n", (UINT64)sgFunc.resultOutInt64, sgFunc.resultOut, func);
+         LOGGING("Returning %llu  vs  %lf for func %lld\n", (uint64_t)sgFunc.resultOutInt64, sgFunc.resultOut, func);
          return PyLong_FromUnsignedLongLong(sgFunc.resultOutInt64);
 
       case NPY_FLOAT:
@@ -2497,8 +2497,8 @@ PyObject*
 Reduce(PyObject* self, PyObject* args)
 {
    PyArrayObject* inArr1 = NULL;
-   INT64 tupleSize = Py_SIZE(args);
-   INT64 ddof = 1;
+   int64_t tupleSize = Py_SIZE(args);
+   int64_t ddof = 1;
 
    if (tupleSize == 3) {
       PyObject* ddofItem = (PyObject*)PyTuple_GET_ITEM(args, 2);
@@ -2522,7 +2522,7 @@ Reduce(PyObject* self, PyObject* args)
       if (PyArray_STRIDE(inArr1, 0) == PyArray_ITEMSIZE(inArr1)) {
          PyObject* object2 = PyTuple_GET_ITEM(args, 1);
          if (PyLong_Check(object2)) {
-            INT64 func = PyLong_AsLongLong(object2);
+            int64_t func = PyLong_AsLongLong(object2);
 
             // possible TODO: wrap result back into np scalar type             
             return ReduceInternal(inArr1, (REDUCE_FUNCTIONS)func, ddof);

--- a/src/Reduce.cpp
+++ b/src/Reduce.cpp
@@ -236,13 +236,13 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT:  return non_vector<int32_t>;
+      case NPY_INT32:  return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT: return non_vector<uint32_t>;
+      case NPY_UINT32: return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -312,13 +312,13 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT:  return non_vector<int32_t>;
+      case NPY_INT32:  return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT: return non_vector<uint32_t>;
+      case NPY_UINT32: return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -413,13 +413,13 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT:  return non_vector<int32_t>;
+      case NPY_INT32:  return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT: return non_vector<uint32_t>;
+      case NPY_UINT32: return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -513,13 +513,13 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT:  return non_vector<int32_t>;
+      case NPY_INT32:  return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT: return non_vector<uint32_t>;
+      case NPY_UINT32: return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -661,13 +661,13 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return avx2<int8_t, __m256i, __m128i>;
       case NPY_INT16:  return avx2<int16_t, __m256i, __m128i>;
-      case NPY_INT:  return avx2<int32_t, __m256i, __m128i>;
+      case NPY_INT32:  return avx2<int32_t, __m256i, __m128i>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT: return avx2<uint32_t, __m256i, __m128i>;
+      case NPY_UINT32: return avx2<uint32_t, __m256i, __m128i>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -1019,13 +1019,13 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return avx2<int8_t, __m256i, __m128i>;
       case NPY_INT16:  return avx2<int16_t, __m256i, __m128i>;
-      case NPY_INT:  return avx2<int32_t, __m256i, __m128i>;
+      case NPY_INT32:  return avx2<int32_t, __m256i, __m128i>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT: return avx2<uint32_t, __m256i, __m128i>;
+      case NPY_UINT32: return avx2<uint32_t, __m256i, __m128i>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -1239,13 +1239,13 @@ public:
       case NPY_LONGDOUBLE: return non_vector<long double>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT:  return non_vector<int32_t>;
+      case NPY_INT32:  return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT: return non_vector<uint32_t>;
+      case NPY_UINT32: return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -1464,13 +1464,13 @@ public:
       case NPY_LONGDOUBLE: return non_vector<long double>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT:  return non_vector<int32_t>;
+      case NPY_INT32:  return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT: return non_vector<uint32_t>;
+      case NPY_UINT32: return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -1872,14 +1872,14 @@ public:
       case NPY_BOOL: // TODO: Call/return our fast SumBooleanMask() implementation.
       case NPY_INT8:   return ReduceAddSlow<int8_t>;
       case NPY_INT16:  return ReduceAddSlow<int16_t>;
-      case NPY_INT: return ReduceAddI32;
+      case NPY_INT32: return ReduceAddI32;
       case NPY_INT64:
       case NPY_LONGLONG:
           return ReduceAddI64;
 
       case NPY_UINT8:   return ReduceAddSlow<uint8_t>;
       case NPY_UINT16:  return ReduceAddSlow<uint16_t>;
-      case NPY_UINT:  return ReduceAddSlow<uint32_t>;
+      case NPY_UINT32:  return ReduceAddSlow<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return ReduceAddU64;
@@ -1931,14 +1931,14 @@ public:
       case NPY_BOOL: return non_vector<bool>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT: return non_vector<int32_t>;
+      case NPY_INT32: return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
           return non_vector<int64_t>;
 
       case NPY_UINT8:   return non_vector<uint8_t>;
       case NPY_UINT16:  return non_vector<uint16_t>;
-      case NPY_UINT:  return non_vector<uint32_t>;
+      case NPY_UINT32:  return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;
@@ -2099,14 +2099,14 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return ReduceVar<int8_t>;
       case NPY_INT16:  return ReduceVar<int16_t>;
-      case NPY_INT: return ReduceVar<int32_t>;
+      case NPY_INT32: return ReduceVar<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
           return ReduceVar<int64_t>;
 
       case NPY_UINT8:   return ReduceVar<uint8_t>;
       case NPY_UINT16:  return ReduceVar<uint16_t>;
-      case NPY_UINT:  return ReduceVar<uint32_t>;
+      case NPY_UINT32:  return ReduceVar<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return ReduceVar<uint64_t>;
@@ -2162,14 +2162,14 @@ public:
       case NPY_BOOL:   return non_vector<bool>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT: return non_vector<int32_t>;
+      case NPY_INT32: return non_vector<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
           return non_vector<int64_t>;
 
       case NPY_UINT8:   return non_vector<uint8_t>;
       case NPY_UINT16:  return non_vector<uint16_t>;
-      case NPY_UINT:  return non_vector<uint32_t>;
+      case NPY_UINT32:  return non_vector<uint32_t>;
       case NPY_UINT64:
       case NPY_ULONGLONG:
           return non_vector<uint64_t>;

--- a/src/Reduce.cpp
+++ b/src/Reduce.cpp
@@ -236,15 +236,15 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32:  return non_vector<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return non_vector<int32_t>;
+      CASE_NPY_INT64:
+      
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return non_vector<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return non_vector<uint32_t>;
+      CASE_NPY_UINT64:
+      
           return non_vector<uint64_t>;
       default:
          return nullptr;
@@ -312,15 +312,15 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32:  return non_vector<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return non_vector<int32_t>;
+      CASE_NPY_INT64:
+      
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return non_vector<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return non_vector<uint32_t>;
+      CASE_NPY_UINT64:
+      
           return non_vector<uint64_t>;
       default:
          return nullptr;
@@ -413,15 +413,15 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32:  return non_vector<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return non_vector<int32_t>;
+      CASE_NPY_INT64:
+      
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return non_vector<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return non_vector<uint32_t>;
+      CASE_NPY_UINT64:
+      
           return non_vector<uint64_t>;
       default:
          return nullptr;
@@ -513,15 +513,15 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32:  return non_vector<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return non_vector<int32_t>;
+      CASE_NPY_INT64:
+      
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return non_vector<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return non_vector<uint32_t>;
+      CASE_NPY_UINT64:
+      
           return non_vector<uint64_t>;
       default:
          return nullptr;
@@ -661,15 +661,15 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return avx2<int8_t, __m256i, __m128i>;
       case NPY_INT16:  return avx2<int16_t, __m256i, __m128i>;
-      case NPY_INT32:  return avx2<int32_t, __m256i, __m128i>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return avx2<int32_t, __m256i, __m128i>;
+      CASE_NPY_INT64:
+      
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return avx2<uint32_t, __m256i, __m128i>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return avx2<uint32_t, __m256i, __m128i>;
+      CASE_NPY_UINT64:
+      
           return non_vector<uint64_t>;
       default:
          return nullptr;
@@ -1019,15 +1019,15 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return avx2<int8_t, __m256i, __m128i>;
       case NPY_INT16:  return avx2<int16_t, __m256i, __m128i>;
-      case NPY_INT32:  return avx2<int32_t, __m256i, __m128i>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return avx2<int32_t, __m256i, __m128i>;
+      CASE_NPY_INT64:
+      
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return avx2<uint32_t, __m256i, __m128i>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return avx2<uint32_t, __m256i, __m128i>;
+      CASE_NPY_UINT64:
+      
           return non_vector<uint64_t>;
       default:
          return nullptr;
@@ -1239,15 +1239,15 @@ public:
       case NPY_LONGDOUBLE: return non_vector<long double>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32:  return non_vector<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return non_vector<int32_t>;
+      CASE_NPY_INT64:
+      
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return non_vector<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return non_vector<uint32_t>;
+      CASE_NPY_UINT64:
+      
           return non_vector<uint64_t>;
 
       // bools are currently handled specially; we don't consider bool to have a nan/invalid value
@@ -1464,15 +1464,15 @@ public:
       case NPY_LONGDOUBLE: return non_vector<long double>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32:  return non_vector<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return non_vector<int32_t>;
+      CASE_NPY_INT64:
+      
            return non_vector<int64_t>;
       case NPY_UINT8:  return non_vector<uint8_t>;
       case NPY_UINT16: return non_vector<uint16_t>;
-      case NPY_UINT32: return non_vector<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32: return non_vector<uint32_t>;
+      CASE_NPY_UINT64:
+      
           return non_vector<uint64_t>;
 
       // bools are currently handled specially; we don't consider bool to have a nan/invalid value
@@ -1872,16 +1872,16 @@ public:
       case NPY_BOOL: // TODO: Call/return our fast SumBooleanMask() implementation.
       case NPY_INT8:   return ReduceAddSlow<int8_t>;
       case NPY_INT16:  return ReduceAddSlow<int16_t>;
-      case NPY_INT32: return ReduceAddI32;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32: return ReduceAddI32;
+      CASE_NPY_INT64:
+      
           return ReduceAddI64;
 
       case NPY_UINT8:   return ReduceAddSlow<uint8_t>;
       case NPY_UINT16:  return ReduceAddSlow<uint16_t>;
-      case NPY_UINT32:  return ReduceAddSlow<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32:  return ReduceAddSlow<uint32_t>;
+      CASE_NPY_UINT64:
+      
           return ReduceAddU64;
 
       default:
@@ -1931,16 +1931,16 @@ public:
       case NPY_BOOL: return non_vector<bool>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32: return non_vector<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32: return non_vector<int32_t>;
+      CASE_NPY_INT64:
+      
           return non_vector<int64_t>;
 
       case NPY_UINT8:   return non_vector<uint8_t>;
       case NPY_UINT16:  return non_vector<uint16_t>;
-      case NPY_UINT32:  return non_vector<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32:  return non_vector<uint32_t>;
+      CASE_NPY_UINT64:
+      
           return non_vector<uint64_t>;
 
       default:
@@ -2099,16 +2099,16 @@ public:
       case NPY_BOOL:
       case NPY_INT8:   return ReduceVar<int8_t>;
       case NPY_INT16:  return ReduceVar<int16_t>;
-      case NPY_INT32: return ReduceVar<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32: return ReduceVar<int32_t>;
+      CASE_NPY_INT64:
+      
           return ReduceVar<int64_t>;
 
       case NPY_UINT8:   return ReduceVar<uint8_t>;
       case NPY_UINT16:  return ReduceVar<uint16_t>;
-      case NPY_UINT32:  return ReduceVar<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32:  return ReduceVar<uint32_t>;
+      CASE_NPY_UINT64:
+      
           return ReduceVar<uint64_t>;
 
       default:
@@ -2162,16 +2162,16 @@ public:
       case NPY_BOOL:   return non_vector<bool>;
       case NPY_INT8:   return non_vector<int8_t>;
       case NPY_INT16:  return non_vector<int16_t>;
-      case NPY_INT32: return non_vector<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32: return non_vector<int32_t>;
+      CASE_NPY_INT64:
+      
           return non_vector<int64_t>;
 
       case NPY_UINT8:   return non_vector<uint8_t>;
       case NPY_UINT16:  return non_vector<uint16_t>;
-      case NPY_UINT32:  return non_vector<uint32_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT32:  return non_vector<uint32_t>;
+      CASE_NPY_UINT64:
+      
           return non_vector<uint64_t>;
 
       default:
@@ -2483,15 +2483,15 @@ static PyObject* ReduceInternal(PyArrayObject* inArr1, REDUCE_FUNCTIONS func, co
       if (func == REDUCE_FUNCTIONS::REDUCE_SUM || func == REDUCE_FUNCTIONS::REDUCE_NANSUM) {
          // Check for overflow
          switch (numpyInType) {
-         case NPY_UINT64:
-         case NPY_ULONGLONG:
+         CASE_NPY_UINT64:
+         
             if (sgFunc.resultOut > 18446744073709551615.0) {
                LOGGING("Returning overflow %lf  for func %lld\n", sgFunc.resultOut, func);
                return PyFloat_FromDouble(sgFunc.resultOut);
             }
             break;
-         case NPY_INT64:
-         case NPY_LONGLONG:
+         CASE_NPY_INT64:
+         
             if (sgFunc.resultOut > 9223372036854775807.0 || sgFunc.resultOut < -9223372036854775808.0) {
                LOGGING("Returning overflow %lf  for func %lld\n", sgFunc.resultOut, func);
                return PyFloat_FromDouble(sgFunc.resultOut);
@@ -2502,8 +2502,8 @@ static PyObject* ReduceInternal(PyArrayObject* inArr1, REDUCE_FUNCTIONS func, co
       }
 
       switch (numpyInType) {
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT64:
+      
          LOGGING("Returning %llu  vs  %lf for func %lld\n", (uint64_t)sgFunc.resultOutInt64, sgFunc.resultOut, func);
          return PyLong_FromUnsignedLongLong(sgFunc.resultOutInt64);
 

--- a/src/Reduce.h
+++ b/src/Reduce.h
@@ -3,4 +3,4 @@
 PyObject *
 Reduce(PyObject *self, PyObject *args);
 
-PyObject*  ReduceInternal(PyArrayObject *inArr1, INT64 func);
+PyObject*  ReduceInternal(PyArrayObject *inArr1, int64_t func);

--- a/src/RipTide.cpp
+++ b/src/RipTide.cpp
@@ -192,7 +192,7 @@ INT32 TypeToDtype(PyTypeObject *out_dtype) {
    }
 
    PyErr_SetString(PyExc_ValueError,
-      "DType conversion failed");
+                   "DType conversion failed");
 
    return -1;
 }
@@ -356,7 +356,7 @@ extern "C" {
       // Attempt to recycle, if succeeds, the refnct will be incremented so we can hold on
       if (!RecycleNumpyInternal((PyArrayObject*)object)) {
          PyArrayObject* pArray = (PyArrayObject*)object;
-		 LOG_ALLOC("freeing %p %s  len:%lld\n", object, object->ob_type->tp_name, ArrayLength(pArray));
+         LOG_ALLOC("freeing %p %s  len:%lld\n", object, object->ob_type->tp_name, ArrayLength(pArray));
          g_FastArrayInstanceDeallocate(object);
       } // else we are keeping it around
    }
@@ -476,48 +476,48 @@ PyFunctionObject* GetFunctionObject(PyObject* arg1) {
 //-----------------------------------------------------------------------------------
 // This routine is not finished
 void* GetFunctionName(PyObject *arg1) {
-   PyFunctionObject* function = NULL;
-   const char* functionName = NULL;
-   if (PyCFunction_Check(arg1)) {
-      PyCFunctionObject* f = (PyCFunctionObject*)arg1;
-      functionName = f->m_ml->ml_name;
-      //printf("CFunction %s\n", f->m_ml->ml_name);
-   }
+PyFunctionObject* function = NULL;
+const char* functionName = NULL;
+if (PyCFunction_Check(arg1)) {
+PyCFunctionObject* f = (PyCFunctionObject*)arg1;
+functionName = f->m_ml->ml_name;
+//printf("CFunction %s\n", f->m_ml->ml_name);
+}
 
-   function = GetFunctionObject(arg1);
+function = GetFunctionObject(arg1);
 
-   if (!function) {
+if (!function) {
 
-      // Supply a temp name here
-      functionName = "Test";
+// Supply a temp name here
+functionName = "Test";
 
-      // TODO: If this is a ufunc, the __call__ wil exist
-      // Also, can get the function name (a PyUnicodeString pbject)
-      //functionName = PyObject_GetAttrString(arg1, "__name__")
+// TODO: If this is a ufunc, the __call__ wil exist
+// Also, can get the function name (a PyUnicodeString pbject)
+//functionName = PyObject_GetAttrString(arg1, "__name__")
 
-      //// Check for __call__ from ufunc
-      //PyObject* callfunc = PyObject_GetAttrString(arg1, "__call__");
+//// Check for __call__ from ufunc
+//PyObject* callfunc = PyObject_GetAttrString(arg1, "__call__");
 
-      //LOGGING("call is at %p\n", callfunc);
+//LOGGING("call is at %p\n", callfunc);
 
-      //if (!callfunc || !PyCallable_Check(callfunc)) {
-      //   PyTypeObject* type = (PyTypeObject*)PyObject_Type(arg1);
+//if (!callfunc || !PyCallable_Check(callfunc)) {
+//   PyTypeObject* type = (PyTypeObject*)PyObject_Type(arg1);
 
-      //   PyErr_Format(PyExc_ValueError, "Argument must be a function or a method not %s.  Call was found at %p\n", type->tp_name, callfunc);
-      //   return NULL;
-      //}
+//   PyErr_Format(PyExc_ValueError, "Argument must be a function or a method not %s.  Call was found at %p\n", type->tp_name, callfunc);
+//   return NULL;
+//}
 
-      //function = GetFunctionObject(callfunc);
-      //arg1 = callfunc;
+//function = GetFunctionObject(callfunc);
+//arg1 = callfunc;
 
-      //// Dont need to hold onto ref count
-      //Py_DecRef(callfunc);
-   }
+//// Dont need to hold onto ref count
+//Py_DecRef(callfunc);
+}
 
-   if (function) {
-      // copy this immediately?
-      functionName = DumpPyObject(function->func_qualname);
-   }
+if (function) {
+// copy this immediately?
+functionName = DumpPyObject(function->func_qualname);
+}
 }
 */
 
@@ -625,13 +625,13 @@ PyArrayObject* AllocateNumpyArray(int ndim, npy_intp* dims, INT32 numpyType, INT
    if (commonArray) {
       // NOTE: We now directly allocate a FastArray
       returnObject = (PyArrayObject*)PyArray_New(allocType, ndim, dims, numpyType, NULL, nullptr, 0,
-         array_flags, nullptr);
+                                                 array_flags, nullptr);
 
       if (!returnObject) {
          // GCNOW (attempt to free memory) and try again
          GarbageCollect(0, false);
          returnObject = (PyArrayObject*)PyArray_New(allocType, ndim, dims, numpyType, NULL, nullptr, 0,
-            array_flags, nullptr);
+                                                    array_flags, nullptr);
       }
    }
    else {
@@ -842,10 +842,10 @@ PyObject* Empty(PyObject *self, PyObject *args) {
    PyObject*   isFortran;
 
    if (!PyArg_ParseTuple(args, "O!iLO!",
-         &PyList_Type, &inDimensions,
-         &dtype,
-         &itemsize,
-         &PyBool_Type, &isFortran)) return NULL;
+                         &PyList_Type, &inDimensions,
+                         &dtype,
+                         &itemsize,
+                         &PyBool_Type, &isFortran)) return NULL;
 
    const bool is_fortran = isFortran == Py_True;
 
@@ -856,9 +856,9 @@ PyObject* Empty(PyObject *self, PyObject *args) {
    }
 
 #if NPY_SIZEOF_PY_INTPTR_T == NPY_SIZEOF_LONG
-   #define PyLong_AsNPY_INTPAndOverflow PyLong_AsLongAndOverflow
+#define PyLong_AsNPY_INTPAndOverflow PyLong_AsLongAndOverflow
 #elif defined(PY_LONG_LONG) && (NPY_SIZEOF_PY_INTPTR_T == NPY_SIZEOF_LONGLONG)
-   #define PyLong_AsNPY_INTPAndOverflow PyLong_AsLongLongAndOverflow
+#define PyLong_AsNPY_INTPAndOverflow PyLong_AsLongLongAndOverflow
 #else
 #error Unable to determine how to parse PyLong to npy_intp with overflow-checking.
 #endif
@@ -888,12 +888,12 @@ INT32 GetArrDType(PyArrayObject* inArr) {
    }
 
 #else
-if (dtype == NPY_LONGLONG) {
-   dtype = NPY_INT64;
-}
-if (dtype == NPY_ULONGLONG) {
-   dtype = NPY_UINT64;
-}
+   if (dtype == NPY_LONGLONG) {
+      dtype = NPY_INT64;
+   }
+   if (dtype == NPY_ULONGLONG) {
+      dtype = NPY_UINT64;
+   }
 #endif
 
    return dtype;
@@ -932,52 +932,52 @@ BOOL ConvertSingleItemArray(void* pInput, INT16 numpyInType, _m256all* pDest, IN
 
    switch (numpyInType) {
 
-      case NPY_BOOL:
-         value = (INT64)*(BOOL*)pInput;
-         fvalue =(double) value;
-         break;
-      case NPY_INT8:
-         value = (INT64)*(INT8*)pInput;
-         fvalue = (double)value;
-         break;
-      case NPY_UINT8:
-         value = (INT64)*(UINT8*)pInput;
-         fvalue = (double)value;
-         break;
-      case NPY_INT16:
-         value = (INT64)*(INT16*)pInput;
-         fvalue = (double)value;
-         break;
-      case NPY_UINT16:
-         value = (INT64)*(UINT16*)pInput;
-         fvalue = (double)value;
-         break;
-      CASE_NPY_UINT32:
-         value = (INT64)*(UINT32*)pInput;
-         fvalue = (double)value;
-         break;
-      CASE_NPY_INT32:
-         value = (INT64)*(INT32*)pInput;
-         fvalue = (double)value;
-         break;
-      CASE_NPY_UINT64:
-         value = (INT64)*(UINT64*)pInput;
-         fvalue = (double)value;
-         break;
-      CASE_NPY_INT64:
-         value = (INT64)*(INT64*)pInput;
-         fvalue = (double)value;
-         break;
-      case NPY_FLOAT32:
-         fvalue = (double)*(float*)pInput;
-         value = (INT64)fvalue;
-         break;
-      case NPY_FLOAT64:
-         fvalue = (double)*(double*)pInput;
-         value = (INT64)fvalue;
-         break;
-      default:
-         return FALSE;
+   case NPY_BOOL:
+      value = (INT64)*(BOOL*)pInput;
+      fvalue =(double) value;
+      break;
+   case NPY_INT8:
+      value = (INT64)*(INT8*)pInput;
+      fvalue = (double)value;
+      break;
+   case NPY_UINT8:
+      value = (INT64)*(UINT8*)pInput;
+      fvalue = (double)value;
+      break;
+   case NPY_INT16:
+      value = (INT64)*(INT16*)pInput;
+      fvalue = (double)value;
+      break;
+   case NPY_UINT16:
+      value = (INT64)*(UINT16*)pInput;
+      fvalue = (double)value;
+      break;
+   CASE_NPY_UINT32:
+      value = (INT64)*(UINT32*)pInput;
+      fvalue = (double)value;
+      break;
+   CASE_NPY_INT32:
+      value = (INT64)*(INT32*)pInput;
+      fvalue = (double)value;
+      break;
+   CASE_NPY_UINT64:
+      value = (INT64)*(UINT64*)pInput;
+      fvalue = (double)value;
+      break;
+   CASE_NPY_INT64:
+      value = (INT64)*(INT64*)pInput;
+      fvalue = (double)value;
+      break;
+   case NPY_FLOAT32:
+      fvalue = (double)*(float*)pInput;
+      value = (INT64)fvalue;
+      break;
+   case NPY_FLOAT64:
+      fvalue = (double)*(double*)pInput;
+      value = (INT64)fvalue;
+      break;
+   default:
+      return FALSE;
 
    }
 
@@ -1082,173 +1082,174 @@ BOOL ConvertScalarObject(PyObject* inObject1, _m256all* pDest, INT16 numpyOutTyp
          return FALSE;
       }
    }
- else
-    if (PyLong_Check(inObject1) || isNumpyScalarInteger) {
+   else
+   {
+      if (PyLong_Check(inObject1) || isNumpyScalarInteger) {
 
-       int overflow = 0;
-       INT64 value;
-       UINT64 value2;
+         int overflow = 0;
+         INT64 value;
+         UINT64 value2;
 
-       if (!isNumpyScalarInteger) {
-          value = PyLong_AsLongLongAndOverflow(inObject1, &overflow);
+         if (!isNumpyScalarInteger) {
+            value = PyLong_AsLongLongAndOverflow(inObject1, &overflow);
 
-          // overflow of 1 indicates past LONG_MAX
-          // overflow of -1 indicate past LONG_MIN which we do not handle
-          // PyLong_AsLongLong will RAISE an overflow exception
+            // overflow of 1 indicates past LONG_MAX
+            // overflow of -1 indicate past LONG_MIN which we do not handle
+            // PyLong_AsLongLong will RAISE an overflow exception
 
-          // If the value is negative, conversion to unsigned not allowed
-          if (value >= 0 || overflow == 1) {
-             value2 = PyLong_AsUnsignedLongLongMask(inObject1);
-          }
-          else {
-             value2 = (UINT64)value;
-          }
-       }
-       else {
-          PyArray_Descr* dtype = PyArray_DescrFromScalar(inObject1);
-          //// NOTE: memory leak here?
-          if (dtype->type_num <= NPY_LONGDOUBLE) {
-             if (g_pDescrLongLong == NULL) {
-                g_pDescrLongLong = PyArray_DescrNewFromType(NPY_LONGLONG);
-                g_pDescrULongLong = PyArray_DescrNewFromType(NPY_ULONGLONG);
-             }
+            // If the value is negative, conversion to unsigned not allowed
+            if (value >= 0 || overflow == 1) {
+               value2 = PyLong_AsUnsignedLongLongMask(inObject1);
+            }
+            else {
+               value2 = (UINT64)value;
+            }
+         }
+         else {
+            PyArray_Descr* dtype = PyArray_DescrFromScalar(inObject1);
+            //// NOTE: memory leak here?
+            if (dtype->type_num <= NPY_LONGDOUBLE) {
+               if (g_pDescrLongLong == NULL) {
+                  g_pDescrLongLong = PyArray_DescrNewFromType(NPY_LONGLONG);
+                  g_pDescrULongLong = PyArray_DescrNewFromType(NPY_ULONGLONG);
+               }
 
-             PyArray_CastScalarToCtype(inObject1, &value, g_pDescrLongLong);
-             PyArray_CastScalarToCtype(inObject1, &value2, g_pDescrULongLong);
-          }
-          else {
-             // datetime64 falls into here
-             LOGGING("!!punting on scalar type is %d\n", dtype->type_num);
-             return FALSE;
-          }
-       }
+               PyArray_CastScalarToCtype(inObject1, &value, g_pDescrLongLong);
+               PyArray_CastScalarToCtype(inObject1, &value2, g_pDescrULongLong);
+            }
+            else {
+               // datetime64 falls into here
+               LOGGING("!!punting on scalar type is %d\n", dtype->type_num);
+               return FALSE;
+            }
+         }
 
-       switch (numpyOutType) {
-       case NPY_BOOL:
-       case NPY_INT8:
-          pDest->i = _mm256_set1_epi8((INT8)value);
-          break;
-       case NPY_UINT8:
-          pDest->i = _mm256_set1_epi8((UINT8)value2);
-          break;
-       case NPY_INT16:
-          pDest->i = _mm256_set1_epi16((INT16)value);
-          break;
-       case NPY_UINT16:
-          pDest->i = _mm256_set1_epi16((UINT16)value2);
-          break;
-       CASE_NPY_INT32:
-          pDest->i = _mm256_set1_epi32((INT32)value);
-          break;
-       CASE_NPY_UINT32:
-          pDest->i = _mm256_set1_epi32((UINT32)value2);
-          break;
-       CASE_NPY_INT64:
-          pDest->ci.i1 = _mm_set1_epi64x(value);
-          pDest->ci.i2 = _mm_set1_epi64x(value);
-          break;
-       CASE_NPY_UINT64:
-          pDest->ci.i1 = _mm_set1_epi64x(value2);
-          pDest->ci.i2 = _mm_set1_epi64x(value2);
-          break;
-       case NPY_FLOAT32:
-          pDest->s = _mm256_set1_ps((float)value);
-          break;
-       case NPY_FLOAT64:
-          pDest->d = _mm256_set1_pd((double)value);
-          break;
-       default:
-          printf("unknown long scalar type in convertScalarObject %d\n", numpyOutType);
-          return FALSE;
-       }
-    }
-    else if (PyFloat_Check(inObject1) || PyArray_IsScalar((inObject1), Floating)) {
+         switch (numpyOutType) {
+         case NPY_BOOL:
+         case NPY_INT8:
+            pDest->i = _mm256_set1_epi8((INT8)value);
+            break;
+         case NPY_UINT8:
+            pDest->i = _mm256_set1_epi8((UINT8)value2);
+            break;
+         case NPY_INT16:
+            pDest->i = _mm256_set1_epi16((INT16)value);
+            break;
+         case NPY_UINT16:
+            pDest->i = _mm256_set1_epi16((UINT16)value2);
+            break;
+         CASE_NPY_INT32:
+            pDest->i = _mm256_set1_epi32((INT32)value);
+            break;
+         CASE_NPY_UINT32:
+            pDest->i = _mm256_set1_epi32((UINT32)value2);
+            break;
+         CASE_NPY_INT64:
+            pDest->ci.i1 = _mm_set1_epi64x(value);
+            pDest->ci.i2 = _mm_set1_epi64x(value);
+            break;
+         CASE_NPY_UINT64:
+            pDest->ci.i1 = _mm_set1_epi64x(value2);
+            pDest->ci.i2 = _mm_set1_epi64x(value2);
+            break;
+         case NPY_FLOAT32:
+            pDest->s = _mm256_set1_ps((float)value);
+            break;
+         case NPY_FLOAT64:
+            pDest->d = _mm256_set1_pd((double)value);
+            break;
+         default:
+            printf("unknown long scalar type in convertScalarObject %d\n", numpyOutType);
+            return FALSE;
+         }
+      }
+      else if (PyFloat_Check(inObject1) || PyArray_IsScalar((inObject1), Floating)) {
 
-       double value = PyFloat_AsDouble(inObject1);
+         double value = PyFloat_AsDouble(inObject1);
 
-       switch (numpyOutType) {
-       case NPY_BOOL:
-       case NPY_INT8:
-          pDest->i = _mm256_set1_epi8((INT8)value);
-          break;
-       case NPY_UINT8:
-          pDest->i = _mm256_set1_epi8((UINT8)value);
-          break;
-       case NPY_INT16:
-          pDest->i = _mm256_set1_epi16((INT16)value);
-          break;
-       case NPY_UINT16:
-          pDest->i = _mm256_set1_epi16((UINT16)value);
-          break;
-       CASE_NPY_UINT32:
-          pDest->i = _mm256_set1_epi32((UINT32)value);
-          break;
-       CASE_NPY_INT32:
-          pDest->i = _mm256_set1_epi32((INT32)value);
-          break;
-       CASE_NPY_UINT64:
-          pDest->ci.i1 = _mm_set1_epi64x((UINT64)value);
-          pDest->ci.i2 = _mm_set1_epi64x((UINT64)value);
-          break;
-       CASE_NPY_INT64:
-          pDest->ci.i1 = _mm_set1_epi64x((INT64)value);
-          pDest->ci.i2 = _mm_set1_epi64x((INT64)value);
-          break;
-       case NPY_FLOAT32:
-          pDest->s = _mm256_set1_ps((float)value);
-          break;
-       case NPY_FLOAT64:
-          pDest->d = _mm256_set1_pd((double)value);
-          break;
-       case NPY_LONGDOUBLE:
-          pDest->d = _mm256_set1_pd((double)(long double)value);
-          break;
-       default:
-          printf("unknown float scalar type in convertScalarObject %d\n", numpyOutType);
-          return FALSE;
-       }
+         switch (numpyOutType) {
+         case NPY_BOOL:
+         case NPY_INT8:
+            pDest->i = _mm256_set1_epi8((INT8)value);
+            break;
+         case NPY_UINT8:
+            pDest->i = _mm256_set1_epi8((UINT8)value);
+            break;
+         case NPY_INT16:
+            pDest->i = _mm256_set1_epi16((INT16)value);
+            break;
+         case NPY_UINT16:
+            pDest->i = _mm256_set1_epi16((UINT16)value);
+            break;
+         CASE_NPY_UINT32:
+            pDest->i = _mm256_set1_epi32((UINT32)value);
+            break;
+         CASE_NPY_INT32:
+            pDest->i = _mm256_set1_epi32((INT32)value);
+            break;
+         CASE_NPY_UINT64:
+            pDest->ci.i1 = _mm_set1_epi64x((UINT64)value);
+            pDest->ci.i2 = _mm_set1_epi64x((UINT64)value);
+            break;
+         CASE_NPY_INT64:
+            pDest->ci.i1 = _mm_set1_epi64x((INT64)value);
+            pDest->ci.i2 = _mm_set1_epi64x((INT64)value);
+            break;
+         case NPY_FLOAT32:
+            pDest->s = _mm256_set1_ps((float)value);
+            break;
+         case NPY_FLOAT64:
+            pDest->d = _mm256_set1_pd((double)value);
+            break;
+         case NPY_LONGDOUBLE:
+            pDest->d = _mm256_set1_pd((double)(long double)value);
+            break;
+         default:
+            printf("unknown float scalar type in convertScalarObject %d\n", numpyOutType);
+            return FALSE;
+         }
 
-    }
-    else if (PyBytes_Check(inObject1)) {
-       // happens when pass in b'test'
-       *pItemSize = PyBytes_GET_SIZE(inObject1);
-       *ppDataIn = PyBytes_AS_STRING(inObject1);
-       return TRUE;
-    }
-    else if (PyUnicode_Check(inObject1)) {
-       // happens when pass in 'test'
-       *pItemSize = PyUnicode_GET_SIZE(inObject1) * 4;
-       // memory leak needs to be deleted
-       *ppDataIn = PyUnicode_AsUCS4Copy(inObject1);
-       return TRUE;
-    }
-    else if (PyArray_IsScalar(inObject1, Generic)) {
+      }
+      else if (PyBytes_Check(inObject1)) {
+         // happens when pass in b'test'
+         *pItemSize = PyBytes_GET_SIZE(inObject1);
+         *ppDataIn = PyBytes_AS_STRING(inObject1);
+         return TRUE;
+      }
+      else if (PyUnicode_Check(inObject1)) {
+         // happens when pass in 'test'
+         *pItemSize = PyUnicode_GET_SIZE(inObject1) * 4;
+         // memory leak needs to be deleted
+         *ppDataIn = PyUnicode_AsUCS4Copy(inObject1);
+         return TRUE;
+      }
+      else if (PyArray_IsScalar(inObject1, Generic)) {
 
-       // only integers are not subclassed in numpy world
-       if (PyArray_IsScalar((inObject1), Integer)) {
-          PyArray_Descr* dtype = PyArray_DescrFromScalar(inObject1);
+         // only integers are not subclassed in numpy world
+         if (PyArray_IsScalar((inObject1), Integer)) {
+            PyArray_Descr* dtype = PyArray_DescrFromScalar(inObject1);
 
-          // NOTE: memory leak here?
-          printf("!!integer scalar type is %d\n", dtype->type_num);
-          return FALSE;
-       }
-       else {
-          printf("!!unknown numpy scalar type in convertScalarObject %d --", numpyOutType);
-          return FALSE;
-       }
+            // NOTE: memory leak here?
+            printf("!!integer scalar type is %d\n", dtype->type_num);
+            return FALSE;
+         }
+         else {
+            printf("!!unknown numpy scalar type in convertScalarObject %d --", numpyOutType);
+            return FALSE;
+         }
 
-    }
+      }
 
-    else {
-       // Complex types hits here
-       LOGGING("!!unknown scalar type in convertScalarObject %d --", numpyOutType);
-       PyTypeObject* type = inObject1->ob_type;
-       LOGGING("type name is %s\n", type->tp_name);
-       return FALSE;
-    }
-
-    //printf("returning from scalar conversion\n");
-    return TRUE;
+      else {
+         // Complex types hits here
+         LOGGING("!!unknown scalar type in convertScalarObject %d --", numpyOutType);
+         PyTypeObject* type = inObject1->ob_type;
+         LOGGING("type name is %s\n", type->tp_name);
+         return FALSE;
+      }
+   }
+   //printf("returning from scalar conversion\n");
+   return TRUE;
 }
 
 
@@ -1513,55 +1514,55 @@ PyObject* RecordArrayToColMajor(PyObject* self, PyObject* args);
 
 //--------------------------------------------------------
 const char* docstring_asarray =
-"Parameters\n"
-"----------\n"
-"a : array_like\n"
-"   Input data, in any form that can be converted to an array.This\n"
-"   includes lists, lists of tuples, tuples, tuples of tuples, tuples\n"
-"   of lists and ndarrays.\n"
-"dtype : data - type, optional\n"
-"   By default, the data - type is inferred from the input data.\n"
-"order : {'C', 'F'}, optional\n"
-"   Whether to use row - major(C - style) or\n"
-"   column - major(Fortran - style) memory representation.\n"
-"   Defaults to 'C'.\n"
-"\n"
-"Returns\n"
-"-------\n"
-"out : ndarray or FastArray\n"
-"   Array interpretation of 'a'.  No copy is performed if the input\n"
-"   is already an ndarray or FastArray with matching dtype and order.\n"
-"   If 'a' is a subclass of ndarray, a base class ndarray is returned.\n"
-"\n"
-"See Also\n"
-"--------\n"
-"asfastarray : Similar function which always returns a FastArray.\n";
+   "Parameters\n"
+   "----------\n"
+   "a : array_like\n"
+   "   Input data, in any form that can be converted to an array.This\n"
+   "   includes lists, lists of tuples, tuples, tuples of tuples, tuples\n"
+   "   of lists and ndarrays.\n"
+   "dtype : data - type, optional\n"
+   "   By default, the data - type is inferred from the input data.\n"
+   "order : {'C', 'F'}, optional\n"
+   "   Whether to use row - major(C - style) or\n"
+   "   column - major(Fortran - style) memory representation.\n"
+   "   Defaults to 'C'.\n"
+   "\n"
+   "Returns\n"
+   "-------\n"
+   "out : ndarray or FastArray\n"
+   "   Array interpretation of 'a'.  No copy is performed if the input\n"
+   "   is already an ndarray or FastArray with matching dtype and order.\n"
+   "   If 'a' is a subclass of ndarray, a base class ndarray is returned.\n"
+   "\n"
+   "See Also\n"
+   "--------\n"
+   "asfastarray : Similar function which always returns a FastArray.\n";
 
 
 const char* docstring_asfastarray =
-"Parameters\n"
-"----------\n"
-"a : array_like\n"
-"   Input data, in any form that can be converted to an array.This\n"
-"   includes lists, lists of tuples, tuples, tuples of tuples, tuples\n"
-"   of lists and ndarrays.\n"
-"dtype : data - type, optional\n"
-"   By default, the data - type is inferred from the input data.\n"
-"order : {'C', 'F'}, optional\n"
-"   Whether to use row - major(C - style) or\n"
-"   column - major(Fortran - style) memory representation.\n"
-"   Defaults to 'C'.\n"
-"\n"
-"Returns\n"
-"-------\n"
-"out : FastArray\n"
-"   Array interpretation of 'a'.  No copy is performed if the input\n"
-"   is already an ndarray or FastArray with matching dtype and order.\n"
-"   If 'a' is a subclass of ndarray, a base class ndarray is returned.\n"
-"\n"
-"See Also\n"
-"--------\n"
-"asarray : Similar function.\n";
+   "Parameters\n"
+   "----------\n"
+   "a : array_like\n"
+   "   Input data, in any form that can be converted to an array.This\n"
+   "   includes lists, lists of tuples, tuples, tuples of tuples, tuples\n"
+   "   of lists and ndarrays.\n"
+   "dtype : data - type, optional\n"
+   "   By default, the data - type is inferred from the input data.\n"
+   "order : {'C', 'F'}, optional\n"
+   "   Whether to use row - major(C - style) or\n"
+   "   column - major(Fortran - style) memory representation.\n"
+   "   Defaults to 'C'.\n"
+   "\n"
+   "Returns\n"
+   "-------\n"
+   "out : FastArray\n"
+   "   Array interpretation of 'a'.  No copy is performed if the input\n"
+   "   is already an ndarray or FastArray with matching dtype and order.\n"
+   "   If 'a' is a subclass of ndarray, a base class ndarray is returned.\n"
+   "\n"
+   "See Also\n"
+   "--------\n"
+   "asarray : Similar function.\n";
 
 
 /* ==== Set up the methods table ====================== */
@@ -1617,7 +1618,7 @@ static PyMethodDef CSigMathUtilMethods[] = {
    { "MergeBinnedAndSorted", MergeBinnedAndSorted, METH_VARARGS, "MergeBinnedAndSorted calculation" },
 
    { "GroupByPack32", GroupByPack32, METH_VARARGS, "GroupByPack32 data from int to float, etc" },
-      //{ "GroupByOp32", GroupByOp32, METH_VARARGS, "GroupByOp32 data from int to float, etc" },
+   //{ "GroupByOp32", GroupByOp32, METH_VARARGS, "GroupByOp32 data from int to float, etc" },
    { "GroupByAll32", GroupByAll32, METH_VARARGS, "GroupByAll32 data from int to float, etc" },
    { "GroupByAll64", GroupByAll64, METH_VARARGS, "GroupByAll64 data from int to float, etc" },
    { "GroupByAllPack32", GroupByAllPack32, METH_VARARGS, "GroupByAllPack32 data from int to float, etc" },
@@ -1661,7 +1662,7 @@ static PyMethodDef CSigMathUtilMethods[] = {
    { "BasicMathTwoInputs", BasicMathTwoInputs, METH_VARARGS, "BasicMathTwoInputs functionality" },
 
 
-      // for low level python hooks
+   // for low level python hooks
    { "BasicMathHook", BasicMathHook, METH_VARARGS, "BasicMathHook functionality (pass in fastarray class, FA, np.ndarray)" },
 
    { "LedgerFunction", (PyCFunction)LedgerFunction, METH_VARARGS | METH_KEYWORDS, "LedgerFunction calculation" },
@@ -1722,11 +1723,11 @@ PyMODINIT_FUNC PyInit_riptide_cpp() {
 
    // Count up the
    for (int i = 0; i < 1000; i++) {
-if (CSigMathUtilMethods[i].ml_name == NULL) {
-   break;
-}
+      if (CSigMathUtilMethods[i].ml_name == NULL) {
+         break;
+      }
 
-count++;
+      count++;
    }
 
    LOGGING("FASTMATH: Found %d methods\n", count);
@@ -1802,102 +1803,102 @@ count++;
             pRow->dtype2 = convertType2;
          }
          else
-         if (convertType2 == 0) {
-            // bool converts to anything
-            pRow->dtype1 = convertType1;
-            pRow->dtype2 = convertType1;
-         }
-         else
-         // Check for long upcasting?
-         if (convertType1 > convertType2) {
-            if (convertType1 == NPY_ULONGLONG) {
-               // check for signed value
-               if ((convertType2 & 1) == 1) {
-                  pRow->dtype1 = NPY_FLOAT64;
-                  pRow->dtype2 = NPY_FLOAT64;
-               }
-               else {
-                  pRow->dtype1 = NPY_ULONGLONG;
-                  pRow->dtype2 = NPY_ULONGLONG;
-               }
+            if (convertType2 == 0) {
+               // bool converts to anything
+               pRow->dtype1 = convertType1;
+               pRow->dtype2 = convertType1;
             }
-            else {
-               // if the higher is unsigned and the other is signed go up one
-               if (convertType1 < NPY_ULONGLONG && (convertType1 & 1) == 0 && (convertType2 & 1) == 1) {
-
-                  // Choose the higher dtype +1
-                  pRow->dtype1 = convertType1 + 1;
-                  pRow->dtype2 = convertType1 + 1;
-
-                  // Handle ambiguous dtype upcast (going from int to long does nothing on some C compilers)
-                  if (sizeof(long) == 4) {
-                     if (convertType1 == NPY_INT || convertType1 == NPY_UINT) {
-                        pRow->dtype1 = convertType1 + 3;
-                        pRow->dtype2 = convertType1 + 3;
+            else
+               // Check for long upcasting?
+               if (convertType1 > convertType2) {
+                  if (convertType1 == NPY_ULONGLONG) {
+                     // check for signed value
+                     if ((convertType2 & 1) == 1) {
+                        pRow->dtype1 = NPY_FLOAT64;
+                        pRow->dtype2 = NPY_FLOAT64;
+                     }
+                     else {
+                        pRow->dtype1 = NPY_ULONGLONG;
+                        pRow->dtype2 = NPY_ULONGLONG;
                      }
                   }
                   else {
-                     if (convertType1 == NPY_LONG || convertType1 == NPY_ULONG) {
-                        pRow->dtype1 = convertType1 + 3;
-                        pRow->dtype2 = convertType1 + 3;
-                     }
-                  }
-               }
-               else {
-                  // Choose the higher dtype
-                  pRow->dtype1 = convertType1;
-                  pRow->dtype2 = convertType1;
-               }
-            }
-         }
-         else {
-            if (convertType1 == convertType2) {
-               pRow->dtype1 = convertType2;
-               pRow->dtype2 = convertType2;
-            }
-            else {
-               // convertType2 is larger
-               if (convertType2 == NPY_ULONGLONG) {
-                  // check for signed value
-                  if ((convertType1 & 1) == 1) {
-                     pRow->dtype1 = NPY_FLOAT64;
-                     pRow->dtype2 = NPY_FLOAT64;
-                  }
-                  else {
-                     pRow->dtype2 = NPY_ULONGLONG;
-                     pRow->dtype1 = NPY_ULONGLONG;
-                  }
-               }
-               else {
-                  // Check for signed/unsigned integer
-                  if (convertType2 < NPY_ULONGLONG && (convertType2 & 1) == 0 && (convertType1 & 1) == 1) {
+                     // if the higher is unsigned and the other is signed go up one
+                     if (convertType1 < NPY_ULONGLONG && (convertType1 & 1) == 0 && (convertType2 & 1) == 1) {
 
-                     // Choose the higher dtype +1
-                     pRow->dtype1 = convertType2 + 1;
-                     pRow->dtype2 = convertType2 + 1;
+                        // Choose the higher dtype +1
+                        pRow->dtype1 = convertType1 + 1;
+                        pRow->dtype2 = convertType1 + 1;
 
-                     // Handle ambiguous dtype upcast
-                     if (sizeof(long) == 4) {
-                        if (convertType2 == NPY_INT || convertType2 == NPY_UINT) {
-                           pRow->dtype1 = convertType2 + 3;
-                           pRow->dtype2 = convertType2 + 3;
+                        // Handle ambiguous dtype upcast (going from int to long does nothing on some C compilers)
+                        if (sizeof(long) == 4) {
+                           if (convertType1 == NPY_INT || convertType1 == NPY_UINT) {
+                              pRow->dtype1 = convertType1 + 3;
+                              pRow->dtype2 = convertType1 + 3;
+                           }
+                        }
+                        else {
+                           if (convertType1 == NPY_LONG || convertType1 == NPY_ULONG) {
+                              pRow->dtype1 = convertType1 + 3;
+                              pRow->dtype2 = convertType1 + 3;
+                           }
                         }
                      }
                      else {
-                        if (convertType2 == NPY_LONG || convertType2 == NPY_ULONG) {
-                           pRow->dtype1 = convertType2 + 3;
-                           pRow->dtype2 = convertType2 + 3;
-                        }
+                        // Choose the higher dtype
+                        pRow->dtype1 = convertType1;
+                        pRow->dtype2 = convertType1;
                      }
                   }
-                  else {
-                     // Choose the higher dtype
+               }
+               else {
+                  if (convertType1 == convertType2) {
                      pRow->dtype1 = convertType2;
                      pRow->dtype2 = convertType2;
                   }
+                  else {
+                     // convertType2 is larger
+                     if (convertType2 == NPY_ULONGLONG) {
+                        // check for signed value
+                        if ((convertType1 & 1) == 1) {
+                           pRow->dtype1 = NPY_FLOAT64;
+                           pRow->dtype2 = NPY_FLOAT64;
+                        }
+                        else {
+                           pRow->dtype2 = NPY_ULONGLONG;
+                           pRow->dtype1 = NPY_ULONGLONG;
+                        }
+                     }
+                     else {
+                        // Check for signed/unsigned integer
+                        if (convertType2 < NPY_ULONGLONG && (convertType2 & 1) == 0 && (convertType1 & 1) == 1) {
+
+                           // Choose the higher dtype +1
+                           pRow->dtype1 = convertType2 + 1;
+                           pRow->dtype2 = convertType2 + 1;
+
+                           // Handle ambiguous dtype upcast
+                           if (sizeof(long) == 4) {
+                              if (convertType2 == NPY_INT || convertType2 == NPY_UINT) {
+                                 pRow->dtype1 = convertType2 + 3;
+                                 pRow->dtype2 = convertType2 + 3;
+                              }
+                           }
+                           else {
+                              if (convertType2 == NPY_LONG || convertType2 == NPY_ULONG) {
+                                 pRow->dtype1 = convertType2 + 3;
+                                 pRow->dtype2 = convertType2 + 3;
+                              }
+                           }
+                        }
+                        else {
+                           // Choose the higher dtype
+                           pRow->dtype1 = convertType2;
+                           pRow->dtype2 = convertType2;
+                        }
+                     }
+                  }
                }
-            }
-         }
       }
    }
 
@@ -1925,7 +1926,7 @@ count++;
    if (!mod_dict)
    {
       LOGGING("Unable to get the module dictionary for the riptide_cpp module.\n")
-      return NULL;
+         return NULL;
    }
 
    if (!RegisterSdsPythonTypes(mod_dict))
@@ -1970,7 +1971,7 @@ void* GetDefaultForType(int numpyInType) {
    case NPY_LONGDOUBLE:
    case NPY_DOUBLE: pgDefault = &gDefaultDouble;
       break;
-   // BOOL should not really have an invalid value inhabiting the type
+      // BOOL should not really have an invalid value inhabiting the type
    case NPY_BOOL:   pgDefault = &gDefaultBool;
       break;
    case NPY_BYTE:   pgDefault = &gDefaultInt8;

--- a/src/RipTide.cpp
+++ b/src/RipTide.cpp
@@ -85,8 +85,8 @@ stScalarType NpTypeObjects[MAX_NUMPY_TYPE] = {
    { NULL, 4,  NPY_INT },
    { NULL, 4,  NPY_UINT },
 #if defined(RT_OS_WINDOWS)
-   { NULL, 4,  NPY_INT },   // believe this is 8 bytes on Linux
-   { NULL, 4,  NPY_UINT },  // believe this is 8 bytes on Linux
+   { NULL, 4,  NPY_INT32 },   // believe this is 8 bytes on Linux
+   { NULL, 4,  NPY_UINT32 },  // believe this is 8 bytes on Linux
 #else
    { NULL, 8,  NPY_LONG },   // believe this is 8 bytes on Linux enum 7
    { NULL, 8,  NPY_ULONG },  // believe this is 8 bytes on Linux enum 8
@@ -118,8 +118,8 @@ const char* gNumpyTypeToString[NUMPY_LAST_TYPE] = {
    "NPY_INT",
    "NPY_UINT",
 #if defined(RT_OS_WINDOWS)
-   "NPY_INT",   // not on linux
-   "NPY_UINT",  // not on linux
+   "NPY_INT32",   // not on linux
+   "NPY_UINT32",  // not on linux
 #else
    "NPY_LONG64",   // not on linux
    "NPY_LONG64",  // not on linux
@@ -147,14 +147,14 @@ int32_t gNumpyTypeToSize[NUMPY_LAST_TYPE] = {
    1, //NPY_UBYTE,     2
    2, //NPY_SHORT,     3
    2, //NPY_USHORT,    4
-   4, //NPY_INT,       5 // TJD is this used or just NPY_INT?
-   4, //NPY_UINT,      6 // TJD is this used or just NPY_UINT?
+   4, //NPY_INT,       5 // TJD is this used or just NPY_INT32?
+   4, //NPY_UINT,      6 // TJD is this used or just NPY_UINT32?
 #if defined(RT_OS_WINDOWS)
-   4, //NPY_INT,      7 // TODO: change to sizeof(long)
-   4, //NPY_UINT,     8
+   4, //NPY_INT32,      7 // TODO: change to sizeof(long)
+   4, //NPY_UINT32,     8
 #else
-   8, //NPY_INT,      7
-   8, //NPY_UINT,     8
+   8, //NPY_INT32,      7
+   8, //NPY_UINT32,     8
 
 #endif
    8, //NPY_INT64,  9
@@ -177,7 +177,7 @@ int32_t gNumpyTypeToSize[NUMPY_LAST_TYPE] = {
 
 
 //---------------------------------------------------------------
-// Pass in a type such as np.int32 and a NPY_INT will be returned
+// Pass in a type such as np.int32 and a NPY_INT32 will be returned
 // returns -1 on failure adn set error string
 // otherwise returns NPY_TYPE
 int32_t TypeToDtype(PyTypeObject *out_dtype) {
@@ -200,7 +200,7 @@ int32_t TypeToDtype(PyTypeObject *out_dtype) {
 //---------------------------------------------
 // Return the objects dtype
 // Returns -1 on types > NPY_VOID suchas NPY_DATETIME,
-// otherwise the type number such as NPY_INT or NPY_FLOAT
+// otherwise the type number such as NPY_INT32 or NPY_FLOAT
 int32_t ObjectToDtype(PyArrayObject* obj) {
 
    int32_t result = PyArray_TYPE(obj);
@@ -881,10 +881,10 @@ int32_t GetArrDType(PyArrayObject* inArr) {
 #if defined(RT_OS_WINDOWS)
 
    if (dtype == NPY_INT) {
-      dtype = NPY_INT;
+      dtype = NPY_INT32;
    }
    if (dtype == NPY_UINT) {
-      dtype = NPY_UINT;
+      dtype = NPY_UINT32;
    }
 
 #else
@@ -918,8 +918,8 @@ int32_t GetArrDType(PyArrayObject* inArr) {
 // NPY_USHORT   4
 // NPY_INT      5
 // NPY_UINT     6
-// NPY_INT      7
-// NPY_UINT     8
+// NPY_INT32      7
+// NPY_UINT32     8
 // NPY_INT64      9
 // NPY_UINT64     10
 // NPY_FLOAT      11
@@ -952,13 +952,13 @@ bool ConvertSingleItemArray(void* pInput, int16_t numpyInType, _m256all* pDest, 
       value = (int64_t)*(uint16_t*)pInput;
       fvalue = (double)value;
       break;
-   case NPY_UINT:
-//   case NPY_UINT: This enumeration is the same value as NPY_UINT above
+   case NPY_UINT32:
+//   case NPY_UINT: This enumeration is the same value as NPY_UINT32 above
       value = (int64_t)*(uint32_t*)pInput;
       fvalue = (double)value;
       break;
-   case NPY_INT:
-//   case NPY_INT: This enumeration is the same value as NPY_INT above
+   case NPY_INT32:
+//   case NPY_INT: This enumeration is the same value as NPY_INT32 above
       value = (int64_t)*(int32_t*)pInput;
       fvalue = (double)value;
       break;
@@ -995,10 +995,10 @@ bool ConvertSingleItemArray(void* pInput, int16_t numpyInType, _m256all* pDest, 
    case NPY_UINT16:
       pDest->i = _mm256_set1_epi16((int16_t)value);
       break;
-   case NPY_UINT:
-//   case NPY_UINT: This enumeration has the same value at NPY_UINT above
-   case NPY_INT:
-//   case NPY_INT: This enumeration has the same value as NPY_INT above
+   case NPY_UINT32:
+//   case NPY_UINT: This enumeration has the same value at NPY_UINT32 above
+   case NPY_INT32:
+//   case NPY_INT: This enumeration has the same value as NPY_INT32 above
       pDest->i = _mm256_set1_epi32((int32_t)value);
       break;
    case NPY_UINT64:
@@ -1070,10 +1070,10 @@ bool ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyOutT
       case NPY_UINT16:
          pDest->i = _mm256_set1_epi16((int16_t)value);
          break;
-      case NPY_UINT:
-//      case  NPY_UINT: This enumeration has the same value as NPY_UINT above
-      case NPY_INT:
-//      case NPY_INT: This enumeration has the same value as NPY_INT above
+      case NPY_UINT32:
+//      case  NPY_UINT: This enumeration has the same value as NPY_UINT32 above
+      case NPY_INT32:
+//      case NPY_INT: This enumeration has the same value as NPY_INT32 above
          pDest->i = _mm256_set1_epi32((int32_t)value);
          break;
       case NPY_UINT64:
@@ -1150,12 +1150,12 @@ bool ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyOutT
          case NPY_UINT16:
             pDest->i = _mm256_set1_epi16((uint16_t)value2);
             break;
-         case NPY_INT:
-//         case NPY_INT: This enumeration has the same value as NPY_INT above
+         case NPY_INT32:
+//         case NPY_INT: This enumeration has the same value as NPY_INT32 above
             pDest->i = _mm256_set1_epi32((int32_t)value);
             break;
-         case NPY_UINT:
-//         case NPY_UINT: This enumeration hasa the same value as NPY_UINT above
+         case NPY_UINT32:
+//         case NPY_UINT: This enumeration hasa the same value as NPY_UINT32 above
             pDest->i = _mm256_set1_epi32((uint32_t)value2);
             break;
          case NPY_INT64:
@@ -1197,12 +1197,12 @@ bool ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyOutT
          case NPY_UINT16:
             pDest->i = _mm256_set1_epi16((uint16_t)value);
             break;
-         case NPY_UINT:
-//         case NPY_UINT: This enumeration has the same value as NPY_UINT above
+         case NPY_UINT32:
+//         case NPY_UINT: This enumeration has the same value as NPY_UINT32 above
             pDest->i = _mm256_set1_epi32((uint32_t)value);
             break;
-         case NPY_INT:
-//         case NPY_INT: This enumeration has the same value as NPY_INT above
+         case NPY_INT32:
+//         case NPY_INT: This enumeration has the same value as NPY_INT32 above
             pDest->i = _mm256_set1_epi32((int32_t)value);
             break;
          case NPY_UINT64:
@@ -2001,8 +2001,8 @@ void* GetDefaultForType(int numpyInType) {
    case NPY_INT16:
       pgDefault = &gDefaultInt16;
       break;
-   case NPY_INT: 
-//   case NPY_INT: This is the same numeric value as NPY_INT above
+   case NPY_INT32: 
+//   case NPY_INT: This is the same numeric value as NPY_INT32 above
       pgDefault = &gDefaultInt32;
       break;
    case NPY_INT64:
@@ -2015,8 +2015,8 @@ void* GetDefaultForType(int numpyInType) {
    case NPY_UINT16:
       pgDefault = &gDefaultUInt16;
       break;
-   case NPY_UINT:
-//   case NPY_UINT: This is the same numeric value as NPY_UINT above
+   case NPY_UINT32:
+//   case NPY_UINT: This is the same numeric value as NPY_UINT32 above
       pgDefault = &gDefaultUInt32;
       break;
    case NPY_UINT64:
@@ -2046,7 +2046,7 @@ int GetNumpyType(int16_t value) {
    return NPY_INT16;
 }
 int GetNumpyType(int32_t value) {
-   return NPY_INT;
+   return NPY_INT32;
 }
 int GetNumpyType(int64_t value) {
    return NPY_INT64;
@@ -2058,7 +2058,7 @@ int GetNumpyType(uint16_t value) {
    return NPY_UINT16;
 }
 int GetNumpyType(uint32_t value) {
-   return NPY_UINT;
+   return NPY_UINT32;
 }
 int GetNumpyType(uint64_t value) {
    return NPY_UINT64;

--- a/src/RipTide.cpp
+++ b/src/RipTide.cpp
@@ -952,23 +952,21 @@ bool ConvertSingleItemArray(void* pInput, int16_t numpyInType, _m256all* pDest, 
       value = (int64_t)*(uint16_t*)pInput;
       fvalue = (double)value;
       break;
-   case NPY_UINT32:
-//   case NPY_UINT: This enumeration is the same value as NPY_UINT32 above
+   CASE_NPY_UINT32:
       value = (int64_t)*(uint32_t*)pInput;
       fvalue = (double)value;
       break;
-   case NPY_INT32:
-//   case NPY_INT: This enumeration is the same value as NPY_INT32 above
+   CASE_NPY_INT32:
       value = (int64_t)*(int32_t*)pInput;
       fvalue = (double)value;
       break;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT64:
+   
       value = (int64_t)*(uint64_t*)pInput;
       fvalue = (double)value;
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       value = (int64_t)*(int64_t*)pInput;
       fvalue = (double)value;
       break;
@@ -995,16 +993,14 @@ bool ConvertSingleItemArray(void* pInput, int16_t numpyInType, _m256all* pDest, 
    case NPY_UINT16:
       pDest->i = _mm256_set1_epi16((int16_t)value);
       break;
-   case NPY_UINT32:
-//   case NPY_UINT: This enumeration has the same value at NPY_UINT32 above
-   case NPY_INT32:
-//   case NPY_INT: This enumeration has the same value as NPY_INT32 above
+   CASE_NPY_UINT32:
+   CASE_NPY_INT32:
       pDest->i = _mm256_set1_epi32((int32_t)value);
       break;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_UINT64:
+   
+   CASE_NPY_INT64:
+   
       pDest->ci.i1 = _mm_set1_epi64x(value);
       pDest->ci.i2 = _mm_set1_epi64x(value);
       break;
@@ -1070,16 +1066,14 @@ bool ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyOutT
       case NPY_UINT16:
          pDest->i = _mm256_set1_epi16((int16_t)value);
          break;
-      case NPY_UINT32:
-//      case  NPY_UINT: This enumeration has the same value as NPY_UINT32 above
-      case NPY_INT32:
-//      case NPY_INT: This enumeration has the same value as NPY_INT32 above
+      CASE_NPY_UINT32:
+      CASE_NPY_INT32:
          pDest->i = _mm256_set1_epi32((int32_t)value);
          break;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
-      case NPY_INT64:
-      case  NPY_LONGLONG:
+      CASE_NPY_UINT64:
+      
+      CASE_NPY_INT64:
+
          pDest->ci.i1 = _mm_set1_epi64x(value);
          pDest->ci.i2 = _mm_set1_epi64x(value);
          break;
@@ -1150,21 +1144,19 @@ bool ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyOutT
          case NPY_UINT16:
             pDest->i = _mm256_set1_epi16((uint16_t)value2);
             break;
-         case NPY_INT32:
-//         case NPY_INT: This enumeration has the same value as NPY_INT32 above
+         CASE_NPY_INT32:
             pDest->i = _mm256_set1_epi32((int32_t)value);
             break;
-         case NPY_UINT32:
-//         case NPY_UINT: This enumeration hasa the same value as NPY_UINT32 above
+         CASE_NPY_UINT32:
             pDest->i = _mm256_set1_epi32((uint32_t)value2);
             break;
-         case NPY_INT64:
-         case NPY_LONGLONG:
+         CASE_NPY_INT64:
+         
             pDest->ci.i1 = _mm_set1_epi64x(value);
             pDest->ci.i2 = _mm_set1_epi64x(value);
             break;
-         case NPY_UINT64:
-         case NPY_ULONGLONG:
+         CASE_NPY_UINT64:
+         
             pDest->ci.i1 = _mm_set1_epi64x(value2);
             pDest->ci.i2 = _mm_set1_epi64x(value2);
             break;
@@ -1197,21 +1189,19 @@ bool ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyOutT
          case NPY_UINT16:
             pDest->i = _mm256_set1_epi16((uint16_t)value);
             break;
-         case NPY_UINT32:
-//         case NPY_UINT: This enumeration has the same value as NPY_UINT32 above
+         CASE_NPY_UINT32:
             pDest->i = _mm256_set1_epi32((uint32_t)value);
             break;
-         case NPY_INT32:
-//         case NPY_INT: This enumeration has the same value as NPY_INT32 above
+         CASE_NPY_INT32:
             pDest->i = _mm256_set1_epi32((int32_t)value);
             break;
-         case NPY_UINT64:
-         case NPY_ULONGLONG:
+         CASE_NPY_UINT64:
+         
             pDest->ci.i1 = _mm_set1_epi64x((uint64_t)value);
             pDest->ci.i2 = _mm_set1_epi64x((uint64_t)value);
             break;
-         case NPY_INT64:
-         case NPY_LONGLONG:
+         CASE_NPY_INT64:
+         
             pDest->ci.i1 = _mm_set1_epi64x((int64_t)value);
             pDest->ci.i2 = _mm_set1_epi64x((int64_t)value);
             break;
@@ -2001,12 +1991,12 @@ void* GetDefaultForType(int numpyInType) {
    case NPY_INT16:
       pgDefault = &gDefaultInt16;
       break;
-   case NPY_INT32: 
+   CASE_NPY_INT32: 
 //   case NPY_INT: This is the same numeric value as NPY_INT32 above
       pgDefault = &gDefaultInt32;
       break;
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       pgDefault = &gDefaultInt64;
       break;
    case NPY_UINT8:
@@ -2015,12 +2005,12 @@ void* GetDefaultForType(int numpyInType) {
    case NPY_UINT16:
       pgDefault = &gDefaultUInt16;
       break;
-   case NPY_UINT32:
+   CASE_NPY_UINT32:
 //   case NPY_UINT: This is the same numeric value as NPY_UINT32 above
       pgDefault = &gDefaultUInt32;
       break;
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT64:
+   
       pgDefault = &gDefaultUInt64;
       break;
    case NPY_STRING:

--- a/src/RipTide.cpp
+++ b/src/RipTide.cpp
@@ -953,12 +953,12 @@ bool ConvertSingleItemArray(void* pInput, int16_t numpyInType, _m256all* pDest, 
       fvalue = (double)value;
       break;
    case NPY_UINT32:
-   case NPY_UINT:
+//   case NPY_UINT: This enumeration is the same value as NPY_UINT32 above
       value = (int64_t)*(uint32_t*)pInput;
       fvalue = (double)value;
       break;
    case NPY_INT32:
-   case NPY_INT:
+//   case NPY_INT: This enumeration is the same value as NPY_INT32 above
       value = (int64_t)*(int32_t*)pInput;
       fvalue = (double)value;
       break;
@@ -996,9 +996,9 @@ bool ConvertSingleItemArray(void* pInput, int16_t numpyInType, _m256all* pDest, 
       pDest->i = _mm256_set1_epi16((int16_t)value);
       break;
    case NPY_UINT32:
-   case NPY_UINT:
+//   case NPY_UINT: This enumeration has the same value at NPY_UINT32 above
    case NPY_INT32:
-   case NPY_INT:
+//   case NPY_INT: This enumeration has the same value as NPY_INT32 above
       pDest->i = _mm256_set1_epi32((int32_t)value);
       break;
    case NPY_UINT64:
@@ -1071,9 +1071,9 @@ bool ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyOutT
          pDest->i = _mm256_set1_epi16((int16_t)value);
          break;
       case NPY_UINT32:
-      case  NPY_UINT:
+//      case  NPY_UINT: This enumeration has the same value as NPY_UINT32 above
       case NPY_INT32:
-      case NPY_INT:
+//      case NPY_INT: This enumeration has the same value as NPY_INT32 above
          pDest->i = _mm256_set1_epi32((int32_t)value);
          break;
       case NPY_UINT64:
@@ -1151,11 +1151,11 @@ bool ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyOutT
             pDest->i = _mm256_set1_epi16((uint16_t)value2);
             break;
          case NPY_INT32:
-         case NPY_INT:
+//         case NPY_INT: This enumeration has the same value as NPY_INT32 above
             pDest->i = _mm256_set1_epi32((int32_t)value);
             break;
          case NPY_UINT32:
-         case NPY_UINT:
+//         case NPY_UINT: This enumeration hasa the same value as NPY_UINT32 above
             pDest->i = _mm256_set1_epi32((uint32_t)value2);
             break;
          case NPY_INT64:
@@ -1198,11 +1198,11 @@ bool ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyOutT
             pDest->i = _mm256_set1_epi16((uint16_t)value);
             break;
          case NPY_UINT32:
-         case NPY_UINT:
+//         case NPY_UINT: This enumeration has the same value as NPY_UINT32 above
             pDest->i = _mm256_set1_epi32((uint32_t)value);
             break;
          case NPY_INT32:
-         case NPY_INT:
+//         case NPY_INT: This enumeration has the same value as NPY_INT32 above
             pDest->i = _mm256_set1_epi32((int32_t)value);
             break;
          case NPY_UINT64:
@@ -1790,14 +1790,14 @@ PyMODINIT_FUNC PyInit_riptide_cpp() {
 
    // Build LUTs used in comparisons after mask generated
    for (int i = 0; i < 256; i++) {
-      BYTE* pDest = (BYTE*)&gBooleanLUT64[i];
+      unsigned char* pDest = (unsigned char*)&gBooleanLUT64[i];
       for (int j = 0; j < 8; j++) {
          *pDest++ = ((i >> j) & 1);
       }
    }
    // Build LUTs
    for (int i = 0; i < 16; i++) {
-      BYTE* pDest = (BYTE*)&gBooleanLUT32[i];
+      unsigned char* pDest = (unsigned char*)&gBooleanLUT32[i];
       for (int j = 0; j < 4; j++) {
          *pDest++ = ((i >> j) & 1);
       }
@@ -2001,8 +2001,8 @@ void* GetDefaultForType(int numpyInType) {
    case NPY_INT16:
       pgDefault = &gDefaultInt16;
       break;
-   case NPY_INT32:
-   case NPY_INT:
+   case NPY_INT32: 
+//   case NPY_INT: This is the same numeric value as NPY_INT32 above
       pgDefault = &gDefaultInt32;
       break;
    case NPY_INT64:
@@ -2016,7 +2016,7 @@ void* GetDefaultForType(int numpyInType) {
       pgDefault = &gDefaultUInt16;
       break;
    case NPY_UINT32:
-   case NPY_UINT:
+//   case NPY_UINT: This is the same numeric value as NPY_UINT32 above
       pgDefault = &gDefaultUInt32;
       break;
    case NPY_UINT64:

--- a/src/RipTide.cpp
+++ b/src/RipTide.cpp
@@ -58,11 +58,11 @@ PyArray_Descr* g_pDescrULongLong = NULL;
 
 //----------------------------------------------------------------------------------
 // Lookup to go from 1 byte to 8 byte boolean values
-INT64 gBooleanLUT64[256];
-INT32 gBooleanLUT32[16];
+int64_t gBooleanLUT64[256];
+int32_t gBooleanLUT32[16];
 
-INT64 gBooleanLUT64Inverse[256];
-INT32 gBooleanLUT32Inverse[16];
+int64_t gBooleanLUT64Inverse[256];
+int32_t gBooleanLUT32Inverse[16];
 
 // upcast table from 0-13
 struct stUpCast {
@@ -141,7 +141,7 @@ const char* gNumpyTypeToString[NUMPY_LAST_TYPE] = {
    "NPY_HALF" };
 
 
-INT32 gNumpyTypeToSize[NUMPY_LAST_TYPE] = {
+int32_t gNumpyTypeToSize[NUMPY_LAST_TYPE] = {
    1, //NPY_BOOL =     0,
    1, //NPY_BYTE,      1
    1, //NPY_UBYTE,     2
@@ -180,7 +180,7 @@ INT32 gNumpyTypeToSize[NUMPY_LAST_TYPE] = {
 // Pass in a type such as np.int32 and a NPY_INT32 will be returned
 // returns -1 on failure adn set error string
 // otherwise returns NPY_TYPE
-INT32 TypeToDtype(PyTypeObject *out_dtype) {
+int32_t TypeToDtype(PyTypeObject *out_dtype) {
 
    if (PyType_Check(out_dtype)) {
       for (int i = 0; i < 24; i++) {
@@ -201,9 +201,9 @@ INT32 TypeToDtype(PyTypeObject *out_dtype) {
 // Return the objects dtype
 // Returns -1 on types > NPY_VOID suchas NPY_DATETIME,
 // otherwise the type number such as NPY_INT32 or NPY_FLOAT
-INT32 ObjectToDtype(PyArrayObject* obj) {
+int32_t ObjectToDtype(PyArrayObject* obj) {
 
-   INT32 result = PyArray_TYPE(obj);
+   int32_t result = PyArray_TYPE(obj);
 
    // NOTE: This code does not handle NPY_DATETIME, NPY_TIMEDELTA, etc.
    if (result < 0 || result > NPY_VOID) return -1;
@@ -213,17 +213,17 @@ INT32 ObjectToDtype(PyArrayObject* obj) {
 
 //------------------------------------------------------------
 // gets the itemsize for ndarray, useful for chararray
-// INT32 = 4
-// INT64 = 8
+// int32_t = 4
+// int64_t = 8
 // FLOAT32 = 4
 // '|S5' = 5 for chararry
-INT64 NpyItemSize(PyObject *self) {
+int64_t NpyItemSize(PyObject *self) {
    return PyArray_ITEMSIZE((PyArrayObject*)self);
 }
 
 //------------------------------------------------------------
 // Returns a string description of the numpy type
-const char* NpyToString(INT32 numpyType) {
+const char* NpyToString(int32_t numpyType) {
    if (numpyType < 0 || numpyType >= NUMPY_LAST_TYPE) {
       return "<unknown>";
    }
@@ -234,7 +234,7 @@ const char* NpyToString(INT32 numpyType) {
 
 //------------------------------------------------------------
 // Returns 0 for chars, strings, or unsupported types
-INT32 NpyToSize(INT32 numpyType) {
+int32_t NpyToSize(int32_t numpyType) {
 
    if (numpyType < 0 || numpyType >= NUMPY_LAST_TYPE) {
       return 0;
@@ -267,8 +267,8 @@ PyArrayObject* EnsureContiguousArray(PyArrayObject* inObject) {
 //----------------------------------------------------------------
 // Calculate the total number of bytes used by the array.
 // TODO: Need to extend this to accomodate strided arrays.
-INT64 CalcArrayLength(int ndim, npy_intp* dims) {
-   INT64 length = 1;
+int64_t CalcArrayLength(int ndim, npy_intp* dims) {
+   int64_t length = 1;
 
    // handle case of zero length array
    if (dims && ndim > 0) {
@@ -285,7 +285,7 @@ INT64 CalcArrayLength(int ndim, npy_intp* dims) {
 
 //----------------------------------------------------------------
 // calcluate the total number of bytes used
-INT64 ArrayLength(PyArrayObject* inArr) {
+int64_t ArrayLength(PyArrayObject* inArr) {
 
    int ndim = PyArray_NDIM(inArr);
    npy_intp* dims = PyArray_DIMS(inArr);
@@ -571,13 +571,13 @@ PyObject* LedgerFunction(PyObject *self, PyObject *args, PyObject *kwargs)
 }
 
 
-INT64 g_TotalAllocs = 0;
+int64_t g_TotalAllocs = 0;
 
 //-----------------------------------------------------------------------------------
-PyArrayObject* AllocateNumpyArray(int ndim, npy_intp* dims, INT32 numpyType, INT64 itemsize, BOOL fortran_array, npy_intp* strides) {
+PyArrayObject* AllocateNumpyArray(int ndim, npy_intp* dims, int32_t numpyType, int64_t itemsize, BOOL fortran_array, npy_intp* strides) {
 
    PyArrayObject* returnObject = nullptr;
-   const INT64    len = CalcArrayLength(ndim, dims);
+   const int64_t    len = CalcArrayLength(ndim, dims);
    bool           commonArray = false;
 
    // PyArray_New (and the functions it wraps) don't truly respect the 'flags' argument
@@ -610,7 +610,7 @@ PyArrayObject* AllocateNumpyArray(int ndim, npy_intp* dims, INT32 numpyType, INT
    }
 
    // Make one dimension size on stack
-   volatile INT64 dimensions[1] = { len };
+   volatile int64_t dimensions[1] = { len };
 
    // This is the safest way...
    if (!dims) {
@@ -679,7 +679,7 @@ PyArrayObject* AllocateNumpyArray(int ndim, npy_intp* dims, INT32 numpyType, INT
    }
 
    if (!returnObject) {
-      printf("!!!out of memory allocating numpy array size:%llu  dims:%d  dtype:%d  itemsize:%lld  flags:%d  dim0:%lld\n", len, ndim, numpyType, itemsize, array_flags, (INT64)dims[0]);
+      printf("!!!out of memory allocating numpy array size:%llu  dims:%d  dtype:%d  itemsize:%lld  flags:%d  dim0:%lld\n", len, ndim, numpyType, itemsize, array_flags, (int64_t)dims[0]);
       return nullptr;
    }
 
@@ -689,7 +689,7 @@ PyArrayObject* AllocateNumpyArray(int ndim, npy_intp* dims, INT32 numpyType, INT
    return returnObject;
 }
 
-PyArrayObject* AllocateNumpyArrayForData(int ndim, npy_intp* dims, INT32 numpyType, INT64 itemsize, char* data, int array_flags, npy_intp* strides)
+PyArrayObject* AllocateNumpyArrayForData(int ndim, npy_intp* dims, int32_t numpyType, int64_t itemsize, char* data, int array_flags, npy_intp* strides)
 {
    // If there's no data, short-circuit and return nullptr;
    // we could call the regular AllocateNumpyArray() function but this
@@ -700,12 +700,12 @@ PyArrayObject* AllocateNumpyArrayForData(int ndim, npy_intp* dims, INT32 numpyTy
    }
 
    PyArrayObject* returnObject = nullptr;
-   const INT64    len = CalcArrayLength(ndim, dims);
+   const int64_t    len = CalcArrayLength(ndim, dims);
 
    // This is the safest way...
    if (!dims) {
       // Make one dimension size on stack
-      INT64 dimensions[1] = { len };
+      int64_t dimensions[1] = { len };
 
       // Happens with a=FA([]); 100*a;
       //printf("dims was null when allocating\n");
@@ -759,7 +759,7 @@ PyArrayObject* AllocateNumpyArrayForData(int ndim, npy_intp* dims, INT32 numpyTy
    
 
    if (!returnObject) {
-      printf("!!!out of memory allocating numpy array size:%llu  dims:%d  dtype:%d  itemsize:%lld  flags:%d  dim0:%lld\n", len, ndim, numpyType, itemsize, array_flags, (INT64)dims[0]);
+      printf("!!!out of memory allocating numpy array size:%llu  dims:%d  dtype:%d  itemsize:%lld  flags:%d  dim0:%lld\n", len, ndim, numpyType, itemsize, array_flags, (int64_t)dims[0]);
       return nullptr;
    }
 
@@ -772,7 +772,7 @@ PyArrayObject* AllocateNumpyArrayForData(int ndim, npy_intp* dims, INT32 numpyTy
 
 //-----------------------------------------------------------------------------------
 // Check recycle pool
-PyArrayObject* AllocateLikeNumpyArray(PyArrayObject* inArr, INT32 numpyType) {
+PyArrayObject* AllocateLikeNumpyArray(PyArrayObject* inArr, int32_t numpyType) {
    const int ndim = PyArray_NDIM(inArr);
    npy_intp* const dims = PyArray_DIMS(inArr);
 
@@ -807,7 +807,7 @@ PyArrayObject* AllocateLikeNumpyArray(PyArrayObject* inArr, INT32 numpyType) {
 //-----------------------------------------------------------------------------------
 // Check recycle pool
 PyArrayObject* AllocateLikeResize(PyArrayObject* inArr, npy_intp rowSize) {
-   INT32 numpyType = PyArray_TYPE(inArr);
+   int32_t numpyType = PyArray_TYPE(inArr);
 
    PyArrayObject* result = NULL;
 
@@ -816,7 +816,7 @@ PyArrayObject* AllocateLikeResize(PyArrayObject* inArr, npy_intp rowSize) {
       return nullptr;
    }
    else if (PyTypeNum_ISSTRING(numpyType)) {
-      INT64 itemSize = NpyItemSize((PyObject*)inArr);
+      int64_t itemSize = NpyItemSize((PyObject*)inArr);
       result = AllocateNumpyArray(1, &rowSize, numpyType, itemSize);
    }
    else {
@@ -838,7 +838,7 @@ PyArrayObject* AllocateLikeResize(PyArrayObject* inArr, npy_intp rowSize) {
 PyObject* Empty(PyObject *self, PyObject *args) {
    PyObject*   inDimensions;
    int         dtype;
-   INT64       itemsize;
+   int64_t       itemsize;
    PyObject*   isFortran;
 
    if (!PyArg_ParseTuple(args, "O!iLO!",
@@ -849,7 +849,7 @@ PyObject* Empty(PyObject *self, PyObject *args) {
 
    const bool is_fortran = isFortran == Py_True;
 
-   INT64 dims = PyList_GET_SIZE(inDimensions);
+   int64_t dims = PyList_GET_SIZE(inDimensions);
    if (dims != 1) {
       Py_IncRef(Py_None);
       return Py_None;
@@ -876,8 +876,8 @@ PyObject* Empty(PyObject *self, PyObject *args) {
 }
 
 
-INT32 GetArrDType(PyArrayObject* inArr) {
-   INT32 dtype = PyArray_TYPE(inArr);
+int32_t GetArrDType(PyArrayObject* inArr) {
+   int32_t dtype = PyArray_TYPE(inArr);
 #if defined(RT_OS_WINDOWS)
 
    if (dtype == NPY_INT) {
@@ -925,56 +925,56 @@ INT32 GetArrDType(PyArrayObject* inArr) {
 // NPY_FLOAT      11
 // NPY_DOUBLE     12
 // NPY_LONGDOUBLE 13
-BOOL ConvertSingleItemArray(void* pInput, INT16 numpyInType, _m256all* pDest, INT16 numpyOutType) {
+BOOL ConvertSingleItemArray(void* pInput, int16_t numpyInType, _m256all* pDest, int16_t numpyOutType) {
 
-   INT64 value = 0;
+   int64_t value = 0;
    double fvalue=0;
 
    switch (numpyInType) {
 
    case NPY_BOOL:
-      value = (INT64)*(BOOL*)pInput;
+      value = (int64_t)*(BOOL*)pInput;
       fvalue =(double) value;
       break;
    case NPY_INT8:
-      value = (INT64)*(INT8*)pInput;
+      value = (int64_t)*(int8_t*)pInput;
       fvalue = (double)value;
       break;
    case NPY_UINT8:
-      value = (INT64)*(UINT8*)pInput;
+      value = (int64_t)*(uint8_t*)pInput;
       fvalue = (double)value;
       break;
    case NPY_INT16:
-      value = (INT64)*(INT16*)pInput;
+      value = (int64_t)*(int16_t*)pInput;
       fvalue = (double)value;
       break;
    case NPY_UINT16:
-      value = (INT64)*(UINT16*)pInput;
+      value = (int64_t)*(uint16_t*)pInput;
       fvalue = (double)value;
       break;
    CASE_NPY_UINT32:
-      value = (INT64)*(UINT32*)pInput;
+      value = (int64_t)*(uint32_t*)pInput;
       fvalue = (double)value;
       break;
    CASE_NPY_INT32:
-      value = (INT64)*(INT32*)pInput;
+      value = (int64_t)*(int32_t*)pInput;
       fvalue = (double)value;
       break;
    CASE_NPY_UINT64:
-      value = (INT64)*(UINT64*)pInput;
+      value = (int64_t)*(uint64_t*)pInput;
       fvalue = (double)value;
       break;
    CASE_NPY_INT64:
-      value = (INT64)*(INT64*)pInput;
+      value = (int64_t)*(int64_t*)pInput;
       fvalue = (double)value;
       break;
    case NPY_FLOAT32:
       fvalue = (double)*(float*)pInput;
-      value = (INT64)fvalue;
+      value = (int64_t)fvalue;
       break;
    case NPY_FLOAT64:
       fvalue = (double)*(double*)pInput;
-      value = (INT64)fvalue;
+      value = (int64_t)fvalue;
       break;
    default:
       return FALSE;
@@ -985,15 +985,15 @@ BOOL ConvertSingleItemArray(void* pInput, INT16 numpyInType, _m256all* pDest, IN
    case NPY_BOOL:
    case NPY_INT8:
    case NPY_UINT8:
-      pDest->i = _mm256_set1_epi8((INT8)value);
+      pDest->i = _mm256_set1_epi8((int8_t)value);
       break;
    case NPY_INT16:
    case NPY_UINT16:
-      pDest->i = _mm256_set1_epi16((INT16)value);
+      pDest->i = _mm256_set1_epi16((int16_t)value);
       break;
    CASE_NPY_UINT32:
    CASE_NPY_INT32:
-      pDest->i = _mm256_set1_epi32((INT32)value);
+      pDest->i = _mm256_set1_epi32((int32_t)value);
       break;
    CASE_NPY_UINT64:
    CASE_NPY_INT64:
@@ -1031,7 +1031,7 @@ BOOL ConvertSingleItemArray(void* pInput, INT16 numpyInType, _m256all* pDest, IN
 // If inObject1 is a string or unicode, then ppDataIn is filled in with the itemsize
 //
 // NOTE: Cannot handle numpy scalar types like numpy.int32
-BOOL ConvertScalarObject(PyObject* inObject1, _m256all* pDest, INT16 numpyOutType, void** ppDataIn, INT64 *pItemSize) {
+BOOL ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyOutType, void** ppDataIn, int64_t *pItemSize) {
 
    *pItemSize = 0;
    *ppDataIn = pDest;
@@ -1041,7 +1041,7 @@ BOOL ConvertScalarObject(PyObject* inObject1, _m256all* pDest, INT16 numpyOutTyp
    LOGGING("In convert scalar object!  %d %d %d\n", numpyOutType, isNumpyScalarInteger, isPyBool);
 
    if (isPyBool || PyArray_IsScalar((inObject1), Bool)) {
-      INT64 value = 1;
+      int64_t value = 1;
       if (isPyBool) {
          if (inObject1 == Py_False)
             value = 0;
@@ -1056,15 +1056,15 @@ BOOL ConvertScalarObject(PyObject* inObject1, _m256all* pDest, INT16 numpyOutTyp
       case NPY_BOOL:
       case NPY_INT8:
       case NPY_UINT8:
-         pDest->i = _mm256_set1_epi8((INT8)value);
+         pDest->i = _mm256_set1_epi8((int8_t)value);
          break;
       case NPY_INT16:
       case NPY_UINT16:
-         pDest->i = _mm256_set1_epi16((INT16)value);
+         pDest->i = _mm256_set1_epi16((int16_t)value);
          break;
       CASE_NPY_UINT32:
       CASE_NPY_INT32:
-         pDest->i = _mm256_set1_epi32((INT32)value);
+         pDest->i = _mm256_set1_epi32((int32_t)value);
          break;
       CASE_NPY_UINT64:
       CASE_NPY_INT64:
@@ -1087,8 +1087,8 @@ BOOL ConvertScalarObject(PyObject* inObject1, _m256all* pDest, INT16 numpyOutTyp
       if (PyLong_Check(inObject1) || isNumpyScalarInteger) {
 
          int overflow = 0;
-         INT64 value;
-         UINT64 value2;
+         int64_t value;
+         uint64_t value2;
 
          if (!isNumpyScalarInteger) {
             value = PyLong_AsLongLongAndOverflow(inObject1, &overflow);
@@ -1102,7 +1102,7 @@ BOOL ConvertScalarObject(PyObject* inObject1, _m256all* pDest, INT16 numpyOutTyp
                value2 = PyLong_AsUnsignedLongLongMask(inObject1);
             }
             else {
-               value2 = (UINT64)value;
+               value2 = (uint64_t)value;
             }
          }
          else {
@@ -1127,22 +1127,22 @@ BOOL ConvertScalarObject(PyObject* inObject1, _m256all* pDest, INT16 numpyOutTyp
          switch (numpyOutType) {
          case NPY_BOOL:
          case NPY_INT8:
-            pDest->i = _mm256_set1_epi8((INT8)value);
+            pDest->i = _mm256_set1_epi8((int8_t)value);
             break;
          case NPY_UINT8:
-            pDest->i = _mm256_set1_epi8((UINT8)value2);
+            pDest->i = _mm256_set1_epi8((uint8_t)value2);
             break;
          case NPY_INT16:
-            pDest->i = _mm256_set1_epi16((INT16)value);
+            pDest->i = _mm256_set1_epi16((int16_t)value);
             break;
          case NPY_UINT16:
-            pDest->i = _mm256_set1_epi16((UINT16)value2);
+            pDest->i = _mm256_set1_epi16((uint16_t)value2);
             break;
          CASE_NPY_INT32:
-            pDest->i = _mm256_set1_epi32((INT32)value);
+            pDest->i = _mm256_set1_epi32((int32_t)value);
             break;
          CASE_NPY_UINT32:
-            pDest->i = _mm256_set1_epi32((UINT32)value2);
+            pDest->i = _mm256_set1_epi32((uint32_t)value2);
             break;
          CASE_NPY_INT64:
             pDest->ci.i1 = _mm_set1_epi64x(value);
@@ -1170,30 +1170,30 @@ BOOL ConvertScalarObject(PyObject* inObject1, _m256all* pDest, INT16 numpyOutTyp
          switch (numpyOutType) {
          case NPY_BOOL:
          case NPY_INT8:
-            pDest->i = _mm256_set1_epi8((INT8)value);
+            pDest->i = _mm256_set1_epi8((int8_t)value);
             break;
          case NPY_UINT8:
-            pDest->i = _mm256_set1_epi8((UINT8)value);
+            pDest->i = _mm256_set1_epi8((uint8_t)value);
             break;
          case NPY_INT16:
-            pDest->i = _mm256_set1_epi16((INT16)value);
+            pDest->i = _mm256_set1_epi16((int16_t)value);
             break;
          case NPY_UINT16:
-            pDest->i = _mm256_set1_epi16((UINT16)value);
+            pDest->i = _mm256_set1_epi16((uint16_t)value);
             break;
          CASE_NPY_UINT32:
-            pDest->i = _mm256_set1_epi32((UINT32)value);
+            pDest->i = _mm256_set1_epi32((uint32_t)value);
             break;
          CASE_NPY_INT32:
-            pDest->i = _mm256_set1_epi32((INT32)value);
+            pDest->i = _mm256_set1_epi32((int32_t)value);
             break;
          CASE_NPY_UINT64:
-            pDest->ci.i1 = _mm_set1_epi64x((UINT64)value);
-            pDest->ci.i2 = _mm_set1_epi64x((UINT64)value);
+            pDest->ci.i1 = _mm_set1_epi64x((uint64_t)value);
+            pDest->ci.i2 = _mm_set1_epi64x((uint64_t)value);
             break;
          CASE_NPY_INT64:
-            pDest->ci.i1 = _mm_set1_epi64x((INT64)value);
-            pDest->ci.i2 = _mm_set1_epi64x((INT64)value);
+            pDest->ci.i1 = _mm_set1_epi64x((int64_t)value);
+            pDest->ci.i2 = _mm_set1_epi64x((int64_t)value);
             break;
          case NPY_FLOAT32:
             pDest->s = _mm256_set1_ps((float)value);
@@ -1258,7 +1258,7 @@ BOOL ConvertScalarObject(PyObject* inObject1, _m256all* pDest, INT16 numpyOutTyp
 static PyObject *
 ThreadingMode(PyObject *self, PyObject *args)
 {
-   INT64 threadmode;
+   int64_t threadmode;
 
    if (!PyArg_ParseTuple(args, "L", &threadmode)) return NULL;
 
@@ -1309,7 +1309,7 @@ TestNumpy(PyObject *self, PyObject *args)
    if (PyLong_Check(scalarObject)) {
       // False/True will come as 0 and 1
       int overflow = 0;
-      INT64 val=PyLong_AsLongLongAndOverflow(scalarObject, &overflow);
+      int64_t val=PyLong_AsLongLongAndOverflow(scalarObject, &overflow);
       printf("long %lld\n", val);
 
    }
@@ -1324,7 +1324,7 @@ TestNumpy(PyObject *self, PyObject *args)
    if (PyArray_Check(scalarObject)) {
       PyArrayObject* arr = (PyArrayObject*)scalarObject;
 
-      printf("array itemsize=%lld, strides=%lld, flags=%d, length=%lld:\n", (INT64)PyArray_ITEMSIZE(arr), (INT64)(*PyArray_STRIDES(arr)), PyArray_FLAGS(arr), ArrayLength(arr));
+      printf("array itemsize=%lld, strides=%lld, flags=%d, length=%lld:\n", (int64_t)PyArray_ITEMSIZE(arr), (int64_t)(*PyArray_STRIDES(arr)), PyArray_FLAGS(arr), ArrayLength(arr));
 
       PyObject* pBase = PyArray_BASE((PyArrayObject*)scalarObject);
 
@@ -1376,10 +1376,10 @@ static bool g_IsPreciseTime = false;
 
 //------------------------------------
 // Returns windows time in Nanos
-__inline static UINT64 GetWindowsTime() {
+__inline static uint64_t GetWindowsTime() {
    FILETIME timeNow;
    g_GetSystemTime(&timeNow);
-   return (*(UINT64*)&timeNow * 100) - 11644473600000000000L;
+   return (*(uint64_t*)&timeNow * 100) - 11644473600000000000L;
 }
 
 //-------------------------------------------------------------------
@@ -1418,7 +1418,7 @@ static CTimeStamp* g_TimeStamp = new CTimeStamp();
 
 
 //---------------------------------------------------------
-// Returns and INT64 nanosecs since unix epoch
+// Returns and int64_t nanosecs since unix epoch
 static PyObject* GetNanoTime(PyObject* self, PyObject* args) {
 
    // return nano time since Unix Epoch
@@ -1426,7 +1426,7 @@ static PyObject* GetNanoTime(PyObject* self, PyObject* args) {
 }
 
 //---------------------------------------------------------
-// Returns and UINT64 timestamp counter
+// Returns and uint64_t timestamp counter
 static PyObject* GetTSC(PyObject* self, PyObject* args) {
 
    // return tsc
@@ -1459,7 +1459,7 @@ static __inline__ unsigned long long rdtsc(void)
 }
 
 //---------------------------------------------------------
-// Returns and UINT64 timestamp counter
+// Returns and uint64_t timestamp counter
 static PyObject* GetTSC(PyObject* self, PyObject* args) {
 
    // return tsc
@@ -1467,7 +1467,7 @@ static PyObject* GetTSC(PyObject* self, PyObject* args) {
 }
 
 //---------------------------------------------------------
-// Returns and INT64 nanosecs since unix epoch
+// Returns and int64_t nanosecs since unix epoch
 static PyObject* GetNanoTime(PyObject* self, PyObject* args) {
 
    // return nano time since Unix Epoch
@@ -1479,7 +1479,7 @@ static PyObject* GetNanoTime(PyObject* self, PyObject* args) {
 
 //---------------------------------------------------------
 // Returns nanoseconds since utc epoch
-UINT64 GetUTCNanos() {
+uint64_t GetUTCNanos() {
 #if defined(_WIN32)
    return GetWindowsTime();
 #else
@@ -1498,7 +1498,7 @@ static PyObject* GetThreadWakeUp(PyObject* self, PyObject* args) {
 //---------------------------------------------------------
 // Returns curent thread wakeup setting to existing
 static PyObject* SetThreadWakeUp(PyObject* self, PyObject* args) {
-   INT64 newWakeup = 1;
+   int64_t newWakeup = 1;
    if (!PyArg_ParseTuple(args, "L", &newWakeup)) {
       return NULL;
    }
@@ -1719,7 +1719,7 @@ static PyModuleDef CSigMathUtilModule = {
 // For Python version 3,  PyInit_{module_name} must be used as this function is called when the module is imported
 PyMODINIT_FUNC PyInit_riptide_cpp() {
 
-   INT32 count = 0;
+   int32_t count = 0;
 
    // Count up the
    for (int i = 0; i < 1000; i++) {
@@ -1735,7 +1735,7 @@ PyMODINIT_FUNC PyInit_riptide_cpp() {
    InitRecycler();
 
    // allocate plus one because last one is sentinel fulled with nulls
-   INT64 allocSize = sizeof(PyMethodDef) * (count + 1);
+   int64_t allocSize = sizeof(PyMethodDef) * (count + 1);
 
    // Allocate a new array
    PyMethodDef* pNewMethods = (PyMethodDef*)PYTHON_ALLOC(allocSize);
@@ -1943,20 +1943,20 @@ PyMODINIT_FUNC PyInit_riptide_cpp() {
 }
 
 //-------------------------------------------------------------------------
-//INT64 default1 = -9223372036854775808L;
-static INT64  gDefaultInt64 = 0x8000000000000000;
-static INT32  gDefaultInt32 = 0x80000000;
-static UINT16 gDefaultInt16 = 0x8000;
-static UINT8  gDefaultInt8 = 0x80;
+//int64_t default1 = -9223372036854775808L;
+static int64_t  gDefaultInt64 = 0x8000000000000000;
+static int32_t  gDefaultInt32 = 0x80000000;
+static uint16_t gDefaultInt16 = 0x8000;
+static uint8_t  gDefaultInt8 = 0x80;
 
-static UINT64 gDefaultUInt64 = 0xFFFFFFFFFFFFFFFF;
-static UINT32 gDefaultUInt32 = 0xFFFFFFFF;
-static UINT16 gDefaultUInt16 = 0xFFFF;
-static UINT8  gDefaultUInt8 = 0xFF;
+static uint64_t gDefaultUInt64 = 0xFFFFFFFFFFFFFFFF;
+static uint32_t gDefaultUInt32 = 0xFFFFFFFF;
+static uint16_t gDefaultUInt16 = 0xFFFF;
+static uint8_t  gDefaultUInt8 = 0xFF;
 
 static float  gDefaultFloat = NAN;
 static double gDefaultDouble = NAN;
-static INT8   gDefaultBool = 0;
+static int8_t   gDefaultBool = 0;
 static char   gString[1024] = { 0,0,0,0 };
 
 //----------------------------------------------------
@@ -2004,28 +2004,28 @@ void* GetDefaultForType(int numpyInType) {
 int GetNumpyType(bool value) {
    return NPY_BOOL;
 }
-int GetNumpyType(INT8 value) {
+int GetNumpyType(int8_t value) {
    return NPY_INT8;
 }
-int GetNumpyType(INT16 value) {
+int GetNumpyType(int16_t value) {
    return NPY_INT16;
 }
-int GetNumpyType(INT32 value) {
+int GetNumpyType(int32_t value) {
    return NPY_INT32;
 }
-int GetNumpyType(INT64 value) {
+int GetNumpyType(int64_t value) {
    return NPY_INT64;
 }
-int GetNumpyType(UINT8 value) {
+int GetNumpyType(uint8_t value) {
    return NPY_UINT8;
 }
-int GetNumpyType(UINT16 value) {
+int GetNumpyType(uint16_t value) {
    return NPY_UINT16;
 }
-int GetNumpyType(UINT32 value) {
+int GetNumpyType(uint32_t value) {
    return NPY_UINT32;
 }
-int GetNumpyType(UINT64 value) {
+int GetNumpyType(uint64_t value) {
    return NPY_UINT64;
 }
 int GetNumpyType(float value) {
@@ -2045,7 +2045,7 @@ int GetNumpyType(char* value) {
 // Returns FALSE if cannot upcast
 // Input: numpyInType1, numpyInType2
 // Output: convertType1, convertType2
-BOOL GetUpcastType(int numpyInType1, int numpyInType2, int& convertType1, int& convertType2, INT64 funcNumber) {
+BOOL GetUpcastType(int numpyInType1, int numpyInType2, int& convertType1, int& convertType2, int64_t funcNumber) {
    if (numpyInType1 == numpyInType2) {
       convertType1 = numpyInType1;
       convertType2 = numpyInType1;
@@ -2107,7 +2107,7 @@ BOOL GetUpcastType(int numpyInType1, int numpyInType2, int& convertType1, int& c
 //  return value 0: one loop can process all data, FALSE = multiple loops
 //  NOTE: if return value is 0 and itemsze == stride, then vector math possible
 //
-int GetStridesAndContig(PyArrayObject* inArray, int& ndim, INT64& stride) {
+int GetStridesAndContig(PyArrayObject* inArray, int& ndim, int64_t& stride) {
    stride = PyArray_ITEMSIZE(inArray);
    int direction = 0;
    ndim = PyArray_NDIM(inArray);
@@ -2116,7 +2116,7 @@ int GetStridesAndContig(PyArrayObject* inArray, int& ndim, INT64& stride) {
       if (ndim > 1) {
          // at least two strides
          int ndims = PyArray_NDIM(inArray);
-         INT64 lastStride = PyArray_STRIDE(inArray, ndims - 1);
+         int64_t lastStride = PyArray_STRIDE(inArray, ndims - 1);
          if (lastStride == stride) {
             // contiguous with one of the dimensions having length 1
          }
@@ -2125,7 +2125,7 @@ int GetStridesAndContig(PyArrayObject* inArray, int& ndim, INT64& stride) {
                // Row Major - 'C' Style
                // work backwards
                int currentdim = ndims - 1;
-               INT64 curStrideLen = lastStride;
+               int64_t curStrideLen = lastStride;
                while (currentdim != 0) {
                   curStrideLen *= PyArray_DIM(inArray, currentdim);
                   LOGGING("'C' %lld vs %lld  dim: %lld  stride: %lld \n", curStrideLen, PyArray_STRIDE(inArray, currentdim - 1), PyArray_DIM(inArray, currentdim - 1), lastStride);
@@ -2139,7 +2139,7 @@ int GetStridesAndContig(PyArrayObject* inArray, int& ndim, INT64& stride) {
             else {
                // Col Major - 'F' Style
                int currentdim = 0;
-               INT64 curStrideLen = stride;
+               int64_t curStrideLen = stride;
                while (currentdim != (ndims - 1)) {
                   curStrideLen *= PyArray_DIM(inArray, currentdim);
                   LOGGING("'F' %lld vs %lld  dim:  %lld   stride: %lld \n", curStrideLen, PyArray_STRIDE(inArray, currentdim + 1), PyArray_DIM(inArray, currentdim + 1), stride);

--- a/src/RipTide.cpp
+++ b/src/RipTide.cpp
@@ -85,8 +85,8 @@ stScalarType NpTypeObjects[MAX_NUMPY_TYPE] = {
    { NULL, 4,  NPY_INT },
    { NULL, 4,  NPY_UINT },
 #if defined(RT_OS_WINDOWS)
-   { NULL, 4,  NPY_INT32 },   // believe this is 8 bytes on Linux
-   { NULL, 4,  NPY_UINT32 },  // believe this is 8 bytes on Linux
+   { NULL, 4,  NPY_INT },   // believe this is 8 bytes on Linux
+   { NULL, 4,  NPY_UINT },  // believe this is 8 bytes on Linux
 #else
    { NULL, 8,  NPY_LONG },   // believe this is 8 bytes on Linux enum 7
    { NULL, 8,  NPY_ULONG },  // believe this is 8 bytes on Linux enum 8
@@ -118,8 +118,8 @@ const char* gNumpyTypeToString[NUMPY_LAST_TYPE] = {
    "NPY_INT",
    "NPY_UINT",
 #if defined(RT_OS_WINDOWS)
-   "NPY_INT32",   // not on linux
-   "NPY_UINT32",  // not on linux
+   "NPY_INT",   // not on linux
+   "NPY_UINT",  // not on linux
 #else
    "NPY_LONG64",   // not on linux
    "NPY_LONG64",  // not on linux
@@ -147,14 +147,14 @@ int32_t gNumpyTypeToSize[NUMPY_LAST_TYPE] = {
    1, //NPY_UBYTE,     2
    2, //NPY_SHORT,     3
    2, //NPY_USHORT,    4
-   4, //NPY_INT,       5 // TJD is this used or just NPY_INT32?
-   4, //NPY_UINT,      6 // TJD is this used or just NPY_UINT32?
+   4, //NPY_INT,       5 // TJD is this used or just NPY_INT?
+   4, //NPY_UINT,      6 // TJD is this used or just NPY_UINT?
 #if defined(RT_OS_WINDOWS)
-   4, //NPY_INT32,      7 // TODO: change to sizeof(long)
-   4, //NPY_UINT32,     8
+   4, //NPY_INT,      7 // TODO: change to sizeof(long)
+   4, //NPY_UINT,     8
 #else
-   8, //NPY_INT32,      7
-   8, //NPY_UINT32,     8
+   8, //NPY_INT,      7
+   8, //NPY_UINT,     8
 
 #endif
    8, //NPY_INT64,  9
@@ -177,7 +177,7 @@ int32_t gNumpyTypeToSize[NUMPY_LAST_TYPE] = {
 
 
 //---------------------------------------------------------------
-// Pass in a type such as np.int32 and a NPY_INT32 will be returned
+// Pass in a type such as np.int32 and a NPY_INT will be returned
 // returns -1 on failure adn set error string
 // otherwise returns NPY_TYPE
 int32_t TypeToDtype(PyTypeObject *out_dtype) {
@@ -200,7 +200,7 @@ int32_t TypeToDtype(PyTypeObject *out_dtype) {
 //---------------------------------------------
 // Return the objects dtype
 // Returns -1 on types > NPY_VOID suchas NPY_DATETIME,
-// otherwise the type number such as NPY_INT32 or NPY_FLOAT
+// otherwise the type number such as NPY_INT or NPY_FLOAT
 int32_t ObjectToDtype(PyArrayObject* obj) {
 
    int32_t result = PyArray_TYPE(obj);
@@ -881,10 +881,10 @@ int32_t GetArrDType(PyArrayObject* inArr) {
 #if defined(RT_OS_WINDOWS)
 
    if (dtype == NPY_INT) {
-      dtype = NPY_INT32;
+      dtype = NPY_INT;
    }
    if (dtype == NPY_UINT) {
-      dtype = NPY_UINT32;
+      dtype = NPY_UINT;
    }
 
 #else
@@ -918,8 +918,8 @@ int32_t GetArrDType(PyArrayObject* inArr) {
 // NPY_USHORT   4
 // NPY_INT      5
 // NPY_UINT     6
-// NPY_INT32      7
-// NPY_UINT32     8
+// NPY_INT      7
+// NPY_UINT     8
 // NPY_INT64      9
 // NPY_UINT64     10
 // NPY_FLOAT      11
@@ -952,13 +952,13 @@ bool ConvertSingleItemArray(void* pInput, int16_t numpyInType, _m256all* pDest, 
       value = (int64_t)*(uint16_t*)pInput;
       fvalue = (double)value;
       break;
-   case NPY_UINT32:
-//   case NPY_UINT: This enumeration is the same value as NPY_UINT32 above
+   case NPY_UINT:
+//   case NPY_UINT: This enumeration is the same value as NPY_UINT above
       value = (int64_t)*(uint32_t*)pInput;
       fvalue = (double)value;
       break;
-   case NPY_INT32:
-//   case NPY_INT: This enumeration is the same value as NPY_INT32 above
+   case NPY_INT:
+//   case NPY_INT: This enumeration is the same value as NPY_INT above
       value = (int64_t)*(int32_t*)pInput;
       fvalue = (double)value;
       break;
@@ -995,10 +995,10 @@ bool ConvertSingleItemArray(void* pInput, int16_t numpyInType, _m256all* pDest, 
    case NPY_UINT16:
       pDest->i = _mm256_set1_epi16((int16_t)value);
       break;
-   case NPY_UINT32:
-//   case NPY_UINT: This enumeration has the same value at NPY_UINT32 above
-   case NPY_INT32:
-//   case NPY_INT: This enumeration has the same value as NPY_INT32 above
+   case NPY_UINT:
+//   case NPY_UINT: This enumeration has the same value at NPY_UINT above
+   case NPY_INT:
+//   case NPY_INT: This enumeration has the same value as NPY_INT above
       pDest->i = _mm256_set1_epi32((int32_t)value);
       break;
    case NPY_UINT64:
@@ -1070,10 +1070,10 @@ bool ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyOutT
       case NPY_UINT16:
          pDest->i = _mm256_set1_epi16((int16_t)value);
          break;
-      case NPY_UINT32:
-//      case  NPY_UINT: This enumeration has the same value as NPY_UINT32 above
-      case NPY_INT32:
-//      case NPY_INT: This enumeration has the same value as NPY_INT32 above
+      case NPY_UINT:
+//      case  NPY_UINT: This enumeration has the same value as NPY_UINT above
+      case NPY_INT:
+//      case NPY_INT: This enumeration has the same value as NPY_INT above
          pDest->i = _mm256_set1_epi32((int32_t)value);
          break;
       case NPY_UINT64:
@@ -1150,12 +1150,12 @@ bool ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyOutT
          case NPY_UINT16:
             pDest->i = _mm256_set1_epi16((uint16_t)value2);
             break;
-         case NPY_INT32:
-//         case NPY_INT: This enumeration has the same value as NPY_INT32 above
+         case NPY_INT:
+//         case NPY_INT: This enumeration has the same value as NPY_INT above
             pDest->i = _mm256_set1_epi32((int32_t)value);
             break;
-         case NPY_UINT32:
-//         case NPY_UINT: This enumeration hasa the same value as NPY_UINT32 above
+         case NPY_UINT:
+//         case NPY_UINT: This enumeration hasa the same value as NPY_UINT above
             pDest->i = _mm256_set1_epi32((uint32_t)value2);
             break;
          case NPY_INT64:
@@ -1197,12 +1197,12 @@ bool ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyOutT
          case NPY_UINT16:
             pDest->i = _mm256_set1_epi16((uint16_t)value);
             break;
-         case NPY_UINT32:
-//         case NPY_UINT: This enumeration has the same value as NPY_UINT32 above
+         case NPY_UINT:
+//         case NPY_UINT: This enumeration has the same value as NPY_UINT above
             pDest->i = _mm256_set1_epi32((uint32_t)value);
             break;
-         case NPY_INT32:
-//         case NPY_INT: This enumeration has the same value as NPY_INT32 above
+         case NPY_INT:
+//         case NPY_INT: This enumeration has the same value as NPY_INT above
             pDest->i = _mm256_set1_epi32((int32_t)value);
             break;
          case NPY_UINT64:
@@ -2001,8 +2001,8 @@ void* GetDefaultForType(int numpyInType) {
    case NPY_INT16:
       pgDefault = &gDefaultInt16;
       break;
-   case NPY_INT32: 
-//   case NPY_INT: This is the same numeric value as NPY_INT32 above
+   case NPY_INT: 
+//   case NPY_INT: This is the same numeric value as NPY_INT above
       pgDefault = &gDefaultInt32;
       break;
    case NPY_INT64:
@@ -2015,8 +2015,8 @@ void* GetDefaultForType(int numpyInType) {
    case NPY_UINT16:
       pgDefault = &gDefaultUInt16;
       break;
-   case NPY_UINT32:
-//   case NPY_UINT: This is the same numeric value as NPY_UINT32 above
+   case NPY_UINT:
+//   case NPY_UINT: This is the same numeric value as NPY_UINT above
       pgDefault = &gDefaultUInt32;
       break;
    case NPY_UINT64:
@@ -2046,7 +2046,7 @@ int GetNumpyType(int16_t value) {
    return NPY_INT16;
 }
 int GetNumpyType(int32_t value) {
-   return NPY_INT32;
+   return NPY_INT;
 }
 int GetNumpyType(int64_t value) {
    return NPY_INT64;
@@ -2058,7 +2058,7 @@ int GetNumpyType(uint16_t value) {
    return NPY_UINT16;
 }
 int GetNumpyType(uint32_t value) {
-   return NPY_UINT32;
+   return NPY_UINT;
 }
 int GetNumpyType(uint64_t value) {
    return NPY_UINT64;

--- a/src/RipTide.h
+++ b/src/RipTide.h
@@ -78,17 +78,17 @@ static const int MAX_NUMPY_TYPE = 24;
 
 // Conversion related routines
 extern stScalarType NpTypeObjects[MAX_NUMPY_TYPE];
-extern INT32 TypeToDtype(PyTypeObject *out_dtype);
-extern INT32 ObjectToDtype(PyArrayObject* obj);
+extern int32_t TypeToDtype(PyTypeObject *out_dtype);
+extern int32_t ObjectToDtype(PyArrayObject* obj);
 
-extern INT32 gNumpyTypeToSize[NUMPY_LAST_TYPE];
+extern int32_t gNumpyTypeToSize[NUMPY_LAST_TYPE];
 
 // Boolean look up tables to go from packed bits to 1 bool per byte
-extern INT64 gBooleanLUT64[256];
-extern INT32 gBooleanLUT32[16];
+extern int64_t gBooleanLUT64[256];
+extern int32_t gBooleanLUT32[16];
 
-extern INT64 gBooleanLUT64Inverse[256];
-extern INT32 gBooleanLUT32Inverse[16];
+extern int64_t gBooleanLUT64Inverse[256];
+extern int32_t gBooleanLUT32Inverse[16];
 
 extern PyArray_Descr* g_pDescrLongLong;
 extern PyArray_Descr* g_pDescrULongLong;
@@ -99,8 +99,8 @@ typedef struct {
       npy_bool obval;
 } PyBoolScalarObject;
 
-extern BOOL GetUpcastType(int numpyInType1, int numpyInType2, int& convertType1, int& convertType2, INT64 funcNumber);
-extern int GetStridesAndContig(PyArrayObject* inArray, int& ndim, INT64& stride);
+extern BOOL GetUpcastType(int numpyInType1, int numpyInType2, int& convertType1, int& convertType2, int64_t funcNumber);
+extern int GetStridesAndContig(PyArrayObject* inArray, int& ndim, int64_t& stride);
 
 /**
  * @brief Calculate the number of elements in an array with the given dimensions.
@@ -110,11 +110,11 @@ extern int GetStridesAndContig(PyArrayObject* inArray, int& ndim, INT64& stride)
  * @return npy_intp The number of elements in the array.
  * @note Similar to the numpy PyArray_MultiplyList() function.
  */
-extern INT64 CalcArrayLength(int ndim, npy_intp* dims);
+extern int64_t CalcArrayLength(int ndim, npy_intp* dims);
 
 // for speed and to ensure dim of 0 has length of 0
-inline static INT64 CALC_ARRAY_LENGTH(int ndim, npy_intp* dims) {
-   INT64 length = 1;
+inline static int64_t CALC_ARRAY_LENGTH(int ndim, npy_intp* dims) {
+   int64_t length = 1;
 
    // handle case of zero length array
    if (dims && ndim > 0) {
@@ -142,7 +142,7 @@ inline static INT64 CALC_ARRAY_LENGTH(int ndim, npy_intp* dims) {
  * @return PyArrayObject* The allocated array object, or nullptr if an error occurred.
  * @note if the @p dtype is NPY_STRING or NPY_UNICODE -- then @p itemsize is valid.
  */
-extern PyArrayObject* AllocateNumpyArray(int ndim, npy_intp* dims, INT32 numpyType, INT64 itemsize = 0, BOOL fortran_array = FALSE, npy_intp* strides = nullptr);
+extern PyArrayObject* AllocateNumpyArray(int ndim, npy_intp* dims, int32_t numpyType, int64_t itemsize = 0, BOOL fortran_array = FALSE, npy_intp* strides = nullptr);
 
 /**
  * @brief Allocate a numpy array (or FastArray) backed by an existing data buffer.
@@ -157,19 +157,19 @@ extern PyArrayObject* AllocateNumpyArray(int ndim, npy_intp* dims, INT32 numpyTy
  * @return PyObject* The allocated PyArrayObject object; or nullptr if @p data is nullptr or an error occurred.
  * @note if the @p dtype is NPY_STRING or NPY_UNICODE -- then @p itemsize is valid.
  */
-extern PyArrayObject* AllocateNumpyArrayForData(int ndim, npy_intp* dims, INT32 numpyType, INT64 itemsize, char* data, int array_flags, npy_intp* strides = nullptr);
+extern PyArrayObject* AllocateNumpyArrayForData(int ndim, npy_intp* dims, int32_t numpyType, int64_t itemsize, char* data, int array_flags, npy_intp* strides = nullptr);
 
-extern PyArrayObject* AllocateLikeNumpyArray(PyArrayObject* inArr, INT32 numpyType);
+extern PyArrayObject* AllocateLikeNumpyArray(PyArrayObject* inArr, int32_t numpyType);
 extern PyArrayObject* AllocateLikeResize(PyArrayObject* inArr, npy_intp rowSize);
 
-extern INT32 GetArrDType(PyArrayObject* inArr);
-extern BOOL ConvertScalarObject(PyObject* inObject1, _m256all* pDest, INT16 numpyType, void** pDataIn, INT64 *pItemSize);
-extern BOOL ConvertSingleItemArray(void* pInput, INT16 numpyInType, _m256all* pDest, INT16 numpyType);
+extern int32_t GetArrDType(PyArrayObject* inArr);
+extern BOOL ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyType, void** pDataIn, int64_t *pItemSize);
+extern BOOL ConvertSingleItemArray(void* pInput, int16_t numpyInType, _m256all* pDest, int16_t numpyType);
 extern PyArrayObject* EnsureContiguousArray(PyArrayObject* inObject);
 
-extern INT64 NpyItemSize(PyObject *self);
-extern const char* NpyToString(INT32 numpyType);
-extern INT32 NpyToSize(INT32 numpyType);
+extern int64_t NpyItemSize(PyObject *self);
+extern const char* NpyToString(int32_t numpyType);
+extern int32_t NpyToSize(int32_t numpyType);
 
 /**
  * @brief Calculate the number of elements in the given array.
@@ -178,7 +178,7 @@ extern INT32 NpyToSize(INT32 numpyType);
  * @return npy_intp The number of elements in the array.
  * @note Similar to the numpy PyArray_Size() function.
  */
-extern INT64 ArrayLength(PyArrayObject* inArr);
+extern int64_t ArrayLength(PyArrayObject* inArr);
 
 extern PyTypeObject*  g_FastArrayType;
 extern PyObject*  g_FastArrayModule;
@@ -212,14 +212,14 @@ PyObject* SetFastArrayView(PyArrayObject* pArray);
 
 
 extern int GetNumpyType(bool value);
-extern int GetNumpyType(INT8 value);
-extern int GetNumpyType(INT16 value);
-extern int GetNumpyType(INT32 value);
-extern int GetNumpyType(INT64 value);
-extern int GetNumpyType(UINT8 value);
-extern int GetNumpyType(UINT16 value);
-extern int GetNumpyType(UINT32 value);
-extern int GetNumpyType(UINT64 value);
+extern int GetNumpyType(int8_t value);
+extern int GetNumpyType(int16_t value);
+extern int GetNumpyType(int32_t value);
+extern int GetNumpyType(int64_t value);
+extern int GetNumpyType(uint8_t value);
+extern int GetNumpyType(uint16_t value);
+extern int GetNumpyType(uint32_t value);
+extern int GetNumpyType(uint64_t value);
 extern int GetNumpyType(float value);
 extern int GetNumpyType(double value);
 extern int GetNumpyType(long double value);
@@ -227,7 +227,7 @@ extern int GetNumpyType(char* value);
 
 //---------------------------------------------------------
 // Returns nanoseconds since utc epoch
-extern UINT64 GetUTCNanos();
+extern uint64_t GetUTCNanos();
 
 template <typename T>
 static void* GetInvalid() {
@@ -236,7 +236,7 @@ static void* GetInvalid() {
 
 PyFunctionObject* GetFunctionObject(PyObject* arg1);
 
-// INT32 invalid index used
+// int32_t invalid index used
 #define INVALID_INDEX -214783648
 
 // mark invalid index with -1 because it will always

--- a/src/RipTide.h
+++ b/src/RipTide.h
@@ -1,4 +1,5 @@
 #pragma once
+
 // Hack because debug builds force python36_d.lib
 #ifdef _DEBUG
 #undef _DEBUG
@@ -99,7 +100,7 @@ typedef struct {
       npy_bool obval;
 } PyBoolScalarObject;
 
-extern BOOL GetUpcastType(int numpyInType1, int numpyInType2, int& convertType1, int& convertType2, int64_t funcNumber);
+extern bool GetUpcastType(int numpyInType1, int numpyInType2, int& convertType1, int& convertType2, int64_t funcNumber);
 extern int GetStridesAndContig(PyArrayObject* inArray, int& ndim, int64_t& stride);
 
 /**
@@ -142,7 +143,7 @@ inline static int64_t CALC_ARRAY_LENGTH(int ndim, npy_intp* dims) {
  * @return PyArrayObject* The allocated array object, or nullptr if an error occurred.
  * @note if the @p dtype is NPY_STRING or NPY_UNICODE -- then @p itemsize is valid.
  */
-extern PyArrayObject* AllocateNumpyArray(int ndim, npy_intp* dims, int32_t numpyType, int64_t itemsize = 0, BOOL fortran_array = FALSE, npy_intp* strides = nullptr);
+extern PyArrayObject* AllocateNumpyArray(int ndim, npy_intp* dims, int32_t numpyType, int64_t itemsize = 0, bool fortran_array = false, npy_intp* strides = nullptr);
 
 /**
  * @brief Allocate a numpy array (or FastArray) backed by an existing data buffer.
@@ -163,8 +164,8 @@ extern PyArrayObject* AllocateLikeNumpyArray(PyArrayObject* inArr, int32_t numpy
 extern PyArrayObject* AllocateLikeResize(PyArrayObject* inArr, npy_intp rowSize);
 
 extern int32_t GetArrDType(PyArrayObject* inArr);
-extern BOOL ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyType, void** pDataIn, int64_t *pItemSize);
-extern BOOL ConvertSingleItemArray(void* pInput, int16_t numpyInType, _m256all* pDest, int16_t numpyType);
+extern bool ConvertScalarObject(PyObject* inObject1, _m256all* pDest, int16_t numpyType, void** pDataIn, int64_t *pItemSize);
+extern bool ConvertSingleItemArray(void* pInput, int16_t numpyInType, _m256all* pDest, int16_t numpyType);
 extern PyArrayObject* EnsureContiguousArray(PyArrayObject* inObject);
 
 extern int64_t NpyItemSize(PyObject *self);
@@ -183,12 +184,12 @@ extern int64_t ArrayLength(PyArrayObject* inArr);
 extern PyTypeObject*  g_FastArrayType;
 extern PyObject*  g_FastArrayModule;
 
-static inline BOOL IsFastArrayView(PyArrayObject* pArray) {
+static inline bool IsFastArrayView(PyArrayObject* pArray) {
    return (pArray->ob_base.ob_type == g_FastArrayType);
 }
 
 // Optimistic faster way to check for array (most common check)
-static inline BOOL IsFastArrayOrNumpy(PyArrayObject* pArray) {
+static inline bool IsFastArrayOrNumpy(PyArrayObject* pArray) {
    PyTypeObject* pto=   pArray->ob_base.ob_type;
    // consider pto->tp_base for Categoricals
    return ((pto == g_FastArrayType) || (pto == &PyArray_Type) || PyType_IsSubtype(pto, &PyArray_Type));

--- a/src/SDSFile.cpp
+++ b/src/SDSFile.cpp
@@ -887,7 +887,7 @@ typedef HRESULT(*SDS_SharedMemoryEnd)(
 typedef HRESULT(*SDS_SharedMemoryCopy)(
    const char*          pMappingName,
    PMAPPED_VIEW_STRUCT *pReturnStruct,
-   bool                 bTest);
+   int                 bTest);
 
 class SharedMemory {
 

--- a/src/SDSFile.cpp
+++ b/src/SDSFile.cpp
@@ -21,8 +21,8 @@
 #endif
 
 //found in riptide.h
-extern UINT64 GetUTCNanos();
-extern INT64 SumBooleanMask(const INT8* pIn, INT64 length);
+extern uint64_t GetUTCNanos();
+extern int64_t SumBooleanMask(const int8_t* pIn, int64_t length);
 
 //#define MATLAB_MODE 1
 
@@ -66,37 +66,37 @@ std::vector<std::string>   g_gatewaylist;
 #ifdef MATLAB_MODE
 //-------------------------------------------------------------------------
 // CHANGE TABLE FOR MATLAB
-//INT64 default1 = -9223372036854775808L;
-static INT64  gDefaultInt64 = 0;
-static INT32  gDefaultInt32 = 0;
-static UINT16 gDefaultInt16 = 0;
-static UINT8  gDefaultInt8 = 0;
+//int64_t default1 = -9223372036854775808L;
+static int64_t  gDefaultInt64 = 0;
+static int32_t  gDefaultInt32 = 0;
+static uint16_t gDefaultInt16 = 0;
+static uint8_t  gDefaultInt8 = 0;
 
-static UINT64 gDefaultUInt64 = 0;
-static UINT32 gDefaultUInt32 = 0;
-static UINT16 gDefaultUInt16 = 0;
-static UINT8  gDefaultUInt8 = 0;
+static uint64_t gDefaultUInt64 = 0;
+static uint32_t gDefaultUInt32 = 0;
+static uint16_t gDefaultUInt16 = 0;
+static uint8_t  gDefaultUInt8 = 0;
 
 static float  gDefaultFloat = std::numeric_limits<float>::quiet_NaN();
 static double gDefaultDouble = std::numeric_limits<double>::quiet_NaN();
 static long double gDefaultLongDouble = std::numeric_limits<long double>::quiet_NaN();
-static INT8   gDefaultBool = 0;
+static int8_t   gDefaultBool = 0;
 static char   gString[1024] = { 0,0,0,0 };
 #else
-static INT64  gDefaultInt64 = 0x8000000000000000;
-static INT32  gDefaultInt32 = 0x80000000;
-static UINT16 gDefaultInt16 = 0x8000;
-static UINT8  gDefaultInt8 = 0x80;
+static int64_t  gDefaultInt64 = 0x8000000000000000;
+static int32_t  gDefaultInt32 = 0x80000000;
+static uint16_t gDefaultInt16 = 0x8000;
+static uint8_t  gDefaultInt8 = 0x80;
 
-static UINT64 gDefaultUInt64 = 0xFFFFFFFFFFFFFFFF;
-static UINT32 gDefaultUInt32 = 0xFFFFFFFF;
-static UINT16 gDefaultUInt16 = 0xFFFF;
-static UINT8  gDefaultUInt8 = 0xFF;
+static uint64_t gDefaultUInt64 = 0xFFFFFFFFFFFFFFFF;
+static uint32_t gDefaultUInt32 = 0xFFFFFFFF;
+static uint16_t gDefaultUInt16 = 0xFFFF;
+static uint8_t  gDefaultUInt8 = 0xFF;
 
 static float  gDefaultFloat = std::numeric_limits<float>::quiet_NaN();
 static double gDefaultDouble = std::numeric_limits<double>::quiet_NaN();
 static long double gDefaultLongDouble = std::numeric_limits<long double>::quiet_NaN();
-static INT8   gDefaultBool = 0;
+static int8_t   gDefaultBool = 0;
 static char   gString[1024] = { 0,0,0,0 };
 
 #endif
@@ -104,7 +104,7 @@ static char   gString[1024] = { 0,0,0,0 };
 //----------------------------------------------------
 // returns pointer to a data type (of same size in memory) that holds the invalid value for the type
 // does not yet handle strings
-void* SDSGetDefaultType(int numpyInType) {
+void* SDSGetDefaultType(int32_t numpyInType) {
    void* pgDefault = &gDefaultInt64;
 
    switch (numpyInType) {
@@ -114,7 +114,7 @@ void* SDSGetDefaultType(int numpyInType) {
       break;
    case SDS_LONGDOUBLE: pgDefault = &gDefaultLongDouble;
       break;
-      // BOOL should not really have a default type
+      // bool should not really have a default type
    case SDS_BOOL:   pgDefault = &gDefaultBool;
       break;
    case SDS_BYTE:   pgDefault = &gDefaultInt8;
@@ -151,12 +151,12 @@ void* SDSGetDefaultType(int numpyInType) {
 //===========================================
 // Buffer filled in when there is an error
 char g_errorbuffer[512] = { 0 };
-int  g_lastexception = 0;
+int32_t  g_lastexception = 0;
 
 //-----------------------------------------------------
 // platform independent error storage
 void SetErr_Format(
-   int   exception,
+   int32_t   exception,
    const char *format,
    ...
 ) {
@@ -186,7 +186,7 @@ static void PrintIfErrors() {
 }
 
 //------------------------------------------------------------
-static size_t CompressGetBound(int compMode, size_t srcSize) {
+static size_t CompressGetBound(int32_t compMode, size_t srcSize) {
    if (compMode == COMPRESSION_TYPE_ZSTD) {
       return ZSTD_compressBound(srcSize);
    }
@@ -197,9 +197,9 @@ static size_t CompressGetBound(int compMode, size_t srcSize) {
 
 
 //------------------------------------------------------------
-static size_t CompressData(int compMode, void* dst, size_t dstCapacity,
+static size_t CompressData(int32_t compMode, void* dst, size_t dstCapacity,
    const void* src, size_t srcSize,
-   int compressionLevel) {
+   int32_t compressionLevel) {
 
    if (compMode == COMPRESSION_TYPE_ZSTD) {
       return ZSTD_compress(dst, dstCapacity, src, srcSize, compressionLevel);
@@ -228,7 +228,7 @@ size_t ZSTD_decompress_stackmode(void* dst, size_t dstCapacity, const void* src,
 
 
 //------------------------------------------------------------
-static size_t DecompressData(ZSTD_DCtx* pDecompContext, int compMode, void* dst, size_t dstCapacity, const void* src, size_t srcSize) {
+static size_t DecompressData(ZSTD_DCtx* pDecompContext, int32_t compMode, void* dst, size_t dstCapacity, const void* src, size_t srcSize) {
 
    if (pDecompContext) {
       return ZSTD_decompressDCtx(pDecompContext, dst, dstCapacity, src, srcSize);
@@ -253,7 +253,7 @@ static size_t DecompressData(ZSTD_DCtx* pDecompContext, int compMode, void* dst,
 //------------------------------------------------------------
 // Returns <0 for error
 // else return bytes left
-static size_t DecompressDataPartial(int core, int compMode, void* dst, size_t dstCapacity, const void* src, size_t srcSize) {
+static size_t DecompressDataPartial(int32_t core, int32_t compMode, void* dst, size_t dstCapacity, const void* src, size_t srcSize) {
 
    if (core >= 0 && core < SDS_MAX_CORES) {
       ZSTD_DCtx* const dctx = ZSTD_createDCtx();
@@ -295,7 +295,7 @@ static size_t DecompressDataPartial(int core, int compMode, void* dst, size_t ds
 
 
 //------------------------------------------------------------
-static BOOL CompressIsError(int compMode, size_t code) {
+static bool CompressIsError(int32_t compMode, size_t code) {
    if (ZSTD_isError(code)) {
       SetErr_Format(SDS_VALUE_ERROR, "Decompression error: %s", ZSTD_getErrorName(code));
       return TRUE;
@@ -308,7 +308,7 @@ static BOOL CompressIsError(int compMode, size_t code) {
 
 // check to see if any errors were recorded
 // Returns TRUE if there was an error
-//static BOOL CheckErrors() {
+//static bool CheckErrors() {
 //
 //   if (g_lastexception) {
 //      return TRUE;
@@ -396,7 +396,7 @@ void SDS_DESTROY_EVENTHANDLE(SDS_EVENT_HANDLE handle) {
 
 //---------------------------------------------------
 // returns < 0 if file does not exist or error
-INT64 SDSFileSize(const char* fileName) {
+int64_t SDSFileSize(const char* fileName) {
    WIN32_FILE_ATTRIBUTE_DATA  fileInfo;
 
    if (GetFileAttributesEx(fileName, GetFileExInfoStandard, &fileInfo)) {
@@ -411,13 +411,13 @@ INT64 SDSFileSize(const char* fileName) {
 
 //---------------------------------------------------
 // Returns NULL on failure otherwise valid handle
-SDS_FILE_HANDLE SDSFileOpen(const char* fileName, BOOLEAN writeOption, BOOLEAN overlapped, BOOLEAN directIO, BOOLEAN appendOption)
+SDS_FILE_HANDLE SDSFileOpen(const char* fileName, bool writeOption, bool overlapped, bool directIO, bool appendOption)
 {
-   BOOLEAN WriteOption = writeOption;
-   BOOLEAN Overlapped = true; // overlapped;
-   BOOLEAN DirectIO = directIO;
+   bool WriteOption = writeOption;
+   bool Overlapped = true; // overlapped;
+   bool DirectIO = directIO;
 
-   INT32 filemode = OPEN_EXISTING;
+   int32_t filemode = OPEN_EXISTING;
 
    if (WriteOption) {
       if (appendOption) {
@@ -464,14 +464,14 @@ SDS_FILE_HANDLE SDSFileOpen(const char* fileName, BOOLEAN writeOption, BOOLEAN o
 }
 
 //---------------------------------------------------
-void SDSFileSeek(SDS_FILE_HANDLE handle, INT64 pos) {
+void SDSFileSeek(SDS_FILE_HANDLE handle, int64_t pos) {
 
-   INT64 result = 0;
+   int64_t result = 0;
 
    LARGE_INTEGER temp;
    temp.QuadPart = pos;
 
-   BOOL bResult =
+   bool bResult =
       SetFilePointerEx(handle, temp, (PLARGE_INTEGER)&result, SEEK_SET);
 
    if (!bResult)
@@ -484,17 +484,17 @@ void SDSFileSeek(SDS_FILE_HANDLE handle, INT64 pos) {
 
 //---------------------------------------------------
 // Returns bytes read
-INT64 SDSFileReadChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE Handle, void* buffer, INT64 bufferSize, INT64 BufferPos) {
+int64_t SDSFileReadChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE Handle, void* buffer, int64_t bufferSize, int64_t BufferPos) {
    //LogError("!! Suspicious code path for async read %s %d", FileName, LastError);
    OVERLAPPED OverlappedIO;
 
    OverlappedIO.hEvent = eventHandle;
    OverlappedIO.InternalHigh = 0;
    OverlappedIO.Internal = 0;
-   OverlappedIO.OffsetHigh = (UINT32)(BufferPos >> 32);
-   OverlappedIO.Offset = (UINT32)BufferPos;
+   OverlappedIO.OffsetHigh = (uint32_t)(BufferPos >> 32);
+   OverlappedIO.Offset = (uint32_t)BufferPos;
 
-   BOOL bReadDone;
+   bool bReadDone;
 
    OVERLAPPED* pos = &OverlappedIO;
    DWORD n;
@@ -503,7 +503,7 @@ INT64 SDSFileReadChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE Handle, voi
       //printf("!!!read buffer size too large %lld\n", bufferSize);
       // break it down
 
-      INT64 totalRead = 0;
+      int64_t totalRead = 0;
       char* cbuffer = (char*)buffer;
 
       while (bufferSize > MAX_READSIZE_ALLOWED) {
@@ -542,7 +542,7 @@ INT64 SDSFileReadChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE Handle, voi
             return 0;
          }
          else {
-            BOOL extraCheck = HasOverlappedIoCompleted(pos);
+            bool extraCheck = HasOverlappedIoCompleted(pos);
             if (!extraCheck) {
                printf("!! internal error reading... complete but not really\n");
             }
@@ -563,21 +563,21 @@ INT64 SDSFileReadChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE Handle, voi
 
 //---------------------------------------------------
 // Returns bytes read
-INT64 SDSFileWriteChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE Handle, void* buffer, INT64 bufferSize, INT64 BufferPos) {
+int64_t SDSFileWriteChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE Handle, void* buffer, int64_t bufferSize, int64_t BufferPos) {
    //LogError("!! Suspicious code path for async read %s %d", FileName, LastError);
    OVERLAPPED OverlappedIO;
 
    OverlappedIO.hEvent = eventHandle;
    OverlappedIO.InternalHigh = 0;
    OverlappedIO.Internal = 0;
-   OverlappedIO.OffsetHigh = (UINT32)(BufferPos >> 32);
-   OverlappedIO.Offset = (UINT32)BufferPos;
+   OverlappedIO.OffsetHigh = (uint32_t)(BufferPos >> 32);
+   OverlappedIO.Offset = (uint32_t)BufferPos;
 
    OVERLAPPED* pos = &OverlappedIO;
    DWORD n;
 
    if (bufferSize > MAX_READSIZE_ALLOWED) {
-      INT64 totalWritten = 0;
+      int64_t totalWritten = 0;
       char* cbuffer = (char*)buffer;
 
       while (bufferSize > MAX_READSIZE_ALLOWED) {
@@ -596,7 +596,7 @@ INT64 SDSFileWriteChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE Handle, vo
    }
 
    DWORD count = (DWORD)bufferSize;
-   BOOL bWriteDone = WriteFile(Handle, buffer, count, &n, pos);
+   bool bWriteDone = WriteFile(Handle, buffer, count, &n, pos);
 
    DWORD LastError = GetLastError();
    if (!bWriteDone && LastError == ERROR_IO_PENDING)
@@ -652,7 +652,7 @@ void SDS_DESTROY_EVENTHANDLE(SDS_EVENT_HANDLE handle) {
 #include <sys/stat.h>
 
 // returns < 0 if file does not exist or error
-INT64 SDSFileSize(const char* fileName) {
+int64_t SDSFileSize(const char* fileName) {
    struct stat statbuf;
    if (stat(fileName, &statbuf) < 0) {
       return -1;
@@ -661,13 +661,13 @@ INT64 SDSFileSize(const char* fileName) {
 }
 
 //---------------------------------------------------
-SDS_FILE_HANDLE SDSFileOpen(const char* fileName, BOOLEAN writeOption, BOOLEAN overlapped, BOOLEAN directIO, BOOLEAN appendOption)
+SDS_FILE_HANDLE SDSFileOpen(const char* fileName, bool writeOption, bool overlapped, bool directIO, bool appendOption)
 {
 
    errno = 0;
    SDS_FILE_HANDLE filehandle = 0;
 
-   int createFlags = 0;
+   int32_t createFlags = 0;
    if (writeOption) {
       if (appendOption) {
          // NOTE: possibly try first without O_CREAT
@@ -699,7 +699,7 @@ SDS_FILE_HANDLE SDSFileOpen(const char* fileName, BOOLEAN writeOption, BOOLEAN o
 }
 
 //---------------------------------------------------
-void SDSFileSeek(SDS_FILE_HANDLE handle, INT64 pos) {
+void SDSFileSeek(SDS_FILE_HANDLE handle, int64_t pos) {
 
    // not used
    return;
@@ -707,14 +707,14 @@ void SDSFileSeek(SDS_FILE_HANDLE handle, INT64 pos) {
 
 //---------------------------------------------------
 // Returns bytes read
-INT64 SDSFileReadChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE fileHandle, void* buffer, INT64 bufferSize, INT64 bufferPos) {
+int64_t SDSFileReadChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE fileHandle, void* buffer, int64_t bufferSize, int64_t bufferPos) {
 
    if (bufferSize > MAX_READSIZE_ALLOWED) {
       //printf("!!!read buffer size too large %lld\n", bufferSize);
       // break it down
 
-      INT64 totalRead = 0;
-      INT64 origSize = bufferSize;
+      int64_t totalRead = 0;
+      int64_t origSize = bufferSize;
       char* cbuffer = (char*)buffer;
 
       while (bufferSize > MAX_READSIZE_ALLOWED) {
@@ -755,11 +755,11 @@ INT64 SDSFileReadChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE fileHandle,
 
 //---------------------------------------------------
 // Returns bytes read
-INT64 SDSFileWriteChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE fileHandle, void* buffer, INT64 bufferSize, INT64 bufferPos) {
+int64_t SDSFileWriteChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE fileHandle, void* buffer, int64_t bufferSize, int64_t bufferPos) {
 
    if (bufferSize > MAX_READSIZE_ALLOWED) {
-      INT64 totalWritten = 0;
-      INT64 origSize = bufferSize;
+      int64_t totalWritten = 0;
+      int64_t origSize = bufferSize;
       char* cbuffer = (char*)buffer;
 
       while (bufferSize > MAX_READSIZE_ALLOWED) {
@@ -803,7 +803,7 @@ INT64 SDSFileWriteChunk(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE fileHandle
 //---------------------------------------------------
 void SDSFileClose(SDS_FILE_HANDLE handle) {
    errno = 0;
-   int result = close(handle);
+   int32_t result = close(handle);
    if (result < 0) {
       printf("Error closing file %s\n", strerror(errno));
    }
@@ -841,7 +841,7 @@ void AddSharedMemory(const char* name, PMAPPED_VIEW_STRUCT pmvs, void* pointer) 
 
 //------------------------------------------------------------------------------------------
 //
-void DelSharedMemory(void* pBase, INT64 length) {
+void DelSharedMemory(void* pBase, int64_t length) {
    auto it = g_SMMap.begin();
 
    while (it != g_SMMap.end())
@@ -859,10 +859,10 @@ void DelSharedMemory(void* pBase, INT64 length) {
 
 typedef SDS_EVENT_HANDLE(*SDS_CreateEventHandle)();
 typedef void(*SDS_DestroyEventHandle)(SDS_EVENT_HANDLE handle);
-typedef INT64(*SDS_FileSize)(const char* fileName);
-typedef SDS_FILE_HANDLE(*SDS_FileOpen)(const char* fileName, BOOLEAN writeOption, BOOLEAN overlapped, BOOLEAN directIO, BOOLEAN appendOption);
-typedef INT64(*SDS_FileReadChunk)(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE Handle, void* buffer, INT64 bufferSize, INT64 BufferPos);
-typedef INT64(*SDS_FileWriteChunk)(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE fileHandle, void* buffer, INT64 bufferSize, INT64 bufferPos);
+typedef int64_t(*SDS_FileSize)(const char* fileName);
+typedef SDS_FILE_HANDLE(*SDS_FileOpen)(const char* fileName, bool writeOption, bool overlapped, bool directIO, bool appendOption);
+typedef int64_t(*SDS_FileReadChunk)(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE Handle, void* buffer, int64_t bufferSize, int64_t BufferPos);
+typedef int64_t(*SDS_FileWriteChunk)(SDS_EVENT_HANDLE eventHandle, SDS_FILE_HANDLE fileHandle, void* buffer, int64_t bufferSize, int64_t bufferPos);
 typedef void(*SDS_FileClose)(SDS_FILE_HANDLE handle);
 
 class  SDSFileIO {
@@ -878,7 +878,7 @@ public:
 
 typedef HRESULT(*SDS_SharedMemoryBegin)(
    const char*              pMappingName,
-   INT64                Size,
+   int64_t                Size,
    PMAPPED_VIEW_STRUCT *pReturnStruct);
 
 typedef HRESULT(*SDS_SharedMemoryEnd)(
@@ -887,7 +887,7 @@ typedef HRESULT(*SDS_SharedMemoryEnd)(
 typedef HRESULT(*SDS_SharedMemoryCopy)(
    const char*          pMappingName,
    PMAPPED_VIEW_STRUCT *pReturnStruct,
-   BOOL                 bTest);
+   bool                 bTest);
 
 class SharedMemory {
 
@@ -899,7 +899,7 @@ public:
 
    char                    SharedMemoryName[SDS_MAX_FILENAME] = { 0 };
    PMAPPED_VIEW_STRUCT     pMapStruct = NULL;
-   INT64                   SharedMemorySize = 0;
+   int64_t                   SharedMemorySize = 0;
 
    //---------------------- METHODS ---------------------------
    //----------------------------------------------------------
@@ -913,7 +913,7 @@ public:
 
    //--------------------------------------------------
    //
-   char*   GetMemoryOffset(INT64 offset) {
+   char*   GetMemoryOffset(int64_t offset) {
       if (pMapStruct) {
          return ((char*)pMapStruct->BaseAddress) + offset;
       }
@@ -923,7 +923,7 @@ public:
 
    //--------------------------------------------------
    //
-   SDS_ARRAY_BLOCK*  GetArrayBlock(INT64 arrayNum) {
+   SDS_ARRAY_BLOCK*  GetArrayBlock(int64_t arrayNum) {
       SDS_ARRAY_BLOCK* pArrayBlock = (SDS_ARRAY_BLOCK*)GetMemoryOffset(GetFileHeader()->ArrayBlockOffset);
       return &pArrayBlock[arrayNum];
    }
@@ -931,7 +931,7 @@ public:
    //--------------------------------------------------
    //
    HRESULT Begin(
-      INT64                Size) {
+      int64_t                Size) {
 
       LOGGING("Allocating mem share %s with size %lld\n", SharedMemoryName, Size);
 
@@ -1086,7 +1086,7 @@ public:
    }
 
    // Returns 1 if item included
-   int IsIncluded(const char* stritem) {
+   int32_t IsIncluded(const char* stritem) {
 
       // If we have no inclusion list, then every item is accepted
       if (InclusionList.empty()) return 1;
@@ -1185,14 +1185,14 @@ public:
 
 //-------------------------------------------------------
 // Returns bytesPerRow 
-INT64
+int64_t
 GetBytesPerRow(SDS_ARRAY_BLOCK* pBlockInfo) {
    // calculate how many rows
    // rows based on the first dimension
-   INT64 bytesPerRow = 0;
-   INT64 dim0 = pBlockInfo->Dimensions[0];
-   INT64 arrayLength = dim0;
-   for (int i = 1; i < pBlockInfo->NDim; i++) {
+   int64_t bytesPerRow = 0;
+   int64_t dim0 = pBlockInfo->Dimensions[0];
+   int64_t arrayLength = dim0;
+   for (int32_t i = 1; i < pBlockInfo->NDim; i++) {
       arrayLength *= pBlockInfo->Dimensions[i];
    }
 
@@ -1208,13 +1208,13 @@ GetBytesPerRow(SDS_ARRAY_BLOCK* pBlockInfo) {
 // Returns both bytesPerBand and changes the bandCount
 // May pass in NULL for bandCount
 // ArrayLength is all the dimensions multiplied together
-INT64
-GetBytesPerBand(SDSArrayInfo* pArrayInfo, INT64 bandSize, INT64* bandCount=NULL) {
+int64_t
+GetBytesPerBand(SDSArrayInfo* pArrayInfo, int64_t bandSize, int64_t* bandCount=NULL) {
 
    // calculate how many bands
    // band based on the first dimension
-   INT64 bytesPerBand = 0;
-   INT64 dim0 = pArrayInfo->Dimensions[0];
+   int64_t bytesPerBand = 0;
+   int64_t dim0 = pArrayInfo->Dimensions[0];
 
    if (dim0 > 0) {
       bytesPerBand = (pArrayInfo->ArrayLength / dim0) * bandSize;
@@ -1236,31 +1236,31 @@ GetBytesPerBand(SDSArrayInfo* pArrayInfo, INT64 bandSize, INT64* bandCount=NULL)
 //
 static size_t 
 DecompressWithFilter(
-   INT64    compressedSize,      // pBlockInfo->ArrayCompressedSize
-   INT64    uncompressedSize,
-   INT64    arrayDataOffset,     // pBlockInfo->ArrayDataOffset
-   INT64    bytesPerRow,
+   int64_t    compressedSize,      // pBlockInfo->ArrayCompressedSize
+   int64_t    uncompressedSize,
+   int64_t    arrayDataOffset,     // pBlockInfo->ArrayDataOffset
+   int64_t    bytesPerRow,
    SDS_EVENT_HANDLE eventHandle,
    SDS_FILE_HANDLE fileHandle,
    void* tempBuffer,             // used to decompress
    void* destBuffer,             // the array buffer (final destination of data)
    SDS_FILTER* pFilter, 
-   INT64 rowOffset,              // the original row offset
-   INT64 stackIndex,             // when stacking, the stack #
-   int core,                     // thread # we are on
-   int compMode
+   int64_t rowOffset,              // the original row offset
+   int64_t stackIndex,             // when stacking, the stack #
+   int32_t core,                     // thread # we are on
+   int32_t compMode
 ) {
-   INT64 result = -1;
+   int64_t result = -1;
 
-   INT64 lastRow = pFilter->BoolMaskLength;
-   INT64 lastPossibleRow = (uncompressedSize - bytesPerRow) / bytesPerRow;
-   INT64 lastData = (bytesPerRow * lastRow);
+   int64_t lastRow = pFilter->BoolMaskLength;
+   int64_t lastPossibleRow = (uncompressedSize - bytesPerRow) / bytesPerRow;
+   int64_t lastData = (bytesPerRow * lastRow);
 
    // Check if user just wants the very first bytes
    // All set to TRUE in mask
    if (rowOffset ==0 && lastRow <= lastPossibleRow && lastRow == pFilter->BoolMaskTrueCount && lastData <= uncompressedSize) {
-      INT64 firstBand = 0;
-      INT64 firstData = bytesPerRow * firstBand;
+      int64_t firstBand = 0;
+      int64_t firstData = bytesPerRow * firstBand;
 
       LOGGING("special read: %lld  lastData:%lld\n", lastRow, lastData);
 
@@ -1274,7 +1274,7 @@ DecompressWithFilter(
          // TJD: More work to do here.  We read extra but we do not always have to.
          // Instead we could keep calling the stream decompressor, and if it needed more input, we could then read again
          // tested with 65536, but it was not enough
-         INT64 worstCase = CompressGetBound(compMode, lastData) + (2 * 65536);
+         int64_t worstCase = CompressGetBound(compMode, lastData) + (2 * 65536);
 
          LOGGING("[%d][%lld] worst case %lld v %lld  <-- DecompressWithFilter\n", core, stackIndex, worstCase, compressedSize);
          if (worstCase < compressedSize) {
@@ -1295,7 +1295,7 @@ DecompressWithFilter(
                // reduce the uncompressedSize since we do not need all the data
                uncompressedSize = lastData;
             }
-            INT64 dcSize = DecompressDataPartial(core, compMode, destBuffer, uncompressedSize, tempBuffer, compressedSize);
+            int64_t dcSize = DecompressDataPartial(core, compMode, destBuffer, uncompressedSize, tempBuffer, compressedSize);
 
             if (dcSize != uncompressedSize) {
                printf("[%d][%lld] MTDecompression band error direct size %lld vs %lld\n", core, stackIndex, dcSize, uncompressedSize);
@@ -1305,9 +1305,9 @@ DecompressWithFilter(
       }
    } else {
       //===================================================
-      // BOOLEAN MASK
+      // bool MASK
       //TODO: check for out of bounds lastBand and if found reduce masklength
-      INT64 lastRow = pFilter->BoolMaskLength;
+      int64_t lastRow = pFilter->BoolMaskLength;
 
       if (rowOffset > lastRow) {
          // nothing to do
@@ -1319,7 +1319,7 @@ DecompressWithFilter(
       // Make sure something to read
       //if (pFilter->pFilterInfo && pFilter->pFilterInfo[stackIndex].TrueCount > 0) {
       if (pFilter->BoolMaskTrueCount > 0) {
-         BOOL uncompressedRead = FALSE;
+         bool uncompressedRead = FALSE;
 
          if (compressedSize == uncompressedSize) {
             // this data was saved uncompressed
@@ -1341,7 +1341,7 @@ DecompressWithFilter(
 
             if (pTempBuffer) {
                // Read uncompressed chunk directly into our destination
-               INT64 dcSize = 0;
+               int64_t dcSize = 0;
 
                if (uncompressedRead) {
                   dcSize = DefaultFileIO.FileReadChunk(eventHandle, fileHandle, pTempBuffer, uncompressedSize, arrayDataOffset);
@@ -1352,7 +1352,7 @@ DecompressWithFilter(
 
                if (dcSize == uncompressedSize) {
                   char* pDest = (char*)destBuffer;
-                  INT64 sectionLength = uncompressedSize / bytesPerRow;
+                  int64_t sectionLength = uncompressedSize / bytesPerRow;
 
                   // User may have clipped data
                   if ((rowOffset + sectionLength) > pFilter->BoolMaskLength) {
@@ -1363,7 +1363,7 @@ DecompressWithFilter(
 
                   switch (bytesPerRow) {
                   case 1:
-                     for (INT64 i = 0; i < sectionLength; i++) {
+                     for (int64_t i = 0; i < sectionLength; i++) {
                         if (pMask[i]) {
                            *pDest = pTempBuffer[i];
                            pDest++;
@@ -1372,9 +1372,9 @@ DecompressWithFilter(
                      break;
                   case 2:
                      {
-                        INT16* pOut = (INT16*)pDest;
-                        INT16* pIn = (INT16*)pTempBuffer;
-                        for (INT64 i = 0; i < sectionLength; i++) {
+                        int16_t* pOut = (int16_t*)pDest;
+                        int16_t* pIn = (int16_t*)pTempBuffer;
+                        for (int64_t i = 0; i < sectionLength; i++) {
                            if (pMask[i]) {
                               *pOut++ = pIn[i];
                            }
@@ -1383,9 +1383,9 @@ DecompressWithFilter(
                      break;
                   case 4:
                   {
-                     INT32* pOut = (INT32*)pDest;
-                     INT32* pIn = (INT32*)pTempBuffer;
-                     for (INT64 i = 0; i < sectionLength; i++) {
+                     int32_t* pOut = (int32_t*)pDest;
+                     int32_t* pIn = (int32_t*)pTempBuffer;
+                     for (int64_t i = 0; i < sectionLength; i++) {
                         if (pMask[i]) {
                            *pOut++ = pIn[i];
                         }
@@ -1394,9 +1394,9 @@ DecompressWithFilter(
                   break;
                   case 8:
                   {
-                     INT64* pOut = (INT64*)pDest;
-                     INT64* pIn = (INT64*)pTempBuffer;
-                     for (INT64 i = 0; i < sectionLength; i++) {
+                     int64_t* pOut = (int64_t*)pDest;
+                     int64_t* pIn = (int64_t*)pTempBuffer;
+                     for (int64_t i = 0; i < sectionLength; i++) {
                         if (pMask[i]) {
                            *pOut++ = pIn[i];
                         }
@@ -1405,7 +1405,7 @@ DecompressWithFilter(
                   break;
 
                   default:
-                     for (INT64 i = 0; i < sectionLength; i++) {
+                     for (int64_t i = 0; i < sectionLength; i++) {
                         if (pMask[i]) {
                            memcpy(pDest, pTempBuffer + (i * bytesPerRow), bytesPerRow);
                            pDest += bytesPerRow;
@@ -1427,7 +1427,7 @@ DecompressWithFilter(
 //-----------------------------------------------------
 // Called when a filter is passed in to read
 // The data is banded.
-INT64
+int64_t
 ReadAndDecompressBandWithFilter(
    SDS_ARRAY_BLOCK *pBlockInfo,  // may contain banding information
    SDS_EVENT_HANDLE eventHandle,
@@ -1435,50 +1435,50 @@ ReadAndDecompressBandWithFilter(
    void*             tempBuffer, // used to decompress
    void*          destBuffer,    // the array buffer (final destination of data)
    SDS_FILTER*    pFilter,
-   INT64          rowOffset,             // the array # we are on
-   INT64          stackIndex,
-   int            core,                  // thread # we are on
-   int            compMode,
+   int64_t          rowOffset,             // the array # we are on
+   int64_t          stackIndex,
+   int32_t            core,                  // thread # we are on
+   int32_t            compMode,
 
-   INT64          bandDataSize,
-   INT64*         pBands
+   int64_t          bandDataSize,
+   int64_t*         pBands
 ) {
 
    // Check if all filtered out
    if (pFilter->pFilterInfo && pFilter->pFilterInfo[stackIndex].TrueCount == 0) return 0;
 
-   INT64 arrayDataOffset = pBlockInfo->ArrayDataOffset + bandDataSize;
+   int64_t arrayDataOffset = pBlockInfo->ArrayDataOffset + bandDataSize;
    char* destBandBuffer = (char*)destBuffer;
 
-   INT64 bytesPerRow = GetBytesPerRow(pBlockInfo);
+   int64_t bytesPerRow = GetBytesPerRow(pBlockInfo);
 
-   INT64 previousSize = 0;
+   int64_t previousSize = 0;
 
    // Is it a fancy mask filter?
-//   INT32 firstBand = rowOffset;
-   INT64 boolLength = pFilter->BoolMaskLength;
-   INT64 bandStart = 0;
-   INT64 bandIndex = 0;
-   INT64 result = -1;
-   INT64 runningTrueCount = 0;
+//   int32_t firstBand = rowOffset;
+   int64_t boolLength = pFilter->BoolMaskLength;
+   int64_t bandStart = 0;
+   int64_t bandIndex = 0;
+   int64_t result = -1;
+   int64_t runningTrueCount = 0;
 
    LOGGING("[%lld] seek to %lld  compsz:%lld  uncompsz:%lld  stackIndex:%lld  bytesPerRow:%lld  <-- ReadAndDecompressBandWithFilter\n", rowOffset, pBlockInfo->ArrayDataOffset, pBlockInfo->ArrayCompressedSize, pBlockInfo->ArrayUncompressedSize, stackIndex, bytesPerRow);
    
-   for (int i = 0; i < pBlockInfo->ArrayBandCount; i++) {
-      INT64 compressedSize = pBands[i] - previousSize;
+   for (int32_t i = 0; i < pBlockInfo->ArrayBandCount; i++) {
+      int64_t compressedSize = pBands[i] - previousSize;
       previousSize = pBands[i];
 
-      INT64 bandSize = pBlockInfo->ArrayBandSize;
-      INT64 uncompressedSize = pBlockInfo->ArrayBandSize * bytesPerRow;
+      int64_t bandSize = pBlockInfo->ArrayBandSize;
+      int64_t uncompressedSize = pBlockInfo->ArrayBandSize * bytesPerRow;
 
       // check for last band
       if ((i + 1) == pBlockInfo->ArrayBandCount) {
          uncompressedSize = pBlockInfo->ArrayUncompressedSize - (pBlockInfo->ArrayBandSize * bytesPerRow *i);
          bandSize = uncompressedSize / bytesPerRow;
       }
-      INT64 bandEnd = bandStart + bandSize;
+      int64_t bandEnd = bandStart + bandSize;
 
-      INT64 sectionLength = uncompressedSize / bytesPerRow;
+      int64_t sectionLength = uncompressedSize / bytesPerRow;
 
       // If the rest of the data is masked out, break
       if (rowOffset >= boolLength) {
@@ -1492,7 +1492,7 @@ ReadAndDecompressBandWithFilter(
 
       // Copy all TRUE rows
       bool*    pMask = pFilter->pBoolMask + rowOffset;
-      INT64 trueCount = SumBooleanMask((INT8*)pMask, sectionLength);
+      int64_t trueCount = SumBooleanMask((int8_t*)pMask, sectionLength);
 
       if (trueCount) {
 
@@ -1557,15 +1557,15 @@ ReadAndDecompressArrayBlockWithFilter(
    SDS_FILE_HANDLE fileHandle,
    void* tempBuffer,             // used to decompress
    void* destBuffer,             // the array buffer (final destination of data)
-   INT64 rowOffset,              // when stacking the orig row offset
+   int64_t rowOffset,              // when stacking the orig row offset
    SDS_FILTER* pFilter,
-   INT64 stackIndex,             // the stack # we are on
-   int core,                     // thread # we are on
-   int compMode
+   int64_t stackIndex,             // the stack # we are on
+   int32_t core,                     // thread # we are on
+   int32_t compMode
 ) {
 
-   INT64 result = -1;
-   BOOL didAlloc = FALSE;
+   int64_t result = -1;
+   bool didAlloc = FALSE;
 
    if (!tempBuffer) {
       LOGGING("Allocating tempbuffer of %lld\n", pBlockInfo->ArrayCompressedSize);
@@ -1582,8 +1582,8 @@ ReadAndDecompressArrayBlockWithFilter(
 
          // read in band header
          // allocate memory on the stack
-         INT64  bandDataSize = pBlockInfo->ArrayBandCount * sizeof(INT64);
-         INT64* pBands = (INT64*)alloca(bandDataSize);
+         int64_t  bandDataSize = pBlockInfo->ArrayBandCount * sizeof(int64_t);
+         int64_t* pBands = (int64_t*)alloca(bandDataSize);
          result = DefaultFileIO.FileReadChunk(eventHandle, fileHandle, pBands, bandDataSize, pBlockInfo->ArrayDataOffset);
 
          if (result == bandDataSize) {
@@ -1655,14 +1655,14 @@ ReadAndDecompressArrayBlock(
    SDS_FILE_HANDLE fileHandle, 
    void* tempBuffer,             // used to decompress
    void* destBuffer,             // the array buffer (final destination of data)
-   INT64 arrayIndex,             // the array # we are on
-   int core,                     // thread # we are on
-   int compMode
+   int64_t arrayIndex,             // the array # we are on
+   int32_t core,                     // thread # we are on
+   int32_t compMode
 ) {
 
 
-   INT64 result = -1;
-   INT64 compressedSize = pBlockInfo->ArrayCompressedSize;
+   int64_t result = -1;
+   int64_t compressedSize = pBlockInfo->ArrayCompressedSize;
 
    LOGGING("[%lld] seek to %lld  sz: %lld  <-- ReadAndDecompressArrayBlock\n", arrayIndex, pBlockInfo->ArrayDataOffset, pBlockInfo->ArrayCompressedSize);
 
@@ -1687,23 +1687,23 @@ ReadAndDecompressArrayBlock(
 
          // read in band
          // allocate memory on the stack
-         INT64  bandDataSize = pBlockInfo->ArrayBandCount * sizeof(INT64);
-         INT64* pBands = (INT64*)alloca(bandDataSize);
+         int64_t  bandDataSize = pBlockInfo->ArrayBandCount * sizeof(int64_t);
+         int64_t* pBands = (int64_t*)alloca(bandDataSize);
          result = DefaultFileIO.FileReadChunk(eventHandle, fileHandle, pBands, bandDataSize, pBlockInfo->ArrayDataOffset);
 
-         INT64 arrayDataOffset = pBlockInfo->ArrayDataOffset + bandDataSize;
+         int64_t arrayDataOffset = pBlockInfo->ArrayDataOffset + bandDataSize;
          char* destBandBuffer = (char*)destBuffer;
 
-         INT64 bytesPerRow = GetBytesPerRow(pBlockInfo);
+         int64_t bytesPerRow = GetBytesPerRow(pBlockInfo);
 
          if (result == bandDataSize) {
-            INT64 previousSize = 0;
+            int64_t previousSize = 0;
 
-            for (int i = 0; i < pBlockInfo->ArrayBandCount; i++) {
-               INT64 compressedSize = pBands[i] - previousSize;
+            for (int32_t i = 0; i < pBlockInfo->ArrayBandCount; i++) {
+               int64_t compressedSize = pBands[i] - previousSize;
                previousSize = pBands[i];
 
-               INT64 uncompressedSize = pBlockInfo->ArrayBandSize;
+               int64_t uncompressedSize = pBlockInfo->ArrayBandSize;
                uncompressedSize *= bytesPerRow;
 
                // check for last band
@@ -1723,7 +1723,7 @@ ReadAndDecompressArrayBlock(
 
                   result = DefaultFileIO.FileReadChunk(eventHandle, fileHandle, tempBuffer, compressedSize, arrayDataOffset);
                   //printf("[%d] decompressing  %d  size %lld  uncomp: %lld\n", core, i, compressedSize, uncompressedSize);
-                  INT64 dcSize = DecompressData(NULL, compMode, destBandBuffer, uncompressedSize, tempBuffer, compressedSize);
+                  int64_t dcSize = DecompressData(NULL, compMode, destBandBuffer, uncompressedSize, tempBuffer, compressedSize);
                   if (dcSize != uncompressedSize) {
                      printf("[%d][%lld][%d] MTDecompression band error size %lld vs %lld vs %lld\n", core, arrayIndex, i, dcSize, uncompressedSize, compressedSize);
                      result = -1;
@@ -1753,9 +1753,9 @@ ReadAndDecompressArrayBlock(
          }
          else {
 
-            INT64 uncompressedSize = pBlockInfo->ArrayUncompressedSize;
+            int64_t uncompressedSize = pBlockInfo->ArrayUncompressedSize;
 
-            INT64 dcSize = DecompressData(NULL, compMode, destBuffer, uncompressedSize, tempBuffer, compressedSize);
+            int64_t dcSize = DecompressData(NULL, compMode, destBuffer, uncompressedSize, tempBuffer, compressedSize);
 
             if (CompressIsError(compMode, dcSize)) {
                printf("[%d][%lld] MTDecompression error\n", core, arrayIndex);
@@ -1779,18 +1779,18 @@ ReadAndDecompressArrayBlock(
 // Called when starting a file
 void FillFileHeader(
    SDS_FILE_HEADER *pFileHeader,
-   INT64 fileOffset,
-   INT16 compMode,
-   INT16 compType,
-   INT32 compLevel,
-   INT16 fileType,
-   INT16 stackType,
-   INT32 authorId,
-   INT64 listNameLength,
-   INT64 listNameCount,
-   INT64 metaBlockSize,
-   INT64 arrayCount,
-   INT64 bandSize) {
+   int64_t fileOffset,
+   int16_t compMode,
+   int16_t compType,
+   int32_t compLevel,
+   int16_t fileType,
+   int16_t stackType,
+   int32_t authorId,
+   int64_t listNameLength,
+   int64_t listNameCount,
+   int64_t metaBlockSize,
+   int64_t arrayCount,
+   int64_t bandSize) {
 
    // To help detect old versions or corrupt files
    pFileHeader->SDSHeaderMagic = SDS_MAGIC;
@@ -1843,7 +1843,7 @@ void FillFileHeader(
    pFileHeader->FileOffset = fileOffset;
    pFileHeader->TimeStampUTCNanos = 0;
 
-   for (UINT64 i = 0; i < sizeof(pFileHeader->Reserved); i++) {
+   for (uint64_t i = 0; i < sizeof(pFileHeader->Reserved); i++) {
       pFileHeader->Reserved[i] = 0;  
    }
 }
@@ -1853,7 +1853,7 @@ void FillFileHeader(
 //void FillFileHeaderExtra(
 //   SDS_FILE_HEADER *pFileHeader,
 //   const char* sectionName,
-//   INT64 sectionNameLength) {
+//   int64_t sectionNameLength) {
 //
 //   pFileHeader->SectionBlockSize = 0;
 //   pFileHeader->SectionBlockOffset = 0;  // points to section directory if it exists
@@ -1864,7 +1864,7 @@ void FillFileHeader(
 //----------------------------------------
 // Returns: -1 file will be closed
 // Returns: 0 file is ok
-INT64 ReadFileHeader(SDS_FILE_HANDLE fileHandle, SDS_FILE_HEADER* pFileHeader, INT64 fileOffset, const char* fileName) {
+int64_t ReadFileHeader(SDS_FILE_HANDLE fileHandle, SDS_FILE_HEADER* pFileHeader, int64_t fileOffset, const char* fileName) {
    size_t bytesRead =
       DefaultFileIO.FileReadChunk(NULL, fileHandle, pFileHeader, sizeof(SDS_FILE_HEADER), fileOffset);
 
@@ -1896,14 +1896,14 @@ INT64 ReadFileHeader(SDS_FILE_HANDLE fileHandle, SDS_FILE_HEADER* pFileHeader, I
 // Returns sizeof new section
 // Returns pointer in *pListNames
 // NOTE: caller must WORKSPACE_FREE *pListNames
-INT64
+int64_t
    SDSSectionName::BuildSectionNamesAndOffsets(
       char** pListNames,                // Returned
       const char*  pNewSectionName,
-      INT64  newSectionOffset           // 0 Allowed
+      int64_t  newSectionOffset           // 0 Allowed
 ) {
    // alloc worst case scenario
-   INT64 allocSize = SDS_PAD_NUMBER((((SDS_MAX_SECTIONNAME + 8) * (SectionCount + 1)) + 1024));
+   int64_t allocSize = SDS_PAD_NUMBER((((SDS_MAX_SECTIONNAME + 8) * (SectionCount + 1)) + 1024));
 
    *pListNames = (char*)WORKSPACE_ALLOC(allocSize);
 
@@ -1915,7 +1915,7 @@ INT64
    char* pDest = *pListNames;
 
    // For all the section write out the section name and the fileoffset to the SDS_FILE_HEADER for that section
-   for (int i = 0; i < SectionCount; i++) {
+   for (int32_t i = 0; i < SectionCount; i++) {
       const char* pName = pSectionNames[i];
 
       // strcpy the name with a 0 char termination
@@ -1923,16 +1923,16 @@ INT64
 
       // after writing the name, write the new fileheader offset
       // Store the 64 bit offset
-      *(INT64*)pDest = pSectionOffsets[i];
-      pDest += sizeof(INT64);
+      *(int64_t*)pDest = pSectionOffsets[i];
+      pDest += sizeof(int64_t);
    }
 
    // strcpy
    while ((*pDest++ = *pNewSectionName++));
 
    // Store the 64 bit offset
-   *(INT64*)pDest = newSectionOffset;
-   pDest += sizeof(INT64);
+   *(int64_t*)pDest = newSectionOffset;
+   pDest += sizeof(int64_t);
 
    // return the size used
    return pDest - pStart;
@@ -1941,7 +1941,7 @@ INT64
 //--------------------------------------------
 // Also zero out pArrayNames, zero out pArrayEnums
 //
-void SDSSectionName::AllocateSectionData(INT64 sectionBlockCount, INT64 sectionSize) {
+void SDSSectionName::AllocateSectionData(int64_t sectionBlockCount, int64_t sectionSize) {
    SectionCount = sectionBlockCount;
    if (pSectionData != NULL) {
       printf("Double Allocation sectionData!!\n");
@@ -1950,11 +1950,11 @@ void SDSSectionName::AllocateSectionData(INT64 sectionBlockCount, INT64 sectionS
 
    // ZERO OUT
    pSectionNames = (const char**)WORKSPACE_ALLOC(SectionCount * sizeof(void*));
-   for (int i = 0; i < SectionCount; i++) {
+   for (int32_t i = 0; i < SectionCount; i++) {
       pSectionNames[i] = NULL;
    }
-   pSectionOffsets = (INT64*)WORKSPACE_ALLOC(SectionCount * sizeof(INT64));
-   for (int i = 0; i < SectionCount; i++) {
+   pSectionOffsets = (int64_t*)WORKSPACE_ALLOC(SectionCount * sizeof(int64_t));
+   for (int32_t i = 0; i < SectionCount; i++) {
       pSectionOffsets[i] = 0;
    }
 }
@@ -1982,20 +1982,20 @@ void SDSSectionName::DeleteSectionData() {
 // Returns the section names and offsets of sections written
 //
 // Called by DecompressFileIntenral
-void SDSSectionName::MakeListSections(const INT64 sectionBlockCount, const INT64 sectionByteSize) {
+void SDSSectionName::MakeListSections(const int64_t sectionBlockCount, const int64_t sectionByteSize) {
    const char* startSectionData = pSectionData;
    const char* pSections = pSectionData;
 
    // for every section
-   for (int i = 0; i < sectionBlockCount; i++) {
+   for (int32_t i = 0; i < sectionBlockCount; i++) {
       const char* pStart = pSections;
 
       // skip to end (search for 0 terminating char)
       while (*pSections++);
 
       // get the offset
-      INT64 value = *(INT64*)pSections;
-      pSections += sizeof(INT64);
+      int64_t value = *(int64_t*)pSections;
+      pSections += sizeof(int64_t);
 
       LOGGING("makelist section is %s, %d, offset at %lld\n", pStart, i, value);
 
@@ -2035,7 +2035,7 @@ char* SDSSectionName::MakeFirstSectionName() {
 // return list of strings (section names)
 // on success pSectionData is valid
 char* SDSSectionName::ReadListSections(SDS_FILE_HANDLE SDSFile, SDS_FILE_HEADER *pFileHeader) {
-   INT64 sectionSize = pFileHeader->SectionBlockSize;
+   int64_t sectionSize = pFileHeader->SectionBlockSize;
 
    if (sectionSize) {
       LOGGING("Section Block Count %lld,  sectionSize %lld, reserved %lld\n", pFileHeader->SectionBlockCount, sectionSize, pFileHeader->SectionBlockReservedSize);
@@ -2047,7 +2047,7 @@ char* SDSSectionName::ReadListSections(SDS_FILE_HANDLE SDSFile, SDS_FILE_HEADER 
          return NULL;
       }
 
-      INT64 bytesRead =
+      int64_t bytesRead =
          DefaultFileIO.FileReadChunk(NULL, SDSFile, pSectionData, sectionSize, pFileHeader->SectionBlockOffset);
 
       if (bytesRead != sectionSize) {
@@ -2082,25 +2082,25 @@ SDS_FILE_HANDLE StartCompressedFile(
    const char* fileName,
    SDS_FILE_HEADER* pFileHeader,
 
-   INT16 compType,
-   INT32 compLevel,
-   INT16 fileType,
-   INT16 stackType,
-   INT32 authorId,
+   int16_t compType,
+   int32_t compLevel,
+   int16_t fileType,
+   int16_t stackType,
+   int32_t authorId,
 
    const char* listNames,
-   INT64 listNameLength,
-   INT64 listNameCount,
+   int64_t listNameLength,
+   int64_t listNameCount,
 
    const char* strMeta,
-   INT64 strMetaLength,
-   INT64 arrayCount,
-   INT32 mode,       // COMPRESSION_MODE_COMPRESS_APPEND_FILE
+   int64_t strMetaLength,
+   int64_t arrayCount,
+   int32_t mode,       // COMPRESSION_MODE_COMPRESS_APPEND_FILE
    SDS_STRING_LIST* pFolderName,
-   INT64 bandSize,
+   int64_t bandSize,
    SDS_WRITE_INFO* pWriteInfo) {
 
-   INT64    fileOffset=0;
+   int64_t    fileOffset=0;
 
    // TODO: have an override mode for appending?
    if (mode == COMPRESSION_MODE_COMPRESS_APPEND_FILE) {
@@ -2132,7 +2132,7 @@ SDS_FILE_HANDLE StartCompressedFile(
 
    if (mode == COMPRESSION_MODE_COMPRESS_APPEND_FILE) {
       // Check to make sure the fileheader is valid before appending
-      INT64 result =
+      int64_t result =
          ReadFileHeader(fileHandle, pFileHeader, 0, fileName);
 
       if (result != 0) {
@@ -2143,7 +2143,7 @@ SDS_FILE_HANDLE StartCompressedFile(
 
    size_t dest_size = strMetaLength;
    void* dest = (void*)strMeta;
-   INT64 cSize = strMetaLength;
+   int64_t cSize = strMetaLength;
 
    // Check if we compress metadata
    if (compType == COMPRESSION_TYPE_ZSTD) {
@@ -2204,7 +2204,7 @@ SDS_FILE_HANDLE StartCompressedFile(
    //// PAD THE REST OUT
    //char* filler = (char*)WORKSPACE_ALLOC(SDS_PADSIZE);
    //memset(filler, 0, SDS_PADSIZE);
-   //INT64 diff = SDS_PAD_NUMBER(cSize);
+   //int64_t diff = SDS_PAD_NUMBER(cSize);
    //diff = diff - cSize;
    //if (diff > 0) {
    //   fwrite(filler, diff, 1, fileHandle);
@@ -2235,7 +2235,7 @@ void EndCompressedFile(
 
    LOGGING("SDS: Array first offset --- %lld   Total comp size %lld\n",  pFileHeader->ArrayFirstOffset, pFileHeader->TotalArrayCompressedSize);
 
-   INT64 LastFileOffset = pFileHeader->GetEndOfFileOffset();
+   int64_t LastFileOffset = pFileHeader->GetEndOfFileOffset();
 
    // Check if the user is appending to an existing file
    if (pWriteInfo->sectionName) {
@@ -2249,7 +2249,7 @@ void EndCompressedFile(
 
          LOGGING("SDS: Writing first section %s at %lld\n", pWriteInfo->sectionName, LastFileOffset);
 
-         INT64 sectionSize =
+         int64_t sectionSize =
             cSDSSectionName.BuildSectionNamesAndOffsets(
                &pListNames,
                pWriteInfo->sectionName,
@@ -2263,7 +2263,7 @@ void EndCompressedFile(
          pFileHeader->SectionBlockReservedSize = SDS_PAD_NUMBER(sectionSize);
 
          // write first section header
-         INT64 result = DefaultFileIO.FileWriteChunk(NULL, sdsFile, pListNames, pFileHeader->SectionBlockReservedSize, pFileHeader->SectionBlockOffset);
+         int64_t result = DefaultFileIO.FileWriteChunk(NULL, sdsFile, pListNames, pFileHeader->SectionBlockReservedSize, pFileHeader->SectionBlockOffset);
 
          if (result != pFileHeader->SectionBlockReservedSize) {
             SetErr_Format(SDS_VALUE_ERROR, "Compression error cannot append section %lld at %lld", pFileHeader->SectionBlockReservedSize, pFileHeader->SectionBlockOffset);
@@ -2274,7 +2274,7 @@ void EndCompressedFile(
          SDS_FILE_HEADER   fileHeader;
 
          // read in the first file header to get section information since we are appending another section
-         INT64 result =
+         int64_t result =
             ReadFileHeader(sdsFile, &fileHeader, 0, "reread");
 
          if (result == 0) {
@@ -2288,10 +2288,10 @@ void EndCompressedFile(
                fileHeader.SectionBlockCount = 1;
             }
 
-            INT64 blockCount = fileHeader.SectionBlockCount;
+            int64_t blockCount = fileHeader.SectionBlockCount;
 
             LOGGING("SDS: Writing section %s with blockcount:%lld at %lld (%lld) at %lld\n", pWriteInfo->sectionName, blockCount, pFileHeader->FileOffset, fileHeader.FileOffset, LastFileOffset);
-            INT64 sectionSize =
+            int64_t sectionSize =
                cSDSSectionName.BuildSectionNamesAndOffsets(
                   &pListNames,
                   pWriteInfo->sectionName,
@@ -2331,7 +2331,7 @@ void EndCompressedFile(
    //Timestamp
    pFileHeader->TimeStampUTCNanos = GetUTCNanos();
 
-   INT64 result = DefaultFileIO.FileWriteChunk(NULL, sdsFile, pFileHeader, sizeof(SDS_FILE_HEADER), pFileHeader->FileOffset);
+   int64_t result = DefaultFileIO.FileWriteChunk(NULL, sdsFile, pFileHeader, sizeof(SDS_FILE_HEADER), pFileHeader->FileOffset);
    if (result != sizeof(SDS_FILE_HEADER)) {
       SetErr_Format(SDS_VALUE_ERROR, "Compression error cannot write fileheader at offset %lld\n", pFileHeader->FileOffset);
    }
@@ -2356,17 +2356,17 @@ void EndCompressedFile(
 // for normal read: read into pstCompressArrays->ArrayInfo[t].pData
 // size of the READ: pBlockInfo->ArrayCompressedSize
 //
-BOOL DecompressFileArray(void* pstCompressArraysV, int core, INT64 t) {
+bool DecompressFileArray(void* pstCompressArraysV, int32_t core, int64_t t) {
 
    LOGGING("[%lld] Start of decompress array: core %d   compress: %p\n", t, core, pstCompressArraysV);
    SDS_READ_DECOMPRESS_ARRAYS* pstCompressArrays = (SDS_READ_DECOMPRESS_ARRAYS *)pstCompressArraysV;
    SDS_FILE_HANDLE sdsFile = pstCompressArrays->fileHandle;
 
-   // point to blocks
+   // point32_t to blocks
    SDS_ARRAY_BLOCK* pBlockInfo = &pstCompressArrays->pBlockInfo[t];
    //LOGGING("[%lld] Step 2 of decompress array: core %d  blockinfo %p\n", t, core, pBlockInfo);
 
-   INT64 source_size = pBlockInfo->ArrayCompressedSize;
+   int64_t source_size = pBlockInfo->ArrayCompressedSize;
    void* destBuffer = NULL;
 
    // Check if we are reading into memory or reading into a preallocated numpy array
@@ -2407,7 +2407,7 @@ BOOL DecompressFileArray(void* pstCompressArraysV, int core, INT64 t) {
 
       if (pBlockInfo->Flags & SDS_ARRAY_FILTERED) {
          // No stacking but filtering
-         INT64 result =
+         int64_t result =
             ReadAndDecompressArrayBlockWithFilter(
                pBlockInfo,
                pstCompressArrays->eventHandles[core],
@@ -2424,7 +2424,7 @@ BOOL DecompressFileArray(void* pstCompressArraysV, int core, INT64 t) {
       }
       else {
          // No stacking, no filtering
-         INT64 result =
+         int64_t result =
             ReadAndDecompressArrayBlock(
                pBlockInfo,
                pstCompressArrays->eventHandles[core],
@@ -2450,22 +2450,22 @@ BOOL DecompressFileArray(void* pstCompressArraysV, int core, INT64 t) {
 // pstCompressArrays->pArrayInfo must be set
 // pstCompressArrays->pCoreMemory must be set
 // pBlockInfo must be set
-BOOL CompressFileArray(void* pstCompressArraysV, int core, INT64 t) {
+bool CompressFileArray(void* pstCompressArraysV, int32_t core, int64_t t) {
 
    SDS_WRITE_COMPRESS_ARRAYS* pstCompressArrays = (SDS_WRITE_COMPRESS_ARRAYS *)pstCompressArraysV;
    SDS_FILE_HEADER* pFileHeader = pstCompressArrays->pFileHeader;
 
    SDSArrayInfo* pArrayInfo = &pstCompressArrays->pArrayInfo[t];
 
-   INT64 bandSize = pFileHeader->BandSize;
-   INT64 bandCount = 0;
-   INT64 bytesPerBand = 0;
+   int64_t bandSize = pFileHeader->BandSize;
+   int64_t bandCount = 0;
+   int64_t bytesPerBand = 0;
 
-   INT64 source_size = pArrayInfo->ArrayLength * pArrayInfo->ItemSize;
+   int64_t source_size = pArrayInfo->ArrayLength * pArrayInfo->ItemSize;
 
    // Calculate how much to allocate
-   INT64 dest_size = source_size;
-   INT64 wantedSize = source_size;
+   int64_t dest_size = source_size;
+   int64_t wantedSize = source_size;
    
    if (pstCompressArrays->compType == COMPRESSION_TYPE_ZSTD) {
 
@@ -2484,7 +2484,7 @@ BOOL CompressFileArray(void* pstCompressArraysV, int core, INT64 t) {
       dest_size = CompressGetBound(COMPRESSION_TYPE_ZSTD, source_size);
 
       // If banding is on, we store the last offset upfront
-      wantedSize += bandCount * sizeof(INT64);
+      wantedSize += bandCount * sizeof(int64_t);
    }
 
    if (pstCompressArrays->pCoreMemorySize[core] < wantedSize) {
@@ -2520,14 +2520,14 @@ BOOL CompressFileArray(void* pstCompressArraysV, int core, INT64 t) {
          if (bandCount > 0) {
             LOGGING("[%d] banding bytesperband:%lld   bandcount:%lld\n", (int)t, bytesPerBand, bandCount);
 
-            INT64* pBandOffsets = (INT64*)pTempMemory;
+            int64_t* pBandOffsets = (int64_t*)pTempMemory;
             char* pWriteMemory = (char*)(pBandOffsets + bandCount);
             char* pStartWriteMemory = pWriteMemory;
-            INT64 bytesAvailable = dest_size;
-            INT64 bytesRemaining = source_size;
+            int64_t bytesAvailable = dest_size;
+            int64_t bytesRemaining = source_size;
             char* pReadMemory = pArrayInfo->pData;
 
-            for (INT64 i = 0; i < bandCount;) {
+            for (int64_t i = 0; i < bandCount;) {
 
                i++;
 
@@ -2585,8 +2585,8 @@ BOOL CompressFileArray(void* pstCompressArraysV, int core, INT64 t) {
       // Also race condition for addition total size
       InterlockedAdd64(&pFileHeader->TotalArrayUncompressedSize, source_size);
 
-      INT64 arrayNumber = t;
-      INT64 fileOffset = pFileHeader->AddArrayCompressedSize(cSize);
+      int64_t arrayNumber = t;
+      int64_t fileOffset = pFileHeader->AddArrayCompressedSize(cSize);
 
       //==============================================
       // FILL IN ARRAY BLOCK
@@ -2599,23 +2599,23 @@ BOOL CompressFileArray(void* pstCompressArraysV, int core, INT64 t) {
       pArrayBlock->CompressionType = COMPRESSION_TYPE_ZSTD;
 
       // New version 4.3
-      pArrayBlock->ArrayBandCount = (INT32)bandCount;
-      pArrayBlock->ArrayBandSize = (INT32)bandSize;
+      pArrayBlock->ArrayBandCount = (int32_t)bandCount;
+      pArrayBlock->ArrayBandSize = (int32_t)bandSize;
 
       // record array dimensions
-      INT32 ndim = pArrayInfo->NDim;
+      int32_t ndim = pArrayInfo->NDim;
       if (ndim > SDS_MAX_DIMS) {
          printf("!!!SDS: array dimensions too high: %d\n", ndim);
          ndim = SDS_MAX_DIMS;
       }
 
-      pArrayBlock->NDim = (INT8)ndim;
+      pArrayBlock->NDim = (int8_t)ndim;
 
-      for (int i = 0; i < SDS_MAX_DIMS; i++) {
+      for (int32_t i = 0; i < SDS_MAX_DIMS; i++) {
          pArrayBlock->Dimensions[i] = 0;
          pArrayBlock->Strides[i] = 0;
       }
-      for (int i = 0; i < ndim; i++) {
+      for (int32_t i = 0; i < ndim; i++) {
          pArrayBlock->Dimensions[i] = pArrayInfo->Dimensions[i];
          pArrayBlock->Strides[i] = pArrayInfo->Strides[i];
       }
@@ -2623,7 +2623,7 @@ BOOL CompressFileArray(void* pstCompressArraysV, int core, INT64 t) {
       pArrayBlock->Flags = pArrayInfo->Flags;
 
       pArrayBlock->DType = pArrayInfo->NumpyDType;
-      pArrayBlock->ItemSize = (INT32)pArrayInfo->ItemSize;
+      pArrayBlock->ItemSize = (int32_t)pArrayInfo->ItemSize;
       pArrayBlock->HeaderLength = sizeof(SDS_ARRAY_BLOCK);
       pArrayBlock->Magic = COMPRESSION_MAGIC;
 
@@ -2631,7 +2631,7 @@ BOOL CompressFileArray(void* pstCompressArraysV, int core, INT64 t) {
 
       //===========================
       // Write compressed chunk 
-      INT64 result =
+      int64_t result =
          DefaultFileIO.FileWriteChunk(
             pstCompressArrays->eventHandles[core],
             pstCompressArrays->fileHandle,
@@ -2652,24 +2652,24 @@ BOOL CompressFileArray(void* pstCompressArraysV, int core, INT64 t) {
 //------------------------------------------------------------
 // Return amount of memory needed to allocate
 //
-INT64 CalculateSharedMemorySize(SDS_FILE_HEADER* pFileHeader, SDS_ARRAY_BLOCK* pArrayBlocks) {
+int64_t CalculateSharedMemorySize(SDS_FILE_HEADER* pFileHeader, SDS_ARRAY_BLOCK* pArrayBlocks) {
 
    // Calculate size of shared memory
-   INT64    totalSize = 0;
+   int64_t    totalSize = 0;
    totalSize += sizeof(SDS_FILE_HEADER);
    totalSize += SDS_PAD_NUMBER(pFileHeader->NameBlockSize);
    totalSize += SDS_PAD_NUMBER(pFileHeader->TotalMetaUncompressedSize);
    totalSize += SDS_PAD_NUMBER(pFileHeader->ArrayBlockSize);
 
-   INT64 arrayCount = pFileHeader->ArraysWritten;
+   int64_t arrayCount = pFileHeader->ArraysWritten;
 
    if (pArrayBlocks) {
       // Add all the pNumpyArray pointers
-      for (int t = 0; t < arrayCount; t++) {
+      for (int32_t t = 0; t < arrayCount; t++) {
          totalSize += SDS_PAD_NUMBER(pArrayBlocks[t].ArrayUncompressedSize);
       }
 
-      INT64 arraycount = pFileHeader->ArrayBlockSize / sizeof(SDS_ARRAY_BLOCK);
+      int64_t arraycount = pFileHeader->ArrayBlockSize / sizeof(SDS_ARRAY_BLOCK);
 
       if (arraycount != pFileHeader->ArraysWritten) {
          printf("possibly incomplete file %lld %lld\n", arraycount, pFileHeader->ArraysWritten);
@@ -2693,7 +2693,7 @@ typedef void (*sighandler_t)(int);
 
 sighandler_t sigbus_orighandler;
 
-void sigbus_termination_handler(int signum) {
+void sigbus_termination_handler(int32_t signum) {
    // try to recover
    // NOTE: consider changing to siglongjmp
    longjmp(sigbus_jmp, 1);
@@ -2715,7 +2715,7 @@ void sigbus_termination_handler(int signum) {
 // metaData -- block of bytes to store as metadata
 // metaDataSize -- 
 //
-BOOL SDSWriteFileInternal(
+bool SDSWriteFileInternal(
    const char *            fileName,
    const char *            shareName,  // can be NULL
    SDS_STRING_LIST*        pFolderName,  // can be NULL
@@ -2728,28 +2728,28 @@ BOOL SDSWriteFileInternal(
 
    // arrays to save information
    SDSArrayInfo* aInfo = pWriteInfo->aInfo;
-   INT64 arrayCount = pWriteInfo->arrayCount;
+   int64_t arrayCount = pWriteInfo->arrayCount;
 
    // meta information
    const char *metaData = pWriteInfo->metaData;
-   UINT32 metaDataSize = pWriteInfo->metaDataSize;
+   uint32_t metaDataSize = pWriteInfo->metaDataSize;
 
    // names of arrays information
    char* pListNames = pWriteInfo->pListNames;
-   INT64 listNameSize = pWriteInfo->listNameSize;    // total byte size (store in memory)
-   INT64 listNameCount = pWriteInfo->listNameCount;   // number of names
+   int64_t listNameSize = pWriteInfo->listNameSize;    // total byte size (store in memory)
+   int64_t listNameCount = pWriteInfo->listNameCount;   // number of names
 
                                                       // compressed or uncompressed
-   INT32 mode = pWriteInfo->mode;            // = COMPRESSION_MODE_COMPRESS_FILE, COMPRESSION_MODE_COMPRESS_APPEND_FILE
-   INT32 compType = pWriteInfo->compType;    // = COMPRESSION_TYPE_ZSTD,
-   INT32 level = pWriteInfo->level;          // = ZSTD_CLEVEL_DEFAULT;
+   int32_t mode = pWriteInfo->mode;            // = COMPRESSION_MODE_COMPRESS_FILE, COMPRESSION_MODE_COMPRESS_APPEND_FILE
+   int32_t compType = pWriteInfo->compType;    // = COMPRESSION_TYPE_ZSTD,
+   int32_t level = pWriteInfo->level;          // = ZSTD_CLEVEL_DEFAULT;
 
-   INT32 sdsFileType = pWriteInfo->sdsFileType;
-   INT32 authorId = pWriteInfo->sdsAuthorId;
+   int32_t sdsFileType = pWriteInfo->sdsFileType;
+   int32_t authorId = pWriteInfo->sdsAuthorId;
 
-   BOOL bAppendHeader = pWriteInfo->appendRowsMode;
+   bool bAppendHeader = pWriteInfo->appendRowsMode;
 
-   INT64 bandSize = pWriteInfo->bandSize;
+   int64_t bandSize = pWriteInfo->bandSize;
 
    // clamp bandsize to 10K min
    if (bandSize < 10000 && bandSize > 0) bandSize = 10000;
@@ -2776,10 +2776,10 @@ BOOL SDSWriteFileInternal(
          DefaultMemoryIO.MakeShareName(fileName, shareName);
 
          // Calculate size of shared memory
-         INT64 totalSize = CalculateSharedMemorySize(pFileHeader, NULL);
+         int64_t totalSize = CalculateSharedMemorySize(pFileHeader, NULL);
 
          // Add all the pNumpyArray pointers
-         for (int t = 0; t < arrayCount; t++) {
+         for (int32_t t = 0; t < arrayCount; t++) {
             totalSize += SDS_PAD_NUMBER(aInfo[t].ArrayLength * aInfo[t].ItemSize);
          }
 
@@ -2826,10 +2826,10 @@ BOOL SDSWriteFileInternal(
                SDS_ARRAY_BLOCK* pDestArrayBlock = DefaultMemoryIO.GetArrayBlock(0);
 
                // offset to first location of array data
-               INT64 startOffset = pMemoryFileHeader->ArrayFirstOffset;
+               int64_t startOffset = pMemoryFileHeader->ArrayFirstOffset;
 
                // Step 4: have to fill in arrayblocks
-               for (int arrayNumber = 0; arrayNumber < arrayCount; arrayNumber++) {
+               for (int32_t arrayNumber = 0; arrayNumber < arrayCount; arrayNumber++) {
 
                   LOGGING("start offset %d %lld\n", arrayNumber, startOffset);
 
@@ -2841,23 +2841,23 @@ BOOL SDSWriteFileInternal(
                   pDestArrayBlock[arrayNumber].CompressionType = COMPRESSION_TYPE_NONE;
 
                   // record array dimensions
-                  INT32 ndim = aInfo[arrayNumber].NDim;
+                  int32_t ndim = aInfo[arrayNumber].NDim;
                   if (ndim > SDS_MAX_DIMS) ndim = SDS_MAX_DIMS;
                   if (ndim < 1) ndim = 1;
 
-                  pDestArrayBlock[arrayNumber].NDim = (INT8)ndim;
+                  pDestArrayBlock[arrayNumber].NDim = (int8_t)ndim;
 
-                  for (int j = 0; j < SDS_MAX_DIMS; j++) {
+                  for (int32_t j = 0; j < SDS_MAX_DIMS; j++) {
                      pDestArrayBlock[arrayNumber].Dimensions[j] = 0;
                      pDestArrayBlock[arrayNumber].Strides[j] = 0;
                   }
-                  for (int j = 0; j < ndim; j++) {
+                  for (int32_t j = 0; j < ndim; j++) {
                      pDestArrayBlock[arrayNumber].Dimensions[j] = aInfo[arrayNumber].Dimensions[j];
                      pDestArrayBlock[arrayNumber].Strides[j] = aInfo[arrayNumber].Strides[j];
                   }
                   pDestArrayBlock[arrayNumber].Flags = aInfo[arrayNumber].Flags;
                   pDestArrayBlock[arrayNumber].DType = aInfo[arrayNumber].NumpyDType;
-                  pDestArrayBlock[arrayNumber].ItemSize = (INT32)aInfo[arrayNumber].ItemSize;
+                  pDestArrayBlock[arrayNumber].ItemSize = (int32_t)aInfo[arrayNumber].ItemSize;
                   pDestArrayBlock[arrayNumber].HeaderLength = sizeof(SDS_ARRAY_BLOCK);
                   pDestArrayBlock[arrayNumber].Magic = COMPRESSION_MAGIC;
 
@@ -2868,7 +2868,7 @@ BOOL SDSWriteFileInternal(
                LOGGING("Copying array data  %lld\n", arrayCount);
 
                // Step 5 (can make multithreaded) -- copy array blocks
-               for (int arrayNumber = 0; arrayNumber < arrayCount; arrayNumber++) {
+               for (int32_t arrayNumber = 0; arrayNumber < arrayCount; arrayNumber++) {
                   //LOGGING("Writing to offset %lld, length %lld, memptr %p\n", pDestArrayBlock[arrayNumber].ArrayDataOffset, pDestArrayBlock[arrayNumber].ArrayUncompressedSize, DefaultMemoryIO.GetMemoryOffset(pDestArrayBlock[arrayNumber].ArrayDataOffset));
 
                   memcpy(
@@ -2912,7 +2912,7 @@ BOOL SDSWriteFileInternal(
             StartCompressedFile(
                fileName,
                pFileHeader,
-               (INT16)compType,
+               (int16_t)compType,
                level,
                sdsFileType,
                0,                   // stackType
@@ -2947,7 +2947,7 @@ BOOL SDSWriteFileInternal(
 
             pstCompressArrays->compLevel = level;
             pstCompressArrays->compType = compType;
-            pstCompressArrays->compMode = (INT16)mode;
+            pstCompressArrays->compMode = (int16_t)mode;
 
             pstCompressArrays->pArrayInfo = aInfo;
             pstCompressArrays->fileHandle = sdsFile;
@@ -2956,9 +2956,9 @@ BOOL SDSWriteFileInternal(
 
             // Make sure there are arrays to write
             if (arrayCount > 0) {
-               INT numCores = g_cMathWorker->GetNumCores();
+               int32_t numCores = g_cMathWorker->GetNumCores();
 
-               for (int j = 0; j < numCores; j++) {
+               for (int32_t j = 0; j < numCores; j++) {
                   pstCompressArrays->pCoreMemory[j] = NULL;
                   pstCompressArrays->pCoreMemorySize[j] = 0;
                   pstCompressArrays->eventHandles[j] = DefaultFileIO.CreateEventHandle();
@@ -2971,7 +2971,7 @@ BOOL SDSWriteFileInternal(
 
                LOGGING("End of compressing\n");
 
-               for (int j = 0; j < numCores; j++) {
+               for (int32_t j = 0; j < numCores; j++) {
                   if (pstCompressArrays->pCoreMemory[j]) {
                      WORKSPACE_FREE(pstCompressArrays->pCoreMemory[j]);
                   }
@@ -3001,7 +3001,7 @@ BOOL SDSWriteFileInternal(
 //---------------------------------------------------------
 // Linux: long = 64 bits
 // Windows: long = 32 bits
-static int FixupDType(int dtype, INT64 itemsize) {
+static int32_t FixupDType(int32_t dtype, int64_t itemsize) {
 
    if (dtype == SDS_LONG) {
       // types 7 and 8 are ambiguous because of different compilers
@@ -3030,7 +3030,7 @@ static int FixupDType(int dtype, INT64 itemsize) {
 //
 void CopyFromBlockToInfo(SDS_ARRAY_BLOCK*  pBlock, SDSArrayInfo* pDestInfo) {
 
-   int dtype = FixupDType(pBlock->DType, pBlock->ItemSize);
+   int32_t dtype = FixupDType(pBlock->DType, pBlock->ItemSize);
 
    // IS THIS EVER USED??
    pDestInfo->NDim = pBlock->NDim;
@@ -3038,13 +3038,13 @@ void CopyFromBlockToInfo(SDS_ARRAY_BLOCK*  pBlock, SDSArrayInfo* pDestInfo) {
    pDestInfo->ItemSize = pBlock->ItemSize;
    pDestInfo->Flags = pBlock->Flags;
 
-   int ndim = pBlock->NDim;
+   int32_t ndim = pBlock->NDim;
    if (ndim > SDS_MAX_DIMS) { ndim = SDS_MAX_DIMS; }
 
    pDestInfo->ArrayLength = 1;
 
    // Fill in strides, dims, and calc arraylength
-   for (int i = 0; i < ndim; i++) {
+   for (int32_t i = 0; i < ndim; i++) {
       pDestInfo->ArrayLength *= pBlock->Dimensions[i];
       pDestInfo->Dimensions[i] = pBlock->Dimensions[i];
       pDestInfo->Strides[i] = pBlock->Strides[i];
@@ -3062,10 +3062,10 @@ void CopyFromBlockToInfo(SDS_ARRAY_BLOCK*  pBlock, SDSArrayInfo* pDestInfo) {
 
 
 struct SDS_COMPATIBLE {
-   INT8                 IsCompatible;  // set to FALSE if conversion required
-   INT8                 NeedsStringFixup;  // set to 1 if conversion required, or in 2 for mtlab conversion
-   INT8                 NeedsConversion;  // if flag set, dtype conversion called
-   INT8                 NeedsRotation;
+   int8_t                 IsCompatible;  // set to FALSE if conversion required
+   int8_t                 NeedsStringFixup;  // set to 1 if conversion required, or in 2 for mtlab conversion
+   int8_t                 NeedsConversion;  // if flag set, dtype conversion called
+   int8_t                 NeedsRotation;
 };
 
 //=============================================================
@@ -3084,22 +3084,22 @@ struct SDS_IO_PACKET {
    // Used when going to shared memory
    class SharedMemory*  pMemoryIO;
 
-   INT16                CompMode;
-   INT8                 ReservedMode1;
-   INT8                 ReservedMode2;
+   int16_t                CompMode;
+   int8_t                 ReservedMode1;
+   int8_t                 ReservedMode2;
    SDS_COMPATIBLE       Compatible;
 
    // Used in matlab string rotation
-   INT64                ArrayOffset;
-   INT64                OriginalArrayOffset;
-   INT64                StackPosition;
+   int64_t                ArrayOffset;
+   int64_t                OriginalArrayOffset;
+   int64_t                StackPosition;
    const char*          ColName;
 };
 
 struct SDS_MULTI_IO_PACKETS {
    // Per core allocations
    void*                pCoreMemory[SDS_MAX_CORES];
-   INT64                pCoreMemorySize[SDS_MAX_CORES];
+   int64_t                pCoreMemorySize[SDS_MAX_CORES];
    SDS_EVENT_HANDLE     eventHandles[SDS_MAX_CORES];
 
    SDSArrayInfo*        pDestInfo;
@@ -3118,20 +3118,20 @@ struct SDS_MULTI_IO_PACKETS {
    //--------------------------------------
    // Allocates pMultiIOPackets->pDestInfo
    // Allocates event handles
-   static SDS_MULTI_IO_PACKETS* Allocate(INT64 tupleSize, SDS_FILTER*  pFilter) {
-      INT64 allocSize = sizeof(SDS_MULTI_IO_PACKETS) + ((sizeof(SDS_IO_PACKET) * tupleSize));
+   static SDS_MULTI_IO_PACKETS* Allocate(int64_t tupleSize, SDS_FILTER*  pFilter) {
+      int64_t allocSize = sizeof(SDS_MULTI_IO_PACKETS) + ((sizeof(SDS_IO_PACKET) * tupleSize));
       SDS_MULTI_IO_PACKETS* pMultiIOPackets = (SDS_MULTI_IO_PACKETS*)WORKSPACE_ALLOC(allocSize);
       memset(pMultiIOPackets, 0, allocSize);
 
       pMultiIOPackets->pFilter = pFilter;
 
-      INT64 allocSizeDestInfo = tupleSize * sizeof(SDSArrayInfo);
+      int64_t allocSizeDestInfo = tupleSize * sizeof(SDSArrayInfo);
       pMultiIOPackets->pDestInfo = (SDSArrayInfo*)WORKSPACE_ALLOC(allocSizeDestInfo);
       memset(pMultiIOPackets->pDestInfo, 0, allocSizeDestInfo);
 
       // Set all the cores working memory to zero
-      INT numCores = g_cMathWorker->WorkerThreadCount + 1;
-      for (int j = 0; j < numCores; j++) {
+      int32_t numCores = g_cMathWorker->WorkerThreadCount + 1;
+      for (int32_t j = 0; j < numCores; j++) {
          pMultiIOPackets->eventHandles[j] = DefaultFileIO.CreateEventHandle();
       }
       return pMultiIOPackets;
@@ -3143,8 +3143,8 @@ struct SDS_MULTI_IO_PACKETS {
       //---------- CLEAN UP MEMORY AND HANDLES ---------
       // check if any cores allocated any memory
       // Set all the cores working memory to zero
-      INT numCores = g_cMathWorker->WorkerThreadCount + 1;
-      for (int j = 0; j < numCores; j++) {
+      int32_t numCores = g_cMathWorker->WorkerThreadCount + 1;
+      for (int32_t j = 0; j < numCores; j++) {
          if (pMultiIOPackets->pCoreMemory[j]) {
             WORKSPACE_FREE(pMultiIOPackets->pCoreMemory[j]);
             pMultiIOPackets->pCoreMemory[j] = NULL;
@@ -3161,11 +3161,11 @@ struct SDS_MULTI_IO_PACKETS {
 
 //-----------------------------------------------------------
 // Check both folder and column names
-BOOL IsNameIncluded(
+bool IsNameIncluded(
    SDSIncludeExclude*    pInclude,
    SDSIncludeExclude*    pFolderName,
    const char*           nameToCheck,
-   BOOL                  isOneFile) {
+   bool                  isOneFile) {
 
    if (isOneFile) {
       // Only OneFile can have folders
@@ -3222,22 +3222,22 @@ BOOL IsNameIncluded(
 
 //===================================
 // Returns True if array was shrunk or had a mask
-BOOL PossiblyShrinkArray(
+bool PossiblyShrinkArray(
    SDS_ALLOCATE_ARRAY*  pArrayCallback,
    SDS_READ_CALLBACKS*  pReadCallbacks,
-   BOOL                 isStackable
+   bool                 isStackable
 ) {
-   BOOL wasFiltered = FALSE;
+   bool wasFiltered = FALSE;
 
    // Categoricals will not be in original container
-   INT32 mask = SDS_FLAGS_ORIGINAL_CONTAINER;
+   int32_t mask = SDS_FLAGS_ORIGINAL_CONTAINER;
    if ((pArrayCallback->sdsFlags & (SDS_FLAGS_SCALAR | SDS_FLAGS_META | SDS_FLAGS_NESTED)) == 0) {
       if (pArrayCallback->sdsFlags & mask) {
          // Did they pass a fancy index or a bool index?
          if (pReadCallbacks->Filter.pBoolMask && pReadCallbacks->Filter.BoolMaskTrueCount >= 0 && isStackable) {
             wasFiltered = TRUE;
-            INT64 dim0Length = pArrayCallback->dims[0];
-            INT64 newLength = pReadCallbacks->Filter.BoolMaskTrueCount;
+            int64_t dim0Length = pArrayCallback->dims[0];
+            int64_t newLength = pReadCallbacks->Filter.BoolMaskTrueCount;
 
             // If the array allocation is too large, we reduce it
             if (newLength > dim0Length) {
@@ -3250,7 +3250,7 @@ BOOL PossiblyShrinkArray(
       }
       else {
          // Could be a categorical
-         //INT64 dim0Length = pArrayCallback->dims[0];
+         //int64_t dim0Length = pArrayCallback->dims[0];
          //if (pReadCallbacks->Filter.pBoolMask) {
          //   LOGGING("-->Allocation no reduction for %s  len:%lld  fancy:%lld  bool:%lld  flags:%d\n", pArrayCallback->pArrayName, dim0Length, pReadCallbacks->Filter.FancyLength, pReadCallbacks->Filter.BoolMaskTrueCount, pArrayCallback->sdsFlags);
          //}
@@ -3273,9 +3273,9 @@ public:
    // These three are required
    const char*      FileName;       // Fully qualified file path
    const char*      ShareName;      // May be NULL
-   INT64            InstanceIndex;  // 0 if just one instance (for multiday)
-   INT32            Mode;
-   INT64            FileSize;       // only valid when concat
+   int64_t            InstanceIndex;  // 0 if just one instance (for multiday)
+   int32_t            Mode;
+   int64_t            FileSize;       // only valid when concat
 
    SDSIncludeExclude*    pInclude;    // Inclusion list
    SDSIncludeExclude*    pFolderName; // Folder inclusion
@@ -3293,21 +3293,21 @@ public:
    SDS_ARRAY_BLOCK* pArrayBlocks = NULL;
 
    // Meta data
-   INT64 MetaSize = 0;
+   int64_t MetaSize = 0;
    char* MetaData = NULL;
 
    // Name data
    char*          pNameData = NULL;
    const char**   pArrayNames = NULL;
-   INT32*         pArrayEnums = NULL;
-   INT64          NameCount = 0;
+   int32_t*         pArrayEnums = NULL;
+   int64_t          NameCount = 0;
 
    // Section data
    SDSSectionName cSectionName;
 
    // Set to true when file header is read (does not work for shared memory file)
-   BOOL           IsFileValid = FALSE;
-   BOOL           IsFileValidAndNotFilteredOut = FALSE;
+   bool           IsFileValid = FALSE;
+   bool           IsFileValidAndNotFilteredOut = FALSE;
 
    //------------------------------------------------
    // constructor
@@ -3316,11 +3316,11 @@ public:
    SDSDecompressFile(
       const char*          fileName, 
       SDSIncludeExclude*   pInclude = NULL,
-      INT64                instanceIndex=0, 
+      int64_t                instanceIndex=0, 
       const char*          shareName=NULL,
       SDSIncludeExclude*   pFolderName=NULL,
       SDSIncludeExclude*   pSectionsName = NULL,
-      INT32                mode = COMPRESSION_MODE_INFO) {
+      int32_t                mode = COMPRESSION_MODE_INFO) {
 
       this->FileName = fileName;
       this->pInclude = pInclude;
@@ -3335,7 +3335,7 @@ public:
    //-----------------------------------------------------------
    // Caller must fill in pDestInfo->pData because memory will be read into
    //// returns TRUE if array allocated
-   //BOOL CallAllocateArray(SDS_READ_CALLBACKS* pReadCallbacks, SDS_ALLOCATE_ARRAY *pAllocateArray) {
+   //bool CallAllocateArray(SDS_READ_CALLBACKS* pReadCallbacks, SDS_ALLOCATE_ARRAY *pAllocateArray) {
 
    //   if (pReadCallbacks->AllocateArrayCallback) {
    //      pReadCallbacks->AllocateArrayCallback(pAllocateArray);
@@ -3353,18 +3353,18 @@ public:
    // Callee must return:
    // pDestInfo filled in with pData (location of first element in array)
    void AllocateOneArray(
-      int                  colPos,          // which array index (which column in the file)
+      int32_t                  colPos,          // which array index (which column in the file)
       SDS_READ_CALLBACKS*  pReadCallbacks,
       SDSArrayInfo*        pDestInfo,
-      BOOL                 isSharedMemory,
-      BOOL                 isOneFile,
-      BOOL                 isStackable) {
+      bool                 isSharedMemory,
+      bool                 isOneFile,
+      bool                 isStackable) {
 
       SDS_ARRAY_BLOCK*  pBlock = &pArrayBlocks[colPos];
 
       // Allocate all the arrays before multithreading
       // NOTE: do we care about flags -- what if Fortran mode when saved?
-      int dtype = FixupDType(pBlock->DType, pBlock->ItemSize);
+      int32_t dtype = FixupDType(pBlock->DType, pBlock->ItemSize);
 
       // Build array callback block
       SDS_ALLOCATE_ARRAY sdsArrayCallback;
@@ -3396,7 +3396,7 @@ public:
       pDestInfo->pArrayObject = NULL;
       pDestInfo->pData = NULL;
 
-      BOOL wasFiltered = FALSE;
+      bool wasFiltered = FALSE;
 
       //LOGGING("Checking to allocate name %s\n", pAllocateArray->pArrayName);
       // Include exclude check
@@ -3435,14 +3435,14 @@ public:
       SDS_IO_PACKET*       pIOPacket,
       SDSArrayInfo*        pDestInfo,
       SDS_READ_CALLBACKS*  pReadCallbacks,
-      INT64                tupleSize,
-      BOOL                 isSharedMemory
+      int64_t                tupleSize,
+      bool                 isSharedMemory
    ) {
 
-      BOOL oneFile = (pFileHeader->FileType == SDS_FILE_TYPE_ONEFILE);
+      bool oneFile = (pFileHeader->FileType == SDS_FILE_TYPE_ONEFILE);
 
       // Init all the pNumpyArray pointers
-      for (int t = 0; t < tupleSize; t++) {
+      for (int32_t t = 0; t < tupleSize; t++) {
 
          pIOPacket->pReadCallbacks = pReadCallbacks;
          pIOPacket->pBlockInfo = &pArrayBlocks[t];
@@ -3466,8 +3466,8 @@ public:
             pIOPacket->CompMode = COMPRESSION_MODE_DECOMPRESS;
          }
 
-         INT fileType = pFileHeader->FileType;
-         INT fileTypeStackable = (fileType == SDS_FILE_TYPE_DATASET ||
+         int32_t fileType = pFileHeader->FileType;
+         int32_t fileTypeStackable = (fileType == SDS_FILE_TYPE_DATASET ||
             fileType == SDS_FILE_TYPE_TABLE ||
             fileType == SDS_FILE_TYPE_ARRAY);
 
@@ -3493,10 +3493,10 @@ public:
    // RETURNS SDS_READ_DECOMPRESS_ARRAYS + SDSArrayInfo*tupleSize
    SDS_READ_DECOMPRESS_ARRAYS* AllocDecompressArrays(
       SDS_READ_CALLBACKS*  pReadCallbacks,
-      INT64                tupleSize,
-      BOOL                 isSharedMemory,
-      BOOL                 isOneFile,
-      BOOL                 isStackable) {
+      int64_t                tupleSize,
+      bool                 isSharedMemory,
+      bool                 isOneFile,
+      bool                 isStackable) {
 
       // TJD
       // NOTE: TODO, should check isincluded up front
@@ -3505,7 +3505,7 @@ public:
       pstDecompressArrays->totalHeaders = tupleSize;
 
       // Init all the pNumpyArray pointers
-      for (int t = 0; t < tupleSize; t++) {
+      for (int32_t t = 0; t < tupleSize; t++) {
 
          SDSArrayInfo*     pDestInfo = &pstDecompressArrays->ArrayInfo[t];
 
@@ -3524,7 +3524,7 @@ public:
       pstDecompressArrays->pFileHeader = NULL;
 
       pstDecompressArrays->pMemoryIO = NULL;
-      pstDecompressArrays->compMode = (INT16)COMPRESSION_MODE_DECOMPRESS;
+      pstDecompressArrays->compMode = (int16_t)COMPRESSION_MODE_DECOMPRESS;
 
       return pstDecompressArrays;
    }
@@ -3557,7 +3557,7 @@ public:
 
    //--------------------------------------------
    //
-   char* AllocateMetaData(INT64 size) {
+   char* AllocateMetaData(int64_t size) {
       if (MetaData != NULL) {
          printf("Double Allocation meta data!!\n");
       }
@@ -3581,7 +3581,7 @@ public:
    //--------------------------------------------
    // Also zero out pArrayNames, zero out pArrayEnums
    //
-   void AllocateNameData(INT64 nameBlockCount, INT64 nameSize) {
+   void AllocateNameData(int64_t nameBlockCount, int64_t nameSize) {
       NameCount = nameBlockCount;
       if (pNameData != NULL) {
          printf("Double Allocation nameData!!\n");
@@ -3590,11 +3590,11 @@ public:
 
       // ZERO OUT
       pArrayNames = (const char**)WORKSPACE_ALLOC(NameCount * sizeof(void*));
-      for (int i = 0; i < NameCount; i++) {
+      for (int32_t i = 0; i < NameCount; i++) {
          pArrayNames[i] = NULL;
       }
-      pArrayEnums = (INT32*)WORKSPACE_ALLOC(NameCount * sizeof(INT32));
-      for (int i = 0; i < NameCount; i++) {
+      pArrayEnums = (int32_t*)WORKSPACE_ALLOC(NameCount * sizeof(int32_t));
+      for (int32_t i = 0; i < NameCount; i++) {
          pArrayEnums[i] = 0;
       }
    }
@@ -3640,7 +3640,7 @@ public:
 
    //------------------------------------------
    // Understand how to get to sections
-   INT64 GetTotalArraysWritten() {
+   int64_t GetTotalArraysWritten() {
       // todo:
       LOGGING("Section offsets %p   psectiondata %p   sectioncount: %lld\n", cSectionName.pSectionOffsets, cSectionName.pSectionData, cSectionName.SectionCount);
 
@@ -3663,7 +3663,7 @@ public:
    // Output: reads into pFileHeader and returns a good file handle
    //         or returns BAD_SDS_HANDLE on failure
    SDS_FILE_HANDLE
-   StartDecompressedFile(const char* fileName, INT64 fileOffset) {
+   StartDecompressedFile(const char* fileName, int64_t fileOffset) {
 
       SDS_FILE_HANDLE  fileHandle =
          DefaultFileIO.FileOpen(fileName, false, true, false, false);
@@ -3673,7 +3673,7 @@ public:
          return BAD_SDS_HANDLE;
       }
 
-      INT64 result =
+      int64_t result =
          ReadFileHeader(fileHandle, pFileHeader, fileOffset, fileName);
 
       if (result != 0) {
@@ -3700,16 +3700,16 @@ public:
    //   TRUE or FALSE.  if TRUE and NULL passed in then can call GetMetaData()
    //   
    //
-   BOOL DecompressMetaData(
+   bool DecompressMetaData(
       SDS_FILE_HEADER*  pFileHeader,
       char*             metaDataUncompressed,
-      int               core) {
+      int32_t               core) {
 
-      INT64 metaCompressedSize = pFileHeader->TotalMetaCompressedSize;
+      int64_t metaCompressedSize = pFileHeader->TotalMetaCompressedSize;
       char* metaData = NULL;
 
       // Read in metadata from disk/network
-      INT64 bytesRead = 0;
+      int64_t bytesRead = 0;
 
       LOGGING("in decompress meta %lld vs %lld  offset:%lld  handle:%p\n", metaCompressedSize, pFileHeader->TotalMetaUncompressedSize, pFileHeader->MetaBlockOffset, SDSFile);
 
@@ -3734,7 +3734,7 @@ public:
             return FALSE;
          }
 
-         INT64 metaUncompressedSize = pFileHeader->TotalMetaUncompressedSize;
+         int64_t metaUncompressedSize = pFileHeader->TotalMetaUncompressedSize;
 
          // check if user passed in buffer to copy into
          if (!metaDataUncompressed) {
@@ -3753,19 +3753,19 @@ public:
          }
 
          // decompress meta data into metaDataUncompressed
-         INT64 cSize = DecompressData(NULL, COMPRESSION_TYPE_ZSTD, metaDataUncompressed, pFileHeader->TotalMetaUncompressedSize, metaDataCompressed, pFileHeader->TotalMetaCompressedSize);
+         int64_t cSize = DecompressData(NULL, COMPRESSION_TYPE_ZSTD, metaDataUncompressed, pFileHeader->TotalMetaUncompressedSize, metaDataCompressed, pFileHeader->TotalMetaCompressedSize);
 
          WORKSPACE_FREE(metaDataCompressed);
          metaDataCompressed = NULL;
 
          if (CompressIsError(COMPRESSION_TYPE_ZSTD, cSize) || cSize != metaUncompressedSize) {
-            SetErr_Format(SDS_VALUE_ERROR, "Decompression error meta: length mismatch -> decomp %llu != %llu [header]", (UINT64)cSize, metaUncompressedSize);
+            SetErr_Format(SDS_VALUE_ERROR, "Decompression error meta: length mismatch -> decomp %llu != %llu [header]", (uint64_t)cSize, metaUncompressedSize);
             return FALSE;
          }
 
       }
       else {
-         INT64 metaUncompressedSize = metaCompressedSize;
+         int64_t metaUncompressedSize = metaCompressedSize;
 
          // meta was never compressed
          LOGGING("meta was not compressed\n");
@@ -3797,13 +3797,13 @@ public:
    // 
    // Reads from File and decompresses into shared memory
    // Call EndDecompressedFile() when done
-   BOOL
-   CopyIntoSharedMemoryInternal(SDS_READ_CALLBACKS* pReadCallbacks, int core) {
+   bool
+   CopyIntoSharedMemoryInternal(SDS_READ_CALLBACKS* pReadCallbacks, int32_t core) {
 
       if (SDSFile) {
 
-         INT64 nameSize = pFileHeader->NameBlockSize;
-         INT64 metaSize = pFileHeader->TotalMetaCompressedSize;
+         int64_t nameSize = pFileHeader->NameBlockSize;
+         int64_t metaSize = pFileHeader->TotalMetaCompressedSize;
 
          // This will allocate pArrayBlocks
          if (!AllocateArrayBlocks()) {
@@ -3811,15 +3811,15 @@ public:
             return FALSE;
          }
 
-         INT64 bytesRead = DefaultFileIO.FileReadChunk(NULL, SDSFile, pArrayBlocks, pFileHeader->ArrayBlockSize, pFileHeader->ArrayBlockOffset);
+         int64_t bytesRead = DefaultFileIO.FileReadChunk(NULL, SDSFile, pArrayBlocks, pFileHeader->ArrayBlockSize, pFileHeader->ArrayBlockOffset);
          if (bytesRead != pFileHeader->ArrayBlockSize) {
             SetErr_Format(SDS_VALUE_ERROR, "Decompression error in ArrayBlockSize: %lld", pFileHeader->ArrayBlockSize);
             return FALSE;
          }
 
          // Calculate size of shared memory
-         INT64 totalSize = CalculateSharedMemorySize(pFileHeader, pArrayBlocks);
-         INT64 arrayCount = pFileHeader->ArraysWritten;
+         int64_t totalSize = CalculateSharedMemorySize(pFileHeader, pArrayBlocks);
+         int64_t arrayCount = pFileHeader->ArraysWritten;
 
          LOGGING("CopyIntoSharedMem: trying to allocate %lld\n", totalSize);
 
@@ -3865,7 +3865,7 @@ public:
             LOGGING("Fill meta block\n");
 
             // Read from file and write to shared memory
-            BOOL bResult =
+            bool bResult =
                DecompressMetaData(pFileHeader, DefaultMemoryIO.GetMemoryOffset(pMemoryFileHeader->MetaBlockOffset), core);
 
             if (bResult) {
@@ -3877,10 +3877,10 @@ public:
                DefaultFileIO.FileReadChunk(NULL, SDSFile, pDestArrayBlock, pFileHeader->ArrayBlockSize, pFileHeader->ArrayBlockOffset);
 
                // offset to first location of array data
-               INT64 startOffset = pMemoryFileHeader->ArrayFirstOffset;
+               int64_t startOffset = pMemoryFileHeader->ArrayFirstOffset;
 
                // NOTE: have to fixup arrayblocks
-               for (int i = 0; i < arrayCount; i++) {
+               for (int32_t i = 0; i < arrayCount; i++) {
 
                   LOGGING("start offset %d %lld\n", i, startOffset);
 
@@ -3890,7 +3890,7 @@ public:
 
                   // TJD ADDDED CODE
                   // Not sure if shared memroy needs the offset
-                  //pDestArrayBlock[i].Reserved1 = (INT64)DefaultMemoryIO.GetMemoryOffset(startOffset);
+                  //pDestArrayBlock[i].Reserved1 = (int64_t)DefaultMemoryIO.GetMemoryOffset(startOffset);
                   pDestArrayBlock[i].ArrayBandCount = 0;
                   pDestArrayBlock[i].ArrayBandSize = 0;
 
@@ -3902,9 +3902,9 @@ public:
 
                LOGGING("last offset %lld\n", startOffset);
 
-               BOOL oneFile = (pFileHeader->FileType == SDS_FILE_TYPE_ONEFILE);
-               INT fileType = pFileHeader->FileType;
-               BOOL fileTypeStackable = (fileType == SDS_FILE_TYPE_DATASET ||
+               bool oneFile = (pFileHeader->FileType == SDS_FILE_TYPE_ONEFILE);
+               int32_t fileType = pFileHeader->FileType;
+               bool fileTypeStackable = (fileType == SDS_FILE_TYPE_DATASET ||
                   fileType == SDS_FILE_TYPE_TABLE ||
                   fileType == SDS_FILE_TYPE_ARRAY);
 
@@ -3913,8 +3913,8 @@ public:
                   AllocDecompressArrays(pReadCallbacks, arrayCount, TRUE, oneFile, fileTypeStackable);
 
                // Set all the cores working memory to zero
-               INT numCores = g_cMathWorker->WorkerThreadCount + 1;
-               for (int j = 0; j < numCores; j++) {
+               int32_t numCores = g_cMathWorker->WorkerThreadCount + 1;
+               for (int32_t j = 0; j < numCores; j++) {
                   pstCompressArrays->pCoreMemory[j] = NULL;
                   pstCompressArrays->pCoreMemorySize[j] = 0;
                   pstCompressArrays->eventHandles[j] = DefaultFileIO.CreateEventHandle();
@@ -3935,7 +3935,7 @@ public:
 
                //---------- CLEAN UP MEMORY AND HANDLES ---------
                // check if any cores allocated any memory
-               for (int j = 0; j < numCores; j++) {
+               for (int32_t j = 0; j < numCores; j++) {
                   if (pstCompressArrays->pCoreMemory[j]) {
                      WORKSPACE_FREE(pstCompressArrays->pCoreMemory[j]);
                   }
@@ -3960,13 +3960,13 @@ public:
    // Returns TRUE on success
    // 
    // Calls EndDecompressedFile() when done
-   BOOL CopyIntoSharedMemory(SDS_READ_CALLBACKS* pReadCallbacks, const char* fileName, SDSIncludeExclude* pFolderName, int core) {
+   bool CopyIntoSharedMemory(SDS_READ_CALLBACKS* pReadCallbacks, const char* fileName, SDSIncludeExclude* pFolderName, int32_t core) {
 
       // open normal file first
       SDSFile = StartDecompressedFile(fileName, 0);
 
       if (SDSFile) {
-         BOOL bResult = CopyIntoSharedMemoryInternal(pReadCallbacks, core);
+         bool bResult = CopyIntoSharedMemoryInternal(pReadCallbacks, core);
 
          // Shut down the normal file
          EndDecompressedFile();
@@ -3979,19 +3979,19 @@ public:
    //--------------------------------------------------------
    // Returns the names and enum flags of everything written
    // Called by DecompressFileIntenral
-   void MakeListNames(const INT64 nameBlockCount, const INT64 nameByteSize) {
+   void MakeListNames(const int64_t nameBlockCount, const int64_t nameByteSize) {
       const char* startNameData = pNameData;
       const char* pNames = pNameData;
 
       // for every name
-      for (int i = 0; i < nameBlockCount; i++) {
+      for (int32_t i = 0; i < nameBlockCount; i++) {
          const char* pStart = pNames;
 
          // skip to end (search for 0 terminating char)
          while (*pNames++);
 
          // get the enum
-         UINT8 value = *pNames++;
+         uint8_t value = *pNames++;
 
          //LOGGING("makelist name is %s, %d\n", pStart, i);
 
@@ -4011,7 +4011,7 @@ public:
    // return list of strings (column names)
    // on success pNameData is valid
    char* ReadListNames() {
-      INT64 nameSize = pFileHeader->NameBlockSize;
+      int64_t nameSize = pFileHeader->NameBlockSize;
 
       if (nameSize) {
          LOGGING("Name Block Count %lld,  namesize %lld\n", pFileHeader->NameBlockCount, nameSize);
@@ -4023,7 +4023,7 @@ public:
             return NULL;
          }
 
-         INT64 bytesRead =
+         int64_t bytesRead =
             DefaultFileIO.FileReadChunk(NULL, SDSFile, pNameData, nameSize, pFileHeader->NameBlockOffset);
 
          if (bytesRead != nameSize) {
@@ -4043,7 +4043,7 @@ public:
    // returns TRUE/FALSE
    // stops early if Mode == COMPRESSION_MODE_INFO
    // new ver 4.3: handles filter=
-   BOOL DecompressFileInternal(SDS_READ_CALLBACKS* pReadCallbacks, int core, INT64 startOffset) {
+   bool DecompressFileInternal(SDS_READ_CALLBACKS* pReadCallbacks, int32_t core, int64_t startOffset) {
 
       LOGGING("Reading filename %s normally.  Offset: %lld\n", FileName, startOffset);
 
@@ -4084,13 +4084,13 @@ public:
          }
 
          LOGGING("Reading array block at offset:%lld   size: %lld \n", pFileHeader->ArrayBlockOffset, pFileHeader->ArrayBlockSize);
-         INT64 bytesRead = DefaultFileIO.FileReadChunk(NULL, SDSFile, pArrayBlocks, pFileHeader->ArrayBlockSize, pFileHeader->ArrayBlockOffset);
+         int64_t bytesRead = DefaultFileIO.FileReadChunk(NULL, SDSFile, pArrayBlocks, pFileHeader->ArrayBlockSize, pFileHeader->ArrayBlockOffset);
          if (bytesRead != pFileHeader->ArrayBlockSize) {
             SetErr_Format(SDS_VALUE_ERROR, "Decompression error in ArrayBlockSize: %lld", pFileHeader->ArrayBlockSize);
             goto EXIT_DECOMPRESS;
          }
 
-         INT64 tupleSize = pFileHeader->ArraysWritten;
+         int64_t tupleSize = pFileHeader->ArraysWritten;
          LOGGING("Arrays to read %lld  %p\n", tupleSize, pArrayBlocks);
 
          // If we got this far, the file is good
@@ -4103,8 +4103,8 @@ public:
             return TRUE;
          }
 
-         INT fileType = pFileHeader->FileType;
-         BOOL fileTypeStackable = (fileType == SDS_FILE_TYPE_DATASET ||
+         int32_t fileType = pFileHeader->FileType;
+         bool fileTypeStackable = (fileType == SDS_FILE_TYPE_DATASET ||
             fileType == SDS_FILE_TYPE_TABLE ||
             fileType == SDS_FILE_TYPE_ARRAY);
 
@@ -4123,9 +4123,9 @@ public:
          LOGGING("Done allocating arrays %lld\n", tupleSize);
 
          // ---- ALLOCATE EVENT HANDLES
-         INT numCores = g_cMathWorker->GetNumCores();
+         int32_t numCores = g_cMathWorker->GetNumCores();
 
-         for (int j = 0; j < numCores; j++) {
+         for (int32_t j = 0; j < numCores; j++) {
             pstCompressArrays->pCoreMemory[j] = NULL;
             pstCompressArrays->pCoreMemorySize[j] = 0;
             pstCompressArrays->eventHandles[j] = DefaultFileIO.CreateEventHandle();
@@ -4143,7 +4143,7 @@ public:
 
          //---------- CLEAN UP MEMORY AND HANDLES ---------
          // check if any cores allocated any memory
-         for (int j = 0; j < numCores; j++) {
+         for (int32_t j = 0; j < numCores; j++) {
             if (pstCompressArrays->pCoreMemory[j]) {
                WORKSPACE_FREE(pstCompressArrays->pCoreMemory[j]);
             }
@@ -4178,7 +4178,7 @@ public:
    //
    // Returns NULL or result of what user returned in ReadFinalCallback
    //
-   void* DecompressFile(SDS_READ_CALLBACKS* pReadCallbacks, int core, INT64 fileOffset) {
+   void* DecompressFile(SDS_READ_CALLBACKS* pReadCallbacks, int32_t core, int64_t fileOffset) {
 
       LOGGING("Start of DCF %s [%lld]  %s\n", FileName, InstanceIndex, ShareName);
 
@@ -4191,7 +4191,7 @@ public:
 
          // Check for previous existence first
          HRESULT result = DefaultMemoryIO.MapExisting();
-         BOOL bResult = TRUE;
+         bool bResult = TRUE;
 
          if (result < 0) {
             LOGGING("Failed to find existing share name %s\n", DefaultMemoryIO.SharedMemoryName);
@@ -4233,7 +4233,7 @@ public:
          // Drop into normal file reading
       }
 
-      BOOL bResult;
+      bool bResult;
       bResult = DecompressFileInternal(pReadCallbacks, core, fileOffset);
 
       // Make sure final callback is ok to call as well
@@ -4284,8 +4284,8 @@ public:
 //   SDS_VOID
 //};
 
-static INT32 SDS_ITEMSIZE_TABLE[22] = {
-   1,         // BOOL
+static int32_t SDS_ITEMSIZE_TABLE[22] = {
+   1,         // bool
    1,   1,    // BYTE
    2,   2,    // SHORT
    4,   4,    // SDS_INT
@@ -4301,9 +4301,9 @@ static INT32 SDS_ITEMSIZE_TABLE[22] = {
 };
 
 
-void UpgradeType(SDS_ARRAY_BLOCK*  pMasterArrayBlock, int newdtype, INT64 itemsize) {
+void UpgradeType(SDS_ARRAY_BLOCK*  pMasterArrayBlock, int32_t newdtype, int64_t itemsize) {
 
-   int isize = 4;
+   int32_t isize = 4;
 
    // avoid the ambiguous type
    //newdtype = FixupDType(newdtype, itemsize);
@@ -4339,13 +4339,13 @@ void UpgradeType(SDS_ARRAY_BLOCK*  pMasterArrayBlock, int newdtype, INT64 itemsi
 typedef void(*CONVERT_INPLACE)(
    void* pDataIn,
    void* pDataOut,
-   INT64 dataOutSize,
-   int dtypein,
-   int dtypeout);
+   int64_t dataOutSize,
+   int32_t dtypein,
+   int32_t dtypeout);
 
 
 template<typename T, typename U>
-static void ConvertInplace(void* pDataIn, void* pDataOut, INT64 dataInSize, int dtypein, int dtypeout) {
+static void ConvertInplace(void* pDataIn, void* pDataOut, int64_t dataInSize, int32_t dtypein, int32_t dtypeout) {
 
    LOGGING("**conversion %p %p   inLenSize: %lld   inItemSize:%lld  outItemSize:%lld\n", pDataIn, pDataOut, dataInSize, sizeof(T), sizeof(U));
    T* pIn = (T*)pDataIn;
@@ -4353,8 +4353,8 @@ static void ConvertInplace(void* pDataIn, void* pDataOut, INT64 dataInSize, int 
    T pBadValueIn = *(T*)SDSGetDefaultType(dtypein);
    U pBadValueOut = *(U*)SDSGetDefaultType(dtypeout);
 
-   INT64 len = dataInSize / sizeof(T);
-   INT64 dataOutSize = len * sizeof(U);
+   int64_t len = dataInSize / sizeof(T);
+   int64_t dataOutSize = len * sizeof(U);
 
    if (dataInSize > dataOutSize) {
       printf("!! internal error in convertinplace\n");
@@ -4366,10 +4366,10 @@ static void ConvertInplace(void* pDataIn, void* pDataOut, INT64 dataInSize, int 
    pIn--;
    pOut--;
 
-   // NAN converts to MININT (for float --> int conversion)
-   // then the reverse, MIININT converts to NAN (for int --> float conversion)
-   // convert from int --> float
-   for (INT64 i = 0; i < len; i++) {
+   // NAN converts to MINint32_t (for float --> int32_t conversion)
+   // then the reverse, MIINint32_t converts to NAN (for int32_t --> float conversion)
+   // convert from int32_t --> float
+   for (int64_t i = 0; i < len; i++) {
       //printf("[%lld]converted %lf -> %lf\n", i, (double)*pIn, (double)*pOut);
       if (*pIn != pBadValueIn) {
          U temp = (U)*pIn;
@@ -4388,15 +4388,15 @@ static void ConvertInplace(void* pDataIn, void* pDataOut, INT64 dataInSize, int 
 //----------------------------------------
 // Assumes input is a float/double
 template<typename T, typename U>
-static void ConvertInplaceFloat(void* pDataIn, void* pDataOut, INT64 dataInSize, int dtypein, int dtypeout) {
+static void ConvertInplaceFloat(void* pDataIn, void* pDataOut, int64_t dataInSize, int32_t dtypein, int32_t dtypeout) {
 
    LOGGING("**conversionf %p %p   inLenSize: %lld   inItemSize:%lld  outItemSize:%lld\n", pDataIn, pDataOut, dataInSize, sizeof(T), sizeof(U));
    T* pIn = (T*)pDataIn;
    U* pOut = (U*)pDataOut;
    U pBadValueOut = *(U*)SDSGetDefaultType(dtypeout);
 
-   INT64 len = dataInSize / sizeof(T);
-   INT64 dataOutSize = len * sizeof(U);
+   int64_t len = dataInSize / sizeof(T);
+   int64_t dataOutSize = len * sizeof(U);
 
    if (dataInSize > dataOutSize) {
       printf("!! internal error in convertinplace\n");
@@ -4408,10 +4408,10 @@ static void ConvertInplaceFloat(void* pDataIn, void* pDataOut, INT64 dataInSize,
    pIn--;
    pOut--;
 
-   // NAN converts to MININT (for float --> int conversion)
-   // then the reverse, MIININT converts to NAN (for int --> float conversion)
-   // convert from int --> float
-   for (INT64 i = 0; i < len; i++) {
+   // NAN converts to MINint32_t (for float --> int32_t conversion)
+   // then the reverse, MIINint32_t converts to NAN (for int32_t --> float conversion)
+   // convert from int32_t --> float
+   for (int64_t i = 0; i < len; i++) {
       if (*pIn == *pIn) {
          *pOut = (U)*pIn;
       }
@@ -4429,14 +4429,14 @@ static void ConvertInplaceFloat(void* pDataIn, void* pDataOut, INT64 dataInSize,
 //----------------------------------------
 // Assumes input is uint8 out is uint32
 template<typename T, typename U>
-static void ConvertInplaceString(void* pDataIn, void* pDataOut, INT64 dataInSize, int dtypein, int dtypeout) {
+static void ConvertInplaceString(void* pDataIn, void* pDataOut, int64_t dataInSize, int32_t dtypein, int32_t dtypeout) {
 
    LOGGING("**conversions %p %p   inLenSize: %lld   inItemSize:%lld  outItemSize:%lld\n", pDataIn, pDataOut, dataInSize, sizeof(T), sizeof(U));
    T* pIn = (T*)pDataIn;
    U* pOut = (U*)pDataOut;
 
-   INT64 len = dataInSize / sizeof(T);
-   INT64 dataOutSize = len * sizeof(U);
+   int64_t len = dataInSize / sizeof(T);
+   int64_t dataOutSize = len * sizeof(U);
 
    if (dataInSize > dataOutSize) {
       printf("!! internal error in convertinplace\n");
@@ -4449,7 +4449,7 @@ static void ConvertInplaceString(void* pDataIn, void* pDataOut, INT64 dataInSize
    pOut--;
 
    // convert from utf8 to utf32
-   for (INT64 i = 0; i < len; i++) {
+   for (int64_t i = 0; i < len; i++) {
       *pOut = (U)*pIn;
       pIn--;
       pOut--;
@@ -4459,20 +4459,20 @@ static void ConvertInplaceString(void* pDataIn, void* pDataOut, INT64 dataInSize
 
 
 template<typename T>
-static CONVERT_INPLACE GetInplaceConversionStep2Float(int outputType) {
+static CONVERT_INPLACE GetInplaceConversionStep2Float(int32_t outputType) {
    switch (outputType) {
       //case SDS_BOOL:     return ConvertInplace<T, bool>;
    case SDS_FLOAT:    return ConvertInplaceFloat<T, float>;
    case SDS_DOUBLE:   return ConvertInplaceFloat<T, double>;
    case SDS_LONGDOUBLE: return ConvertInplaceFloat<T, long double>;
-   case SDS_BYTE:     return ConvertInplaceFloat<T, INT8>;
-   case SDS_SHORT:    return ConvertInplaceFloat<T, INT16>;
-   case SDS_INT:      return ConvertInplaceFloat<T, INT32>;
-   case SDS_LONGLONG: return ConvertInplaceFloat<T, INT64>;
-   case SDS_UBYTE:    return ConvertInplaceFloat<T, UINT8>;
-   case SDS_USHORT:   return ConvertInplaceFloat<T, UINT16>;
-   case SDS_UINT:     return ConvertInplaceFloat<T, UINT32>;
-   case SDS_ULONGLONG:return ConvertInplaceFloat<T, UINT64>;
+   case SDS_BYTE:     return ConvertInplaceFloat<T, int8_t>;
+   case SDS_SHORT:    return ConvertInplaceFloat<T, int16_t>;
+   case SDS_INT:      return ConvertInplaceFloat<T, int32_t>;
+   case SDS_LONGLONG: return ConvertInplaceFloat<T, int64_t>;
+   case SDS_UBYTE:    return ConvertInplaceFloat<T, uint8_t>;
+   case SDS_USHORT:   return ConvertInplaceFloat<T, uint16_t>;
+   case SDS_UINT:     return ConvertInplaceFloat<T, uint32_t>;
+   case SDS_ULONGLONG:return ConvertInplaceFloat<T, uint64_t>;
    }
    return NULL;
 
@@ -4480,41 +4480,41 @@ static CONVERT_INPLACE GetInplaceConversionStep2Float(int outputType) {
 
 
 template<typename T>
-static CONVERT_INPLACE GetInplaceConversionStep2(int outputType) {
+static CONVERT_INPLACE GetInplaceConversionStep2(int32_t outputType) {
    switch (outputType) {
       //case SDS_BOOL:     return ConvertInplace<T, bool>;
    case SDS_FLOAT:    return ConvertInplace<T, float>;
    case SDS_DOUBLE:   return ConvertInplace<T, double>;
    case SDS_LONGDOUBLE: return ConvertInplace<T, long double>;
-   case SDS_BYTE:     return ConvertInplace<T, INT8>;
-   case SDS_SHORT:    return ConvertInplace<T, INT16>;
-   case SDS_INT:      return ConvertInplace<T, INT32>;
-   case SDS_LONGLONG: return ConvertInplace<T, INT64>;
-   case SDS_UBYTE:    return ConvertInplace<T, UINT8>;
-   case SDS_USHORT:   return ConvertInplace<T, UINT16>;
-   case SDS_UINT:     return ConvertInplace<T, UINT32>;
-   case SDS_ULONGLONG:return ConvertInplace<T, UINT64>;
+   case SDS_BYTE:     return ConvertInplace<T, int8_t>;
+   case SDS_SHORT:    return ConvertInplace<T, int16_t>;
+   case SDS_INT:      return ConvertInplace<T, int32_t>;
+   case SDS_LONGLONG: return ConvertInplace<T, int64_t>;
+   case SDS_UBYTE:    return ConvertInplace<T, uint8_t>;
+   case SDS_USHORT:   return ConvertInplace<T, uint16_t>;
+   case SDS_UINT:     return ConvertInplace<T, uint32_t>;
+   case SDS_ULONGLONG:return ConvertInplace<T, uint64_t>;
    }
    return NULL;
 
 }
 
-static CONVERT_INPLACE GetInplaceConversionFunction(int inputType, int outputType) {
+static CONVERT_INPLACE GetInplaceConversionFunction(int32_t inputType, int32_t outputType) {
 
    switch (inputType) {
    case SDS_BOOL:      return GetInplaceConversionStep2<bool>(outputType);
    case SDS_FLOAT:     return GetInplaceConversionStep2Float<float>(outputType);
    case SDS_DOUBLE:    return GetInplaceConversionStep2Float<double>(outputType);
    case SDS_LONGDOUBLE: return GetInplaceConversionStep2Float<long double>(outputType);
-   case SDS_BYTE:      return GetInplaceConversionStep2<INT8>(outputType);
-   case SDS_SHORT:     return GetInplaceConversionStep2<INT16>(outputType);
-   case SDS_INT:       return GetInplaceConversionStep2<INT32>(outputType);
-   case SDS_LONGLONG:  return GetInplaceConversionStep2<INT64>(outputType);
-   case SDS_UBYTE:     return GetInplaceConversionStep2<UINT8>(outputType);
-   case SDS_USHORT:    return GetInplaceConversionStep2<UINT16>(outputType);
-   case SDS_UINT:      return GetInplaceConversionStep2<UINT32>(outputType);
-   case SDS_ULONGLONG: return GetInplaceConversionStep2<UINT64>(outputType);
-   case SDS_STRING: if (outputType == SDS_UNICODE) return ConvertInplaceString<UINT8, UINT32>; else break;
+   case SDS_BYTE:      return GetInplaceConversionStep2<int8_t>(outputType);
+   case SDS_SHORT:     return GetInplaceConversionStep2<int16_t>(outputType);
+   case SDS_INT:       return GetInplaceConversionStep2<int32_t>(outputType);
+   case SDS_LONGLONG:  return GetInplaceConversionStep2<int64_t>(outputType);
+   case SDS_UBYTE:     return GetInplaceConversionStep2<uint8_t>(outputType);
+   case SDS_USHORT:    return GetInplaceConversionStep2<uint16_t>(outputType);
+   case SDS_UINT:      return GetInplaceConversionStep2<uint32_t>(outputType);
+   case SDS_ULONGLONG: return GetInplaceConversionStep2<uint64_t>(outputType);
+   case SDS_STRING: if (outputType == SDS_UNICODE) return ConvertInplaceString<uint8_t, uint32_t>; else break;
    }
    return NULL;
 }
@@ -4526,52 +4526,52 @@ void GapFill(void* destBuffer, SDSArrayInfo* pDestInfo) {
    LOGGING(">>> gap fill in decompress multi array  length:%lld   dtype:%d  %p\n", pDestInfo->ArrayLength, pDestInfo->NumpyDType, destBuffer);
    LOGGING(">>> more gap dims: %d  itemsz:%d  dim0:%lld  strides0:%lld\n", pDestInfo->NDim, pDestInfo->ItemSize, pDestInfo->Dimensions[0], pDestInfo->Strides[0]);
 
-   INT64 oneRowSize = pDestInfo->ItemSize;
+   int64_t oneRowSize = pDestInfo->ItemSize;
    // Calc oneRowSize for multidimensional
-   for (int j = 1; j < pDestInfo->NDim; j++) {
+   for (int32_t j = 1; j < pDestInfo->NDim; j++) {
       oneRowSize *= pDestInfo->Dimensions[j];
    }
 
    // Get the invalid fill type
    void* pDefaultType = SDSGetDefaultType(pDestInfo->NumpyDType);
-   INT64 bytesToFill = oneRowSize * pDestInfo->ArrayLength;
+   int64_t bytesToFill = oneRowSize * pDestInfo->ArrayLength;
 
    switch (pDestInfo->ItemSize) {
    case 1:
    {
-      INT8* pDestBuffer = (INT8*)destBuffer;
-      INT8 invalid = *(INT8*)pDefaultType;
-      for (int j = 0; j < bytesToFill; j++) {
+      int8_t* pDestBuffer = (int8_t*)destBuffer;
+      int8_t invalid = *(int8_t*)pDefaultType;
+      for (int32_t j = 0; j < bytesToFill; j++) {
          pDestBuffer[j] = invalid;
       }
    }
    break;
    case 2:
    {
-      INT16* pDestBuffer = (INT16*)destBuffer;
-      INT16 invalid = *(INT16*)pDefaultType;
+      int16_t* pDestBuffer = (int16_t*)destBuffer;
+      int16_t invalid = *(int16_t*)pDefaultType;
       bytesToFill /= 2;
-      for (int j = 0; j < bytesToFill; j++) {
+      for (int32_t j = 0; j < bytesToFill; j++) {
          pDestBuffer[j] = invalid;
       }
    }
    break;
    case 4:
    {
-      INT32* pDestBuffer = (INT32*)destBuffer;
-      INT32 invalid = *(INT32*)pDefaultType;
+      int32_t* pDestBuffer = (int32_t*)destBuffer;
+      int32_t invalid = *(int32_t*)pDefaultType;
       bytesToFill /= 4;
-      for (int j = 0; j < bytesToFill; j++) {
+      for (int32_t j = 0; j < bytesToFill; j++) {
          pDestBuffer[j] = invalid;
       }
    }
    break;
    case 8:
    {
-      INT64* pDestBuffer = (INT64*)destBuffer;
-      INT64 invalid = *(INT64*)pDefaultType;
+      int64_t* pDestBuffer = (int64_t*)destBuffer;
+      int64_t invalid = *(int64_t*)pDefaultType;
       bytesToFill /= 8;
-      for (int j = 0; j < bytesToFill; j++) {
+      for (int32_t j = 0; j < bytesToFill; j++) {
          pDestBuffer[j] = invalid;
       }
    }
@@ -4589,27 +4589,27 @@ void GapFill(void* destBuffer, SDSArrayInfo* pDestInfo) {
 //---------------------------------------------------------
 //
 struct _SDS_WHICH_DTYPE {
-   INT8 isFloat;
-   INT8 isInt;
-   INT8 isUInt;
-   INT8 isString;
+   int8_t isFloat;
+   int8_t isInt;
+   int8_t isUInt;
+   int8_t isString;
 
-   INT8 isVoid;
-   INT8 isObject;
-   INT8 isUnknown;
-   INT8 reserved;
+   int8_t isVoid;
+   int8_t isObject;
+   int8_t isUnknown;
+   int8_t reserved;
 };
 
 struct SDS_WHICH_DTYPE {
    union {
       _SDS_WHICH_DTYPE  w;
-      INT64             whole;
+      int64_t             whole;
    };
 };
 
 //----------------------------------------------------------
 // returns with one of the dtype flags set
-SDS_WHICH_DTYPE WhichDType(int dtype)
+SDS_WHICH_DTYPE WhichDType(int32_t dtype)
 {
 
    SDS_WHICH_DTYPE retVal;
@@ -4643,7 +4643,7 @@ SDS_WHICH_DTYPE WhichDType(int dtype)
 
 //----------------------------------------------------------
 // Multithreaded call when stacking
-// int to float, int16 to int32, uint8 to int32 types of conversion
+// int32_t to float, int16 to int32, uint8 to int32 types of conversion
 // the master is the correct dtype
 // the slave must convert and the slave's itemsize is the <= master's itemsize
 // destSize MUST be recalculated if filtering
@@ -4651,12 +4651,12 @@ void  ConvertDType(
    char* destBuffer,
    SDS_ARRAY_BLOCK*  pMasterBlock,
    SDS_ARRAY_BLOCK*  pSlaveBlock,
-   INT64 slaveRows,
-   INT64 slaveItemSize)
+   int64_t slaveRows,
+   int64_t slaveItemSize)
 {
 
-   int sdtype = FixupDType(pSlaveBlock->DType, pSlaveBlock->ItemSize);
-   int mdtype = FixupDType(pMasterBlock->DType, pMasterBlock->ItemSize);
+   int32_t sdtype = FixupDType(pSlaveBlock->DType, pSlaveBlock->ItemSize);
+   int32_t mdtype = FixupDType(pMasterBlock->DType, pMasterBlock->ItemSize);
 
    LOGGING("Convert dtype from:%d  to: %d  buffer:%p  size: %lld   %d vs %d\n", sdtype, mdtype, destBuffer, slaveRows * slaveItemSize, pSlaveBlock->NDim, pMasterBlock->NDim);
    CONVERT_INPLACE pConvert = GetInplaceConversionFunction(
@@ -4665,8 +4665,8 @@ void  ConvertDType(
 
    // Code below to be deleted when bugs in filtering while loading are gone
    //// Calculate length
-   //INT64 dataInLen = pSlaveBlock->Dimensions[0] * pSlaveBlock->ItemSize;
-   //for (int j = 1; j < pSlaveBlock->NDim; j++) {
+   //int64_t dataInLen = pSlaveBlock->Dimensions[0] * pSlaveBlock->ItemSize;
+   //for (int32_t j = 1; j < pSlaveBlock->NDim; j++) {
    //   dataInLen *= pSlaveBlock->Dimensions[j];
    //}
    //
@@ -4688,10 +4688,10 @@ void  ConvertDType(
 typedef void(*SDS_COPY_FORTRAN)(
    void* pDest,        // (upper left corner of array)
    void* pSrc,         // the value to fill each element with
-   INT64 totalRowsize, // all the rows of all the files  
-   INT64 arrayOffset,  // start row for the current file
-   INT64 arrayRowsize, // rowLength for the current file
-   INT64 colSize);
+   int64_t totalRowsize, // all the rows of all the files  
+   int64_t arrayOffset,  // start row for the current file
+   int64_t arrayRowsize, // rowLength for the current file
+   int64_t colSize);
 
 //-----------------------------------------
 //---------------------------------------------------------------
@@ -4710,20 +4710,20 @@ template<typename T>
 void CopyFortran(
    void* pDestT,        // (upper left corner of array)
    void* pSrcT,         // the value to fill each element with
-   INT64 totalRowsize, // all the rows of all the files  
-   INT64 arrayOffset,  // start row for the current file
-   INT64 arrayRowsize, // rowLength for the current file
-   INT64 colSize) {
+   int64_t totalRowsize, // all the rows of all the files  
+   int64_t arrayOffset,  // start row for the current file
+   int64_t arrayRowsize, // rowLength for the current file
+   int64_t colSize) {
 
    T* pDest = (T*)pDestT;
    T* pOriginalDest = pDest;
    T* pSrc = (T*)pSrcT;
 
    // change all 0s to spaces
-   for (INT64 col = 0; col < colSize; col++) {
+   for (int64_t col = 0; col < colSize; col++) {
       // Advance to correct slot
       pDest = pOriginalDest + arrayOffset + (col*totalRowsize);
-      for (INT64 i = 0; i < arrayRowsize; i++) {
+      for (int64_t i = 0; i < arrayRowsize; i++) {
          *pDest++ = *pSrc++;
       }
    }
@@ -4731,20 +4731,20 @@ void CopyFortran(
 
 
 //-----------------------------------------
-SDS_COPY_FORTRAN GetCopyFortran(int dtype) {
+SDS_COPY_FORTRAN GetCopyFortran(int32_t dtype) {
    switch (dtype) {
-   case SDS_BOOL:      return CopyFortran<INT8>;
-   case SDS_FLOAT:     return CopyFortran<INT32>;
-   case SDS_DOUBLE:    return CopyFortran<INT64>;
+   case SDS_BOOL:      return CopyFortran<int8_t>;
+   case SDS_FLOAT:     return CopyFortran<int32_t>;
+   case SDS_DOUBLE:    return CopyFortran<int64_t>;
    case SDS_LONGDOUBLE: return CopyFortran<long double>;
-   case SDS_BYTE:      return CopyFortran<INT8>;
-   case SDS_SHORT:     return CopyFortran<INT16>;
-   case SDS_INT:       return CopyFortran<INT32>;
-   case SDS_LONGLONG:  return CopyFortran<INT64>;
-   case SDS_UBYTE:     return CopyFortran<INT8>;
-   case SDS_USHORT:    return CopyFortran<INT16>;
-   case SDS_UINT:      return CopyFortran<INT32>;
-   case SDS_ULONGLONG: return CopyFortran<INT64>;
+   case SDS_BYTE:      return CopyFortran<int8_t>;
+   case SDS_SHORT:     return CopyFortran<int16_t>;
+   case SDS_INT:       return CopyFortran<int32_t>;
+   case SDS_LONGLONG:  return CopyFortran<int64_t>;
+   case SDS_UBYTE:     return CopyFortran<int8_t>;
+   case SDS_USHORT:    return CopyFortran<int16_t>;
+   case SDS_UINT:      return CopyFortran<int32_t>;
+   case SDS_ULONGLONG: return CopyFortran<int64_t>;
    }
    return NULL;
 }
@@ -4753,10 +4753,10 @@ SDS_COPY_FORTRAN GetCopyFortran(int dtype) {
 //-----------------------------------------
 typedef void(*SDS_GAP_FILL_SPECIAL)(
    void* pDest,        // (upper left corner of array)
-   INT64 totalRowsize, // all the rows of all the files  
-   INT64 arrayOffset,  // start row for the current file
-   INT64 arrayRowsize, // rowLength for the current file
-   INT64 colSize);
+   int64_t totalRowsize, // all the rows of all the files  
+   int64_t arrayOffset,  // start row for the current file
+   int64_t arrayRowsize, // rowLength for the current file
+   int64_t colSize);
 
 //-----------------------------------------
 // Used to fill 2 dim rotated arrays
@@ -4765,10 +4765,10 @@ typedef void(*SDS_GAP_FILL_SPECIAL)(
 template<typename T>
 void GapFillSpecial(
    void* pDestT,        // (upper left corner of array)
-   INT64 totalRowsize, // all the rows of all the files  
-   INT64 arrayOffset,  // start row for the current file
-   INT64 arrayRowsize, // rowLength for the current file
-   INT64 colSize) {
+   int64_t totalRowsize, // all the rows of all the files  
+   int64_t arrayOffset,  // start row for the current file
+   int64_t arrayRowsize, // rowLength for the current file
+   int64_t colSize) {
 
    T* pDest = (T*)pDestT;
    T* pOriginalDest = pDest;
@@ -4779,13 +4779,13 @@ void GapFillSpecial(
 
    // Read horizontally (contiguous)
    // Write vertical (skip around)
-   for (INT64 i = 0; i < arrayRowsize; i++) {
+   for (int64_t i = 0; i < arrayRowsize; i++) {
 
       // Advance to correct slot
       pDest = pOriginalDest + arrayOffset + i;
 
       // change all 0s to spaces
-      for (INT64 col = 0; col < colSize; col++) {
+      for (int64_t col = 0; col < colSize; col++) {
          // replace 0 with space for matlab
          *pDest = fill;
 
@@ -4803,10 +4803,10 @@ void GapFillSpecial(
 template<typename T>
 void GapFillSpecialRowMajor(
    void* pDestT,        // (upper left corner of array)
-   INT64 totalRowsize, // all the rows of all the files  
-   INT64 arrayOffset,  // start row for the current file
-   INT64 arrayRowsize, // rowLength for the current file
-   INT64 colSize) {
+   int64_t totalRowsize, // all the rows of all the files  
+   int64_t arrayOffset,  // start row for the current file
+   int64_t arrayRowsize, // rowLength for the current file
+   int64_t colSize) {
 
    T* pDest = (T*)pDestT;
    T* pOriginalDest = pDest;
@@ -4819,7 +4819,7 @@ void GapFillSpecialRowMajor(
 
    // Read horizontally (contiguous)
    // Write vertical (skip around)
-   for (INT64 i = 0; i < (arrayRowsize * colSize); i++) {
+   for (int64_t i = 0; i < (arrayRowsize * colSize); i++) {
       *pDest++ = fill;
    }
 }
@@ -4844,15 +4844,15 @@ void GapFillSpecialRowMajor(
 //                  arrayRowSize: per file (3)
 //                  itemSize:     3
 // T is char for string
-// T is UINT32 for UNICODE
+// T is uint32_t for UNICODE
 //
 template<typename T>
 void MatlabStringFill(
-   UINT16* pDest,      // 2 byte unicode (see note on location)
-   INT64 totalRowsize, // all the rows of all the files  
-   INT64 arrayOffset,  // start row for the current file
-   INT64 arrayRowsize, // rowLength for the current file
-   INT64 itemSizeMaster) {
+   uint16_t* pDest,      // 2 byte unicode (see note on location)
+   int64_t totalRowsize, // all the rows of all the files  
+   int64_t arrayOffset,  // start row for the current file
+   int64_t arrayRowsize, // rowLength for the current file
+   int64_t itemSizeMaster) {
 
    // NOTE:
    // the pDest is not top left corner.. rather it is 
@@ -4862,7 +4862,7 @@ void MatlabStringFill(
    char* pCurrentDest = (char*)pDest;
    pCurrentDest = pCurrentDest - (arrayOffset*itemSizeMaster);
 
-   UINT16* pOriginalDest = (UINT16*)pCurrentDest;
+   uint16_t* pOriginalDest = (uint16_t*)pCurrentDest;
 
    pOriginalDest += arrayOffset;
    // the itemsize is correct as save as 1byte char then matlab wants 2byte char
@@ -4872,13 +4872,13 @@ void MatlabStringFill(
 
    // Read horizontally (contiguous)
    // Write vertical (skip around)
-   for (INT64 i = 0; i < arrayRowsize; i++) {
+   for (int64_t i = 0; i < arrayRowsize; i++) {
 
       // Advance to correct slot
       pDest = pOriginalDest + i;
 
       // matlab wants gapfill with spaces
-      for (INT64 col = 0; col < itemSizeMaster; col++) {
+      for (int64_t col = 0; col < itemSizeMaster; col++) {
          *pDest = 32;
          pDest += totalRowsize;
       }
@@ -4887,11 +4887,11 @@ void MatlabStringFill(
 
 template<typename T>
 void MatlabStringFillFromUnicode(
-   UINT16* pDest,      // 2 byte unicode (see note on location)
-   INT64 totalRowsize, // all the rows of all the files  
-   INT64 arrayOffset,  // start row for the current file
-   INT64 arrayRowsize, // rowLength for the current file
-   INT64 itemSizeMaster) {
+   uint16_t* pDest,      // 2 byte unicode (see note on location)
+   int64_t totalRowsize, // all the rows of all the files  
+   int64_t arrayOffset,  // start row for the current file
+   int64_t arrayRowsize, // rowLength for the current file
+   int64_t itemSizeMaster) {
 
    // NOTE:
    // the pDest is not top left corner.. rather it is 
@@ -4903,7 +4903,7 @@ void MatlabStringFillFromUnicode(
    pCurrentDest = pCurrentDest - (arrayOffset*itemSizeMaster);
    itemSizeMaster = itemSizeMaster / 4;
 
-   UINT16* pOriginalDest = (UINT16*)pCurrentDest;
+   uint16_t* pOriginalDest = (uint16_t*)pCurrentDest;
 
    pOriginalDest += arrayOffset;
 
@@ -4911,13 +4911,13 @@ void MatlabStringFillFromUnicode(
 
    // Read horizontally (contiguous)
    // Write vertical (skip around)
-   for (INT64 i = 0; i < arrayRowsize; i++) {
+   for (int64_t i = 0; i < arrayRowsize; i++) {
 
       // Advance to correct slot
       pDest = pOriginalDest + i;
 
       // matlab wants gapfill with spaces
-      for (INT64 col = 0; col < itemSizeMaster; col++) {
+      for (int64_t col = 0; col < itemSizeMaster; col++) {
          *pDest = 32;
          pDest += totalRowsize;
       }
@@ -4927,20 +4927,20 @@ void MatlabStringFillFromUnicode(
 
 
 //-----------------------------------------
-SDS_GAP_FILL_SPECIAL GetGapFillSpecial(int dtype) {
+SDS_GAP_FILL_SPECIAL GetGapFillSpecial(int32_t dtype) {
    switch (dtype) {
    case SDS_BOOL:      return GapFillSpecial<bool>;
    case SDS_FLOAT:     return GapFillSpecial<float>;
    case SDS_DOUBLE:    return GapFillSpecial<double>;
    case SDS_LONGDOUBLE: return GapFillSpecial<long double>;
-   case SDS_BYTE:      return GapFillSpecial<INT8>;
-   case SDS_SHORT:     return GapFillSpecial<INT16>;
-   case SDS_INT:       return GapFillSpecial<INT32>;
-   case SDS_LONGLONG:  return GapFillSpecial<INT64>;
-   case SDS_UBYTE:     return GapFillSpecial<UINT8>;
-   case SDS_USHORT:    return GapFillSpecial<UINT16>;
-   case SDS_UINT:      return GapFillSpecial<UINT32>;
-   case SDS_ULONGLONG: return GapFillSpecial<UINT64>;
+   case SDS_BYTE:      return GapFillSpecial<int8_t>;
+   case SDS_SHORT:     return GapFillSpecial<int16_t>;
+   case SDS_INT:       return GapFillSpecial<int32_t>;
+   case SDS_LONGLONG:  return GapFillSpecial<int64_t>;
+   case SDS_UBYTE:     return GapFillSpecial<uint8_t>;
+   case SDS_USHORT:    return GapFillSpecial<uint16_t>;
+   case SDS_UINT:      return GapFillSpecial<uint32_t>;
+   case SDS_ULONGLONG: return GapFillSpecial<uint64_t>;
    }
    return NULL;
 }
@@ -4961,13 +4961,13 @@ void GapFillAny(
    // TODO: matlab string fill is different
    // Fortran >= 2d arrays gap fill is different
    if (pMasterBlock->NDim >= 2 && pMasterBlock->Flags & SDS_ARRAY_F_CONTIGUOUS) {
-      INT64 totalRowLength = pMasterBlock->Dimensions[0];
+      int64_t totalRowLength = pMasterBlock->Dimensions[0];
 
       // rows for this file only
-      INT64 rowLength = pDestInfo->Dimensions[0];
+      int64_t rowLength = pDestInfo->Dimensions[0];
 
-      INT64 colSize = 1;
-      for (int j = 1; j < pMasterBlock->NDim; j++) {
+      int64_t colSize = 1;
+      for (int32_t j = 1; j < pMasterBlock->NDim; j++) {
          colSize *= pMasterBlock->Dimensions[j];
       }
 
@@ -4987,14 +4987,14 @@ void GapFillAny(
 
 #ifdef MATLAB_MODE
       if (pMasterBlock->DType == SDS_UNICODE || pMasterBlock->DType == SDS_STRING) {
-         INT64 totalRowLength = pMasterBlock->Dimensions[0];
-         INT64 rowLength = pDestInfo->Dimensions[0];
+         int64_t totalRowLength = pMasterBlock->Dimensions[0];
+         int64_t rowLength = pDestInfo->Dimensions[0];
 
          // fill with spaces for matlab
          if (pMasterBlock->DType == SDS_STRING) {
             // fill with spaces for matlab
-            MatlabStringFill<UINT16>(
-               (UINT16*)destBuffer,    // upper left corner of src
+            MatlabStringFill<uint16_t>(
+               (uint16_t*)destBuffer,    // upper left corner of src
                totalRowLength,
                pIOPacket->ArrayOffset, // array offset (start row)
                rowLength,              // rows for this file only
@@ -5002,8 +5002,8 @@ void GapFillAny(
          }
          else {
             // fill with spaces for matlab
-            MatlabStringFillFromUnicode<UINT16>(
-               (UINT16*)destBuffer,    // upper left corner of src
+            MatlabStringFillFromUnicode<uint16_t>(
+               (uint16_t*)destBuffer,    // upper left corner of src
                totalRowLength,
                pIOPacket->ArrayOffset, // array offset (start row)
                rowLength,              // rows for this file only
@@ -5042,16 +5042,16 @@ void GapFillAny(
 void RotationalFixup(
    char*      pDest,      // 
    char*      pSrc,       // 
-   INT64 totalRowsize, // all the rows of all the files  
-   INT64 arrayOffset,  // start row for the current file
-   INT64 arrayRowsize, // rowLength for the current file
-   INT64 arrayColsize, // colSize of the current file
-   INT64 itemSize) {
+   int64_t totalRowsize, // all the rows of all the files  
+   int64_t arrayOffset,  // start row for the current file
+   int64_t arrayRowsize, // rowLength for the current file
+   int64_t arrayColsize, // colSize of the current file
+   int64_t itemSize) {
 
    LOG_THREAD("Rotational2 fix off:%lld  totlrow:%lld  filerow:%lld  col:%lld  itemsz:%lld  dest:%p  %p\n", arrayOffset, totalRowsize, arrayRowsize, arrayColsize, itemSize, pDest, pSrc);
    char* pOriginalDest = pDest + (arrayOffset * itemSize);
 
-   for (INT64 i = 0; i < arrayColsize; i++) {
+   for (int64_t i = 0; i < arrayColsize; i++) {
 
       // Advance to correct slot
       pDest = pOriginalDest + (i*totalRowsize*itemSize);
@@ -5080,22 +5080,22 @@ void RotationalFixup(
 //                  arrayRowSize: per file (3)
 //                  itemSize:     3
 // T is char for string
-// T is UINT32 for UNICODE
+// T is uint32_t for UNICODE
 //
 template<typename T>
 void MatlabStringFixup(
-   UINT16* pDest,      // 2 byte unicode (upper left corner of array)
+   uint16_t* pDest,      // 2 byte unicode (upper left corner of array)
    T*      pSrc,       // 1 or 4 byte unicode (file upper left corner)
-   INT64 totalRowsize, // all the rows of all the files  
-   INT64 arrayOffset,  // start row for the current file
-   INT64 arrayRowsize, // rowLength for the current file
-   INT64 itemSize,
-   INT64 itemSizeMaster) {
+   int64_t totalRowsize, // all the rows of all the files  
+   int64_t arrayOffset,  // start row for the current file
+   int64_t arrayRowsize, // rowLength for the current file
+   int64_t itemSize,
+   int64_t itemSizeMaster) {
 
-   UINT16* pOriginalDest = pDest + arrayOffset;
+   uint16_t* pOriginalDest = pDest + arrayOffset;
    itemSize = itemSize / sizeof(T);
    itemSizeMaster = itemSizeMaster / sizeof(T);
-   INT64 itemSizeDelta = itemSizeMaster - itemSize;
+   int64_t itemSizeDelta = itemSizeMaster - itemSize;
 
    if (itemSizeDelta < 0) {
       // internal bug
@@ -5105,14 +5105,14 @@ void MatlabStringFixup(
 
    // Read horizontally (contiguous)
    // Write vertical (skip around)
-   for (INT64 i = 0; i < arrayRowsize; i++) {
+   for (int64_t i = 0; i < arrayRowsize; i++) {
 
       // Advance to correct slot
       pDest = pOriginalDest + i;
 
       // change all 0s to spaces
-      for (INT64 col = 0; col < itemSize; col++) {
-         UINT16 c = *pSrc++;
+      for (int64_t col = 0; col < itemSize; col++) {
+         uint16_t c = *pSrc++;
          if (c == 0) {
             // replace 0 with space for matlab
             *pDest = ' ';
@@ -5123,7 +5123,7 @@ void MatlabStringFixup(
          // skip horizontally
          pDest += totalRowsize;
       }
-      for (INT64 col = 0; col < itemSizeDelta; col++) {
+      for (int64_t col = 0; col < itemSizeDelta; col++) {
          *pDest = ' ';
          pDest += totalRowsize;
       }
@@ -5141,24 +5141,24 @@ void  StringFixup(
    char* destBuffer,
    SDS_ARRAY_BLOCK*  pMasterBlock,
    SDS_ARRAY_BLOCK*  pSlaveBlock,
-   INT64 slaveRowLength,
-   INT64 slaveItemSize)
+   int64_t slaveRowLength,
+   int64_t slaveItemSize)
 {
 
    // Only the itemsize for master is correct
    // The other dimensions are correct in the pSlaveBlock
-   INT64 oneRowSize = pMasterBlock->ItemSize;
-   for (int j = 1; j < pSlaveBlock->NDim; j++) {
+   int64_t oneRowSize = pMasterBlock->ItemSize;
+   for (int32_t j = 1; j < pSlaveBlock->NDim; j++) {
       oneRowSize *= pSlaveBlock->Dimensions[j];
    }
 
-   INT64 gap = oneRowSize - slaveItemSize;
+   int64_t gap = oneRowSize - slaveItemSize;
 
    // Code below to be deleted when ugs in filtering gone
-   //INT64 rows = pSlaveBlock->Dimensions[0];
+   //int64_t rows = pSlaveBlock->Dimensions[0];
    
    // new code for filtering..
-   INT64 rows = slaveRowLength;
+   int64_t rows = slaveRowLength;
 
    if (gap > 0 && rows > 0) {
       if (pMasterBlock->DType == SDS_STRING) {
@@ -5169,7 +5169,7 @@ void  StringFixup(
          pEndString1--;
          pEndString2--;
 
-         for (int i = 0; i < rows; i++) {
+         for (int32_t i = 0; i < rows; i++) {
             char* pFront = pEndString2 - gap;
             while (pEndString2 > pFront) {
                // zero pad backwards
@@ -5192,19 +5192,19 @@ void  StringFixup(
          slaveItemSize /= 4;
          gap /= 4;
 
-         UINT32* pEndString1 = (UINT32*)destBuffer + (slaveItemSize * rows);
-         UINT32* pEndString2 = (UINT32*)destBuffer + (oneRowSize * rows);
+         uint32_t* pEndString1 = (uint32_t*)destBuffer + (slaveItemSize * rows);
+         uint32_t* pEndString2 = (uint32_t*)destBuffer + (oneRowSize * rows);
          pEndString1--;
          pEndString2--;
 
-         for (int i = 0; i < rows; i++) {
+         for (int32_t i = 0; i < rows; i++) {
             // first copy the gap
-            for (int j = 0; j < gap; j++) {
+            for (int32_t j = 0; j < gap; j++) {
                // zero pad backwards
                *pEndString2-- = 0;
             }
             //then copy the string
-            for (int j = 0; j < slaveItemSize; j++) {
+            for (int32_t j = 0; j < slaveItemSize; j++) {
                // zero pad backwards
                *pEndString2-- = *pEndString1--;
             }
@@ -5221,11 +5221,11 @@ SDS_COMPATIBLE IsArrayCompatible(
    const char* colName,
    SDS_ARRAY_BLOCK* pMasterArrayBlock,
    SDS_ARRAY_BLOCK* pArrayBlock,
-   BOOL     doFixup) {
+   bool     doFixup) {
 
    // Fixup for int32 linux vs windows
-   int mdtype = FixupDType(pMasterArrayBlock->DType, pMasterArrayBlock->ItemSize);
-   int odtype = FixupDType(pArrayBlock->DType, pArrayBlock->ItemSize);
+   int32_t mdtype = FixupDType(pMasterArrayBlock->DType, pMasterArrayBlock->ItemSize);
+   int32_t odtype = FixupDType(pArrayBlock->DType, pArrayBlock->ItemSize);
 
    SDS_COMPATIBLE  c;
    c.IsCompatible = TRUE;
@@ -5263,20 +5263,20 @@ SDS_COMPATIBLE IsArrayCompatible(
          }
       }
       else {
-         // Some issue here... float vs int or similar
-         // int vs uint
+         // Some issue here... float vs int32_t or similar
+         // int32_t vs uint
          SDS_WHICH_DTYPE cwhole;
          cwhole.whole = (wmdtype.whole | wodtype.whole);
 
-         // Float to int or uint?
+         // Float to int32_t or uint?
          if (cwhole.w.isFloat && (cwhole.w.isInt || cwhole.w.isUInt)) {
             c.NeedsConversion = TRUE;
-            LOGGING("Conversion: possible upgrade to float32/64 from int/uint for col %s  %d to %d\n", colName, mdtype, odtype);
+            LOGGING("Conversion: possible upgrade to float32/64 from int/uint32_t for col %s  %d to %d\n", colName, mdtype, odtype);
 
             if (doFixup) {
                // does the master have the float?
                if (mdtype > odtype) {
-                  if (odtype >= SDS_INT && mdtype < SDS_DOUBLE) {
+                  if (odtype >= SDS_int32_t && mdtype < SDS_DOUBLE) {
                      // MUST BE ATLEAST FLOAT64!! (auto upgrade)
                      // upgrade the dtype
                      UpgradeType(pMasterArrayBlock, SDS_DOUBLE, 0);
@@ -5288,7 +5288,7 @@ SDS_COMPATIBLE IsArrayCompatible(
                }
                else {
 
-                  if (mdtype >= SDS_INT && odtype < SDS_DOUBLE) {
+                  if (mdtype >= SDS_int32_t && odtype < SDS_DOUBLE) {
                      // MUST BE ATLEAST FLOAT64!! (auto upgrade)
                      // upgrade the dtype
                      UpgradeType(pMasterArrayBlock, SDS_DOUBLE, 0);
@@ -5304,13 +5304,13 @@ SDS_COMPATIBLE IsArrayCompatible(
          }
          else
             if (cwhole.w.isUInt && cwhole.w.isInt) {
-               BOOL handleInt64ToUInt64 = TRUE;
+               bool handleInt64ToUInt64 = TRUE;
                c.NeedsConversion = TRUE;
-               LOGGING("Conversion: int /  uint for col %s  %d to %d  fixup: %d\n", colName, mdtype, odtype, doFixup);
+               LOGGING("Conversion: int32_t /  uint32_t for col %s  %d to %d  fixup: %d\n", colName, mdtype, odtype, doFixup);
 
                if (doFixup) {
-                  int hightype = mdtype;
-                  int lowtype = odtype;
+                  int32_t hightype = mdtype;
+                  int32_t lowtype = odtype;
                   if (lowtype > hightype) {
                      lowtype = mdtype;
                      hightype = odtype;
@@ -5332,7 +5332,7 @@ SDS_COMPATIBLE IsArrayCompatible(
                   }
                   else {
                      // newtype must be an int, so or 1
-                     int newtype = hightype | 1;
+                     int32_t newtype = hightype | 1;
 
                      // if we bumped up to the ambiguous type, (going from 6 to 7)
                      if (newtype == SDS_LONG) newtype = SDS_LONGLONG;
@@ -5384,14 +5384,14 @@ SDS_COMPATIBLE IsArrayCompatible(
       c.IsCompatible = FALSE;
    }
    if (pMasterArrayBlock->NDim > 1) {
-      for (int i = 1; i < pMasterArrayBlock->NDim; i++) {
+      for (int32_t i = 1; i < pMasterArrayBlock->NDim; i++) {
          if (pMasterArrayBlock->Dimensions[i] != pArrayBlock->Dimensions[i]) {
             LOGGING("!!!Incompat due to dim %d not macthing\n", i);
             c.IsCompatible = FALSE;
          }
       }
-      int mflag = (pMasterArrayBlock->Flags & SDS_ARRAY_F_CONTIGUOUS);
-      int oflag = (pArrayBlock->Flags & SDS_ARRAY_F_CONTIGUOUS);
+      int32_t mflag = (pMasterArrayBlock->Flags & SDS_ARRAY_F_CONTIGUOUS);
+      int32_t oflag = (pArrayBlock->Flags & SDS_ARRAY_F_CONTIGUOUS);
 
       if (mflag != oflag) {
          // possibly incompatible
@@ -5419,8 +5419,8 @@ void* CheckRotationalFixup(SDS_IO_PACKET* pIOPacket) {
          if (pMasterBlock->NDim > 2) {
             printf("!!! error cannot rotate above two dimensions\n");
          }
-         INT64 allocSize = pBlockInfo->ItemSize;
-         for (int j = 0; j < pBlockInfo->NDim; j++) {
+         int64_t allocSize = pBlockInfo->ItemSize;
+         for (int32_t j = 0; j < pBlockInfo->NDim; j++) {
             allocSize *= pBlockInfo->Dimensions[j];
          }
          return WORKSPACE_ALLOC(allocSize);
@@ -5428,7 +5428,7 @@ void* CheckRotationalFixup(SDS_IO_PACKET* pIOPacket) {
       }
       else {
          if (pIOPacket->Compatible.NeedsStringFixup & 2) {
-            INT64 allocSize = pBlockInfo->ItemSize * pBlockInfo->Dimensions[0];
+            int64_t allocSize = pBlockInfo->ItemSize * pBlockInfo->Dimensions[0];
             // pick up more string dimensions
             if (pBlockInfo->NDim > 1) {
                printf("!!! error cannot handle multid strings\n");
@@ -5447,7 +5447,7 @@ void* CheckRotationalFixup(SDS_IO_PACKET* pIOPacket) {
 //----------------------------------------------------------
 // Called from multiple threads
 // Frees the buffer allocated from CheckRotationalFixup
-BOOL FinishRotationalFixup(
+bool FinishRotationalFixup(
    SDS_IO_PACKET* pIOPacket,
    void*          origBuffer,
    void*          tempBuffer) {
@@ -5460,9 +5460,9 @@ BOOL FinishRotationalFixup(
    SDS_ARRAY_BLOCK*        pBlockInfo = pIOPacket->pBlockInfo;
 
    if (pMasterBlock->NDim >= 2 && pMasterBlock->Flags & SDS_ARRAY_F_CONTIGUOUS) {
-      INT64 totalRowLength = pMasterBlock->Dimensions[0];
-      INT64 rowLength = pBlockInfo->Dimensions[0];
-      INT64 colLength = pMasterBlock->Dimensions[1];
+      int64_t totalRowLength = pMasterBlock->Dimensions[0];
+      int64_t rowLength = pBlockInfo->Dimensions[0];
+      int64_t colLength = pMasterBlock->Dimensions[1];
 
       RotationalFixup(
          (char*)origBuffer,  // original buffer (upper left of final destination)
@@ -5476,14 +5476,14 @@ BOOL FinishRotationalFixup(
    }
    else
       if (pIOPacket->Compatible.NeedsStringFixup & 2) {
-         INT64 totalRowLength = pMasterBlock->Dimensions[0];
-         INT64 rowLength = pBlockInfo->Dimensions[0];
+         int64_t totalRowLength = pMasterBlock->Dimensions[0];
+         int64_t rowLength = pBlockInfo->Dimensions[0];
 
          if (pMasterBlock->DType == SDS_UNICODE) {
             //rotate and convert data from 1 byte to 2 bytes
-            MatlabStringFixup<UINT32>(
-               (UINT16*)origBuffer,  // original buffer (upper left of final destination)
-               (UINT32*)tempBuffer,  // upper left corner of src
+            MatlabStringFixup<uint32_t>(
+               (uint16_t*)origBuffer,  // original buffer (upper left of final destination)
+               (uint32_t*)tempBuffer,  // upper left corner of src
                totalRowLength,
                pIOPacket->ArrayOffset, // array offset (start row)
                rowLength,              // rows for this file only
@@ -5493,7 +5493,7 @@ BOOL FinishRotationalFixup(
          else {
 
             MatlabStringFixup<char>(
-               (UINT16*)origBuffer,  // original buffer (upper left of final destination)
+               (uint16_t*)origBuffer,  // original buffer (upper left of final destination)
                (char*)tempBuffer,    // upper left corner of src
                totalRowLength,
                pIOPacket->ArrayOffset, // array offset (start row)
@@ -5518,10 +5518,10 @@ BOOL FinishRotationalFixup(
 // for normal read: read into pstCompressArrays->ArrayInfo[t].pData
 // size of the READ: pBlockInfo->ArrayCompressedSize
 //
-BOOL DecompressMultiArray(
+bool DecompressMultiArray(
    void* pstCompressArraysV,
-   int   core,    // which thread running on
-   INT64 t)       // t=task count from 0 - # of iopackets
+   int32_t   core,    // which thread running on
+   int64_t t)       // t=task count from 0 - # of iopackets
 {
    LOG_THREAD("[%lld] Start of decompress multi array: core %d   compress: %p\n", t, core, pstCompressArraysV);
 
@@ -5529,7 +5529,7 @@ BOOL DecompressMultiArray(
    SDS_IO_PACKET*          pIOPacket = &pMultiIOPackets->pIOPacket[t];
    SDS_FILE_HANDLE         sdsFile = pIOPacket->FileHandle;
 
-   // point to block (different from single)
+   // point32_t to block (different from single)
    SDS_ARRAY_BLOCK*        pBlockInfo = pIOPacket->pBlockInfo;
 
    // Master block only exists when stacking
@@ -5564,7 +5564,7 @@ BOOL DecompressMultiArray(
 
    // Make sure we have a valid buffer
    if (destBuffer) {
-      INT64 source_size = pBlockInfo->ArrayCompressedSize;
+      int64_t source_size = pBlockInfo->ArrayCompressedSize;
 
       // Check for matlab strings which are 2 byte
       // If so, allocate another buffer
@@ -5601,12 +5601,12 @@ BOOL DecompressMultiArray(
       void* tempFileBuffer = pMultiIOPackets->pCoreMemory[core];
 
       // NEW ROUTINE...
-      INT64 result = 0;
+      int64_t result = 0;
       if (pIOPacket->StackPosition >= 0) {
 
          // If there is no filtering, the array length in bytes is the uncompressed size
-         INT64 slaveRowLength = 0;
-         INT64 slaveItemSize = GetBytesPerRow(pBlockInfo);
+         int64_t slaveRowLength = 0;
+         int64_t slaveItemSize = GetBytesPerRow(pBlockInfo);
 
          //  If no bytes to read..
          if (slaveItemSize == 0) return TRUE;
@@ -5707,7 +5707,7 @@ public:
    SDSIncludeExclude*   pSectionsList = NULL;
 
    // how many files (include both valid and invalid)
-   INT64                FileCount = 0;
+   int64_t                FileCount = 0;
 
    // user callbacks
    SDS_READ_CALLBACKS*  pReadCallbacks = NULL;
@@ -5716,7 +5716,7 @@ public:
    // Length of all valid filenames
    // Uee for stacking only
    struct SDS_DATASET {
-      INT64                Length;
+      int64_t                Length;
       // pointer to bands
       // which bands are valid?
    };
@@ -5729,22 +5729,22 @@ public:
    //                           lower 32 => column index
    struct SDS_COLUMN_KING {
       const char*       ColName;
-      INT64             ColPos;     // matches the ColumnVector
+      int64_t             ColPos;     // matches the ColumnVector
 
-      INT32             FileRow;    // first file that had this column
-      INT32             ArrayEnum;  // enum of first file that had this column
+      int32_t             FileRow;    // first file that had this column
+      int32_t             ArrayEnum;  // enum of first file that had this column
 
       SDS_ARRAY_BLOCK   KingBlock;          // the king block (master block that determines array dtype)
       SDS_ARRAY_BLOCK** ppArrayBlocks;      // allocate array of these
-      INT64*            pArrayOffsets;      // must be deleted separately 0:5:10:15:20
-      INT64*            pOriginalArrayOffsets;      // must be deleted separately 0:5:10:15:20
-      INT64*            pOriginalLengths;   // must be deleted separately 5:5:5:5:5 -- 0 if needs invalid filling
+      int64_t*            pArrayOffsets;      // must be deleted separately 0:5:10:15:20
+      int64_t*            pOriginalArrayOffsets;      // must be deleted separately 0:5:10:15:20
+      int64_t*            pOriginalLengths;   // must be deleted separately 5:5:5:5:5 -- 0 if needs invalid filling
 
-      INT64             TotalRowLength;      // valid when done tallying
+      int64_t             TotalRowLength;      // valid when done tallying
    };
 
    // check for existence (store column position which can be used in SDS_COLUMN_ORDER)
-   typedef std::unordered_map<std::string, INT64>  SDS_COLUMN_HASH;
+   typedef std::unordered_map<std::string, int64_t>  SDS_COLUMN_HASH;
 
    // insert in order.  TotalUniqueColumns is how many vectors.
    typedef std::vector<SDS_COLUMN_KING>   SDS_COLUMN_ORDER;
@@ -5752,21 +5752,21 @@ public:
    // warning: not concurrent multithread safe
    SDS_COLUMN_HASH      ColumnExists;
    SDS_COLUMN_ORDER     ColumnVector;
-   INT                  TotalUniqueColumns = 0;
-   INT                  TotalStringFixups = 0;
-   INT                  TotalConversions = 0;
-   INT                  TotalDimensionProblems = 0;
-   INT                  TotalColumnGaps = 0;
-   INT                  TotalFirstColumns = 0;
-   INT                  LastRow = -1;
+   int32_t                  TotalUniqueColumns = 0;
+   int32_t                  TotalStringFixups = 0;
+   int32_t                  TotalConversions = 0;
+   int32_t                  TotalDimensionProblems = 0;
+   int32_t                  TotalColumnGaps = 0;
+   int32_t                  TotalFirstColumns = 0;
+   int32_t                  LastRow = -1;
 
 
    //------------------------------------------------
    // input validCount (number of files and thus number of Datasets)
    void AllocateDatasetLengths(
-      INT64 validCount) {
+      int64_t validCount) {
 
-      INT64 allocSize = sizeof(SDS_DATASET)*(validCount);
+      int64_t allocSize = sizeof(SDS_DATASET)*(validCount);
       pDatasets = (SDS_DATASET*)WORKSPACE_ALLOC(allocSize);
       memset(pDatasets, 0, allocSize);
    }
@@ -5778,22 +5778,22 @@ public:
    // returns pArrayLengths
    // returns ppArrayBlocks
    void AllocateVectorList(
-      INT64 validCount,
-      INT64* &pArrayOffsets,
-      INT64* &pOriginalArrayOffsets,
-      INT64* &pOriginalLengths,
+      int64_t validCount,
+      int64_t* &pArrayOffsets,
+      int64_t* &pOriginalArrayOffsets,
+      int64_t* &pOriginalLengths,
       SDS_ARRAY_BLOCK** &ppArrayBlocks) {
 
       // for only valid files
       // arrayoffsets has onemore entry for the final total
-      INT64 allocSize = sizeof(INT64)*(validCount + 1);
-      pArrayOffsets = (INT64*)WORKSPACE_ALLOC(allocSize);
+      int64_t allocSize = sizeof(int64_t)*(validCount + 1);
+      pArrayOffsets = (int64_t*)WORKSPACE_ALLOC(allocSize);
       //memset(pArrayOffsets, 0, allocSize);
 
-      pOriginalArrayOffsets = (INT64*)WORKSPACE_ALLOC(allocSize);
+      pOriginalArrayOffsets = (int64_t*)WORKSPACE_ALLOC(allocSize);
       //memset(pOriginalArrayOffsets, 0, allocSize);
 
-      pOriginalLengths = (INT64*)WORKSPACE_ALLOC(allocSize);
+      pOriginalLengths = (int64_t*)WORKSPACE_ALLOC(allocSize);
       memset(pOriginalLengths, 0, allocSize);
 
       allocSize = sizeof(SDS_ARRAY_BLOCK*)*(validCount);
@@ -5805,7 +5805,7 @@ public:
    // Cleans up the additional allocation that go with each unique column
    void ClearVectorList() {
       // TODO delete this better
-      for (int i = 0; i < TotalUniqueColumns; i++) {
+      for (int32_t i = 0; i < TotalUniqueColumns; i++) {
          WORKSPACE_FREE(ColumnVector[i].ppArrayBlocks);
          WORKSPACE_FREE(ColumnVector[i].pArrayOffsets);
          WORKSPACE_FREE(ColumnVector[i].pOriginalArrayOffsets);
@@ -5845,18 +5845,18 @@ public:
    // 
    // if the name is not found, the unique count goes up
    void AddColumnList(
-      INT64 validPos,
-      INT64 validCount,
+      int64_t validPos,
+      int64_t validCount,
       const char* columnName,
-      INT32 arrayEnum,  // DATASET, OTHER
-      INT32 fileRow,
-      INT64 column,
+      int32_t arrayEnum,  // DATASET, OTHER
+      int32_t fileRow,
+      int64_t column,
       SDS_ARRAY_BLOCK* pArrayBlock) {
 
       SDS_ARRAY_BLOCK**  ppArrayBlocks = NULL;
-      INT64* pArrayOffsets = NULL;
-      INT64* pOriginalArrayOffsets = NULL;
-      INT64* pOriginalLengths = NULL;
+      int64_t* pArrayOffsets = NULL;
+      int64_t* pOriginalArrayOffsets = NULL;
+      int64_t* pOriginalLengths = NULL;
 
       std::string item = std::string(columnName);
       auto columnFind = ColumnExists.find(item);
@@ -5900,7 +5900,7 @@ public:
       else {
 
          // Get the master column
-         INT64 colPos = columnFind->second;
+         int64_t colPos = columnFind->second;
          ppArrayBlocks = ColumnVector[colPos].ppArrayBlocks;
          pArrayOffsets = ColumnVector[colPos].pArrayOffsets;
          pOriginalArrayOffsets = ColumnVector[colPos].pOriginalArrayOffsets;
@@ -5933,7 +5933,7 @@ public:
 
       // If we have 1 or more dimensions, the length is the first dimension
       if (pArrayBlock->NDim > 0) {
-         INT64 rowLength = pArrayBlock->Dimensions[0];
+         int64_t rowLength = pArrayBlock->Dimensions[0];
          pOriginalLengths[validPos] = rowLength;
       }
 
@@ -5950,7 +5950,7 @@ public:
       SDSIncludeExclude*   pIncludeList,
       SDSIncludeExclude*   pFolderList,
       SDSIncludeExclude*   pSectionsList,
-      INT64                fileCount,
+      int64_t                fileCount,
       SDS_READ_CALLBACKS*  pReadCallbacks) {
 
       this->pSDSDecompressFile = pSDSDecompressFile;
@@ -5966,7 +5966,7 @@ public:
    //=================================================
    // Multithreaded callback
    // passes a pointer to itself since static function
-   static BOOL DecompressManyFiles(void* pstManyV, int core, INT64 t) {
+   static bool DecompressManyFiles(void* pstManyV, int32_t core, int64_t t) {
 
       SDSDecompressManyFiles* pSDSDecompressMany = (SDSDecompressManyFiles*)pstManyV;
       SDSDecompressFile* pSDSDecompressFile = pSDSDecompressMany->pSDSDecompressFile[t];
@@ -5982,7 +5982,7 @@ public:
 
    //===========================================
    // multithreaded kick off  (NOTE: do not use non-thread safe calls here)
-   void GetFileInfo(int multiMode) {
+   void GetFileInfo(int32_t multiMode) {
       //printf("Calling... %lld %p\n", i, pSDSDecompressFile[i]);
       // Multithreaded work and we tell caller when we started/stopped
       void* saveState = pReadCallbacks->BeginAllowThreads();
@@ -5998,10 +5998,10 @@ public:
    void* ReadIOPackets(SDS_FINAL_CALLBACK* pReadFinalCallback, SDS_READ_CALLBACKS* pReadCallbacks) {
       // Build IO LIST
       //Allocate all the arrays
-      INT64 totalIOPackets = 0;
+      int64_t totalIOPackets = 0;
 
       // First pass, calculate what we need
-      for (INT64 f = 0; f < FileCount; f++) {
+      for (int64_t f = 0; f < FileCount; f++) {
          SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[f];
          if (pSDSDecompress->IsFileValid) {
             totalIOPackets += pSDSDecompress->GetTotalArraysWritten();
@@ -6012,14 +6012,14 @@ public:
 
       // Allocate MultiIO PACKETS!!
       SDS_MULTI_IO_PACKETS* pMultiIOPackets = SDS_MULTI_IO_PACKETS::Allocate(totalIOPackets, &pReadCallbacks->Filter);
-      INT64 currentPos = 0;
+      int64_t currentPos = 0;
 
       // Fill in all the IOPACKETs
       // Skip over invalid files
-      for (INT64 f = 0; f < FileCount; f++) {
+      for (int64_t f = 0; f < FileCount; f++) {
          SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[f];
          if (pSDSDecompress->IsFileValid) {
-            INT64 tupleSize = pSDSDecompress->pFileHeader->ArraysWritten;
+            int64_t tupleSize = pSDSDecompress->pFileHeader->ArraysWritten;
 
             LOGGING("Allocating %lld arrays\n", tupleSize);
 
@@ -6059,14 +6059,14 @@ public:
 
    static void UpdateSectionData(
       char* pSectionData,
-      INT64 currentSection,
-      INT64 currentOffset) {
+      int64_t currentSection,
+      int64_t currentOffset) {
 
       // again very hackish
       char* pEntry = pSectionData + (currentSection * 10);
       pEntry[0] = '0';
       pEntry[1] = 0;
-      *(INT64*)(pEntry + 2) = currentOffset;
+      *(int64_t*)(pEntry + 2) = currentOffset;
 
    }
    //=====================================================
@@ -6075,22 +6075,22 @@ public:
    // fileOffset is the offset in the output file to start writing at
    // fileSize is the size of the input file
    // set localOffset to non-zero to indicate a section copy
-   static INT64 AppendToFile(
+   static int64_t AppendToFile(
       SDS_FILE_HANDLE  outFileHandle, 
       SDSDecompressFile* pSDSDecompress,
-      INT64 fileOffset, 
-      INT64 fileSize,
+      int64_t fileOffset, 
+      int64_t fileSize,
       char* pSectionData,
-      INT64 &currentSection) {
+      int64_t &currentSection) {
 
       LOGGING("files %s has size %lld\n", pSDSDecompress->FileName, fileSize);
       SDS_FILE_HEADER *pFileHeader = &pSDSDecompress->FileHeader;
-      INT64 currentOffset = fileOffset;
+      int64_t currentOffset = fileOffset;
 
-      INT64 origArrayBlockOffset = pFileHeader->ArrayBlockOffset;
+      int64_t origArrayBlockOffset = pFileHeader->ArrayBlockOffset;
       SDS_FILE_HANDLE inFile = pSDSDecompress->SDSFile;
-      BOOL hasSections = FALSE;
-      INT64 localOffset = 0;
+      bool hasSections = FALSE;
+      int64_t localOffset = 0;
 
       if (pFileHeader->SectionBlockOffset) {
          LOGGING("!!warning file %s has section within section when concat\n", pSDSDecompress->FileName);
@@ -6098,7 +6098,7 @@ public:
       }
 
       // end of file might be larger due to padding... when it is, cap to filesize
-      //INT64 calculatedSize = pFileHeader->GetEndOfFileOffset();
+      //int64_t calculatedSize = pFileHeader->GetEndOfFileOffset();
       //
       //if (calculatedSize < fileSize) {
       //   printf("reducing size %lld!\n", fileSize);
@@ -6118,7 +6118,7 @@ public:
       pFileHeader->FileOffset += fileOffset;
 
       // append the file header to the output file at fileOffset
-      INT64 bytesXfer = DefaultFileIO.FileWriteChunk(NULL, outFileHandle, pFileHeader, sizeof(SDS_FILE_HEADER), fileOffset);
+      int64_t bytesXfer = DefaultFileIO.FileWriteChunk(NULL, outFileHandle, pFileHeader, sizeof(SDS_FILE_HEADER), fileOffset);
       if (bytesXfer != sizeof(SDS_FILE_HEADER)) {
          LOGGING("!!warning file %s failed to write header at offset %lld\n", pSDSDecompress->FileName, fileOffset);
       }
@@ -6131,19 +6131,19 @@ public:
       localOffset += sizeof(SDS_FILE_HEADER);
 
       // Use a 1 MB buffer
-      const INT64 BUFFER_SIZE = 1024 * 1024;
+      const int64_t BUFFER_SIZE = 1024 * 1024;
       char* pBuffer = (char*)WORKSPACE_ALLOC(BUFFER_SIZE);
       if (!pBuffer) return 0;
 
       // Read from source at localoffset and copy to output at currentOffset (which starts at fileOffset)
       while (fileSize > 0) {
-         INT64 copySize = fileSize;
+         int64_t copySize = fileSize;
          if (fileSize > BUFFER_SIZE) {
             copySize = BUFFER_SIZE;
          }
          // read and write
-         INT64 sizeRead = DefaultFileIO.FileReadChunk(NULL, inFile, pBuffer, copySize, localOffset);
-         INT64 sizeWritten = DefaultFileIO.FileWriteChunk(NULL, outFileHandle, pBuffer, copySize, currentOffset);
+         int64_t sizeRead = DefaultFileIO.FileReadChunk(NULL, inFile, pBuffer, copySize, localOffset);
+         int64_t sizeWritten = DefaultFileIO.FileWriteChunk(NULL, outFileHandle, pBuffer, copySize, currentOffset);
          if (sizeRead != sizeWritten || sizeRead != copySize) {
             printf("!!Failed to copy file %s at offset %lld and %lld\n", pSDSDecompress->FileName, currentOffset, localOffset);
          }
@@ -6164,7 +6164,7 @@ public:
       }
 
       // fixup arrayblocks
-      for (int i = 0; i < pFileHeader->ArraysWritten; i++) {
+      for (int32_t i = 0; i < pFileHeader->ArraysWritten; i++) {
          //printf("start offset %d %lld\n", i, pDestArrayBlock[i].ArrayDataOffset);
          pDestArrayBlock[i].ArrayDataOffset += fileOffset;
       }
@@ -6176,14 +6176,14 @@ public:
       //------------
       // Check if sections.. if so read back in each section and fix it up
       if (hasSections) {
-         INT64 sections = pSDSDecompress->cSectionName.SectionCount;
+         int64_t sections = pSDSDecompress->cSectionName.SectionCount;
 
-         for (INT64 section = 1; section < sections; section++) {
-            INT64 sectionOffset = pSDSDecompress->cSectionName.pSectionOffsets[section];
+         for (int64_t section = 1; section < sections; section++) {
+            int64_t sectionOffset = pSDSDecompress->cSectionName.pSectionOffsets[section];
             // section within a section
             // read in a new fileheader
             SDS_FILE_HEADER tempFileHeader;
-            INT64 bytesRead = DefaultFileIO.FileReadChunk(NULL, inFile, &tempFileHeader, sizeof(SDS_FILE_HEADER), sectionOffset);
+            int64_t bytesRead = DefaultFileIO.FileReadChunk(NULL, inFile, &tempFileHeader, sizeof(SDS_FILE_HEADER), sectionOffset);
 
             LOGGING("concat: reading section at %lld for output fileoffset %lld\n", sectionOffset, fileOffset);
 
@@ -6205,12 +6205,12 @@ public:
             tempFileHeader.SectionBlockOffset = 0;
             tempFileHeader.FileOffset += fileOffset;
 
-            INT64 newOffset = fileOffset + sectionOffset;
+            int64_t newOffset = fileOffset + sectionOffset;
 
             LOGGING("concat: newoffset: %lld   %lld + %lld\n", newOffset, fileOffset, sectionOffset);
             UpdateSectionData(pSectionData, currentSection++, newOffset);
 
-            INT64 sizeWritten = DefaultFileIO.FileWriteChunk(NULL, outFileHandle, &tempFileHeader, sizeof(SDS_FILE_HEADER), newOffset);
+            int64_t sizeWritten = DefaultFileIO.FileWriteChunk(NULL, outFileHandle, &tempFileHeader, sizeof(SDS_FILE_HEADER), newOffset);
             LOGGING("Wrote subsect fileheader %lld bytes at offset %lld\n", sizeof(SDS_FILE_HEADER), newOffset);
             if (sizeof(SDS_FILE_HEADER) != sizeWritten) {
                printf("!!Failed to copy file %s at offset %lld and %lld\n", pSDSDecompress->FileName, newOffset, sectionOffset);
@@ -6229,7 +6229,7 @@ public:
             }
 
             // fixup arrayblocks
-            for (int i = 0; i < tempFileHeader.ArraysWritten; i++) {
+            for (int32_t i = 0; i < tempFileHeader.ArraysWritten; i++) {
                 //printf("start offset %d %lld\n", i, pDestArrayBlock2[i].ArrayDataOffset);
                 pDestArrayBlock2[i].ArrayDataOffset += fileOffset;
             }
@@ -6252,7 +6252,7 @@ public:
    // In: strOutputFilename: full path filename to create
    // Uses pSDSDecompressFile
    //
-   void* SDSConcatFiles(const char* strOutputFilename, INT64 validCount) {
+   void* SDSConcatFiles(const char* strOutputFilename, int64_t validCount) {
       LOGGING("concat mode!  found %lld files\n", FileCount);
 
       if (validCount == 0) {
@@ -6271,12 +6271,12 @@ public:
       // The very first valid file is copied as is
       // Keep track of section offsets (section offset rewritten)
       //
-      INT64 fileOffset = 0;
+      int64_t fileOffset = 0;
       SDS_FILE_HEADER*  pFileHeader = NULL;
-      INT64 sectionCount = 0;
+      int64_t sectionCount = 0;
 
       // Pass 1 count sections
-      for (INT64 t = 0; t < FileCount; t++) {
+      for (int64_t t = 0; t < FileCount; t++) {
          SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[t];
          if (pSDSDecompress->IsFileValid) {
             if (!pFileHeader) pFileHeader = &pSDSDecompress->FileHeader;
@@ -6296,26 +6296,26 @@ public:
       if (pFileHeader) {
 
          // Allocate section data
-         INT64 sectionSize = sectionCount * 10;
-         INT64 sectionTotalSize = SDS_PAD_NUMBER(sectionSize);
-         INT64 currentSection = 0;
+         int64_t sectionSize = sectionCount * 10;
+         int64_t sectionTotalSize = SDS_PAD_NUMBER(sectionSize);
+         int64_t currentSection = 0;
          char* pSectionData = (char*)WORKSPACE_ALLOC(sectionTotalSize);
 
          // Pass 2 append to file
-         for (INT64 t = 0; t < FileCount; t++) {
+         for (int64_t t = 0; t < FileCount; t++) {
             SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[t];
             if (pSDSDecompress->IsFileValid) {
 
-               INT64 nextOffset =
+               int64_t nextOffset =
                   AppendToFile(fileHandle, pSDSDecompress, fileOffset, pSDSDecompress->FileSize, pSectionData, currentSection);
 
-               INT64 padFileSize = SDS_PAD_NUMBER(nextOffset);
+               int64_t padFileSize = SDS_PAD_NUMBER(nextOffset);
                fileOffset = padFileSize;
             }
          }
 
          // write section header
-         INT64 result = DefaultFileIO.FileWriteChunk(NULL, fileHandle, pSectionData, sectionTotalSize, fileOffset);
+         int64_t result = DefaultFileIO.FileWriteChunk(NULL, fileHandle, pSectionData, sectionTotalSize, fileOffset);
 
          if (result != sectionTotalSize) {
             SetErr_Format(SDS_VALUE_ERROR, "Compression error cannot append section %lld at %lld", pFileHeader->SectionBlockReservedSize, pFileHeader->SectionBlockOffset);
@@ -6342,7 +6342,7 @@ public:
    // this routine does NOT stack
    // may return NULL if not all files exist
    // 
-   void* ReadManyFiles(SDS_READ_CALLBACKS*  pReadCallbacks, int multiMode) {
+   void* ReadManyFiles(SDS_READ_CALLBACKS*  pReadCallbacks, int32_t multiMode) {
       // Open what might be 100+ files
       GetFileInfo(multiMode);
 
@@ -6354,12 +6354,12 @@ public:
          pSDSDecompressFileExtra = ScanForSections();
       }
 
-      INT64 validCount = 0;
+      int64_t validCount = 0;
       void* result = NULL;
-      INT32 missingfile = -1;
+      int32_t missingfile = -1;
 
       // Get valid count
-      for (INT32 t = 0; t < FileCount; t++) {
+      for (int32_t t = 0; t < FileCount; t++) {
          if (pSDSDecompressFile[t]->IsFileValid) validCount++;
          else missingfile = t;
       }
@@ -6380,8 +6380,8 @@ public:
       else {
          // TJD new code for ver 4.4... check for sections
          // To be completed when we support nested structs within the same file
-         //INT64   FileWithSectionsCount = 0;
-         //for (INT64 t = 0; t < FileCount; t++) {
+         //int64_t   FileWithSectionsCount = 0;
+         //for (int64_t t = 0; t < FileCount; t++) {
          //   SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[t];
 
          //   if (pSDSDecompress->IsFileValid && pSDSDecompress->pFileHeader->SectionBlockCount > 1) {
@@ -6397,7 +6397,7 @@ public:
 
          //if (pReadCallbacks->MustExist) {
          //   // check if all files valid
-         //   for (INT64 t = 0; t < FileCount; t++) {
+         //   for (int64_t t = 0; t < FileCount; t++) {
          //      SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[t];
 
          //      if (!pSDSDecompress->IsFileValid) {
@@ -6413,7 +6413,7 @@ public:
 
          // Now build a hash of all the valid filenames
          // Also.. how homogenous are the files... all datasets?  all structs?
-         for (INT64 t = 0; t < FileCount; t++) {
+         for (int64_t t = 0; t < FileCount; t++) {
             SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[t];
 
             // 
@@ -6488,7 +6488,7 @@ public:
 
       // Check if we expanded becaue we found extra sections
       if (pSDSDecompressFileExtra) {
-         for (INT64 i = 0; i < FileCount; i++) {
+         for (int64_t i = 0; i < FileCount; i++) {
             delete pSDSDecompressFileExtra[i];
          }
          WORKSPACE_FREE(pSDSDecompressFileExtra);
@@ -6498,7 +6498,7 @@ public:
    }
 
    //========================================
-   SDSDecompressFile* CopyDecompressFileFrom(SDSDecompressFile* pSDSDecompress, INT64 instance) {
+   SDSDecompressFile* CopyDecompressFileFrom(SDSDecompressFile* pSDSDecompress, int64_t instance) {
       return new SDSDecompressFile(
          pSDSDecompress->FileName,
          pSDSDecompress->pInclude,
@@ -6515,10 +6515,10 @@ public:
    SDSDecompressFile**  ScanForSections() {
       SDSDecompressFile** pSDSDecompressFileExtra = NULL;
 
-      INT64   FileWithSectionsCount = 0;
+      int64_t   FileWithSectionsCount = 0;
 
       // First pass, count up how many sections total
-      for (INT64 t = 0; t < FileCount; t++) {
+      for (int64_t t = 0; t < FileCount; t++) {
          SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[t];
 
          if (pSDSDecompress->IsFileValid && pSDSDecompress->pFileHeader->SectionBlockCount > 0) {
@@ -6541,24 +6541,24 @@ public:
          FileWithSectionsCount = 0;
 
          // TODO: multithread since we know at least one file has a section
-         for (INT64 t = 0; t < FileCount; t++) {
+         for (int64_t t = 0; t < FileCount; t++) {
             SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[t];
 
             if (pSDSDecompress->IsFileValid && pSDSDecompress->pFileHeader->SectionBlockCount > 1) {
 
                // blockcount is how many sections (files within a file) this file has
-               INT64 blockcount = pSDSDecompress->pFileHeader->SectionBlockCount;
+               int64_t blockcount = pSDSDecompress->pFileHeader->SectionBlockCount;
 
                // Read in all the sections (new for ver 4.4)
-               for (INT64 section = 0; section < blockcount; section++) {
-                  INT64 instance = FileWithSectionsCount + section;
+               for (int64_t section = 0; section < blockcount; section++) {
+                  int64_t instance = FileWithSectionsCount + section;
                   SDSDecompressFile* pSDSDecompressExtra = CopyDecompressFileFrom(pSDSDecompress, instance);
 
                   pSDSDecompressFileExtra[instance] = pSDSDecompressExtra;
                   
                   // read in header for section (note if this is the first header (i.e. section ==0), we are reading it again)
                   // TODO: optimization here
-                  INT64 fileoffset = pSDSDecompress->cSectionName.pSectionOffsets[section];
+                  int64_t fileoffset = pSDSDecompress->cSectionName.pSectionOffsets[section];
                   pSDSDecompressExtra->DecompressFileInternal(pReadCallbacks, 0, fileoffset);
                }
                FileWithSectionsCount += blockcount;
@@ -6588,15 +6588,15 @@ public:
    // more complex routine that makes multiple passes
    // note: pSDSDecompressFile allocated up to FileCount
    // may return NULL when all files do not exist
-   void* ReadAndStackFiles(SDS_READ_CALLBACKS*  pReadCallbacks, int multiMode) {
+   void* ReadAndStackFiles(SDS_READ_CALLBACKS*  pReadCallbacks, int32_t multiMode) {
       // Open what might be 100+ files
       GetFileInfo(multiMode);
 
       SDSDecompressFile** pSDSDecompressFileExtra = ScanForSections();
 
       void* result = NULL;
-      INT64 validPos = 0;
-      INT64 validCount = 0;
+      int64_t validPos = 0;
+      int64_t validCount = 0;
 
       // Capture and clip percent of space to reserve
       double reserveSpace = pReadCallbacks->ReserveSpace;
@@ -6605,10 +6605,10 @@ public:
 
       // NOTE: back into single threaded mode here...
       //ClearColumnList();
-      INT32 missingfile = -1;
+      int32_t missingfile = -1;
 
       // Get valid count
-      for (INT32 t = 0; t < FileCount; t++) {
+      for (int32_t t = 0; t < FileCount; t++) {
          if (pSDSDecompressFile[t]->IsFileValid) validCount++;
          else missingfile = t;
       }
@@ -6627,11 +6627,11 @@ public:
 
       // Now build a hash of all the valid filenames
       // Also.. how homogenous are the files... all datasets?  all structs?
-      for (INT32 t = 0; t < FileCount; t++) {
-         BOOL isStruct = FALSE;
-         BOOL isDataset = FALSE;
-         BOOL isArray = FALSE;
-         BOOL isOneFile = FALSE;
+      for (int32_t t = 0; t < FileCount; t++) {
+         bool isStruct = FALSE;
+         bool isDataset = FALSE;
+         bool isArray = FALSE;
+         bool isOneFile = FALSE;
 
          SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[t];
          if (pSDSDecompress->IsFileValid) {
@@ -6644,7 +6644,7 @@ public:
             isOneFile |= (fileType == SDS_FILE_TYPE_ONEFILE);
 
             // Try to find out how many valid columns
-            for (INT64 c = 0; c < pSDSDecompress->NameCount; c++) {
+            for (int64_t c = 0; c < pSDSDecompress->NameCount; c++) {
                const char* columnName = pSDSDecompress->pArrayNames[c];
 
                // Include exclude check
@@ -6660,7 +6660,7 @@ public:
                   LOGGING("[%d][%lld] %s", t, c, columnName);
 
                   SDS_ARRAY_BLOCK *pArrayBlock = &pSDSDecompress->pArrayBlocks[c];
-                  INT32 arrayEnum = pSDSDecompress->pArrayEnums[c];
+                  int32_t arrayEnum = pSDSDecompress->pArrayEnums[c];
 
                   // If the column is new, SDS_COLUMN_KING will be allocated
                   AddColumnList(
@@ -6676,11 +6676,11 @@ public:
                   if (isDataset) {
 
                      // Check if we have a stackable dataset
-                     INT32 mask = SDS_FLAGS_ORIGINAL_CONTAINER;
+                     int32_t mask = SDS_FLAGS_ORIGINAL_CONTAINER;
                      if ((arrayEnum & mask) == mask) {
                         if (pArrayBlock && pArrayBlock->NDim > 0) {
 
-                           INT64 dlength = pArrayBlock->Dimensions[0];
+                           int64_t dlength = pArrayBlock->Dimensions[0];
 
                            // Get the dataset size
                            if (pDatasets[validPos].Length != 0) {
@@ -6729,14 +6729,14 @@ public:
       //===========================================================================
       // final tally
       // array offset has one more entry for the last entry
-      INT64 rowLengthToAlloc = 0;
+      int64_t rowLengthToAlloc = 0;
 
 
       //if ((isStruct + isDataset + isArray) != 1) {
       //   SetErr_Format(SDS_VALUE_ERROR, "MultiDecompress error -- all the filetypes must be the same type (struct or dataset or array)\nFilename: %s\n", pFirstFileName);
       //   goto EXIT_EARLY;
       //}
-      BOOL isGood = FALSE;
+      bool isGood = FALSE;
 
       if (validCount == 0) {
          SetErr_Format(SDS_VALUE_ERROR, "MultiDecompress error -- none of the files were valid: %s\n", pFirstFileName);
@@ -6766,7 +6766,7 @@ public:
          PrintIfErrors();
          ClearErrors();
 
-         INT64 totalIOPackets = TotalUniqueColumns * validCount;
+         int64_t totalIOPackets = TotalUniqueColumns * validCount;
 
          // Allocate MultiIO PACKETS -- worst case assuming every col * rows
          SDS_MULTI_IO_PACKETS* pMultiIOPackets = SDS_MULTI_IO_PACKETS::Allocate(totalIOPackets, &pReadCallbacks->Filter);
@@ -6787,16 +6787,16 @@ public:
          validPos = 0;
 
          // for calculating boolean filter mask
-         int     hasFilter = 0;
-         INT64   filterTrueCount = 0;
-         INT64   boolMaskLength = pReadCallbacks->Filter.BoolMaskLength;
-         INT     fileTypeStackable = 0;
+         int32_t     hasFilter = 0;
+         int64_t   filterTrueCount = 0;
+         int64_t   boolMaskLength = pReadCallbacks->Filter.BoolMaskLength;
+         int32_t     fileTypeStackable = 0;
 
          // The first valid file determines the filetype when stacking
-         for (int f = 0; f < FileCount; f++) {
+         for (int32_t f = 0; f < FileCount; f++) {
             SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[f];
             if (pSDSDecompress->IsFileValid) {
-               INT fileType = pSDSDecompress->FileHeader.FileType;
+               int32_t fileType = pSDSDecompress->FileHeader.FileType;
                fileTypeStackable = (fileType == SDS_FILE_TYPE_DATASET ||
                   fileType == SDS_FILE_TYPE_TABLE ||
                   fileType == SDS_FILE_TYPE_ARRAY);
@@ -6808,29 +6808,29 @@ public:
 
          // Fill in all the IOPACKETs
          // Skip over invalid files, loop over all valid filenames
-         for (INT64 col = 0; col < TotalUniqueColumns; col++) {
+         for (int64_t col = 0; col < TotalUniqueColumns; col++) {
 
             // Only one king
             SDS_COLUMN_KING*  pKing = &ColumnVector[col];
             // Appears to be a save bug
             // When saving a Dataset, the categories have STACKABLE set but the bin array on has ORIGINAL_CONTAINER
             // When saving a Struct, the categories do not have STACKABLE set
-            //INT32 mask = SDS_FLAGS_ORIGINAL_CONTAINER;
+            //int32_t mask = SDS_FLAGS_ORIGINAL_CONTAINER;
             LOGGING("[%lld]Col: %s -- ColPos:%lld  FileRow:%d pBlock:%p Enum:%d  ftype:%d\n", col, pKing->ColName, pKing->ColPos, pKing->FileRow, pKing->ppArrayBlocks, pKing->ArrayEnum, fileTypeStackable);
 
-            INT64    currentOffset = 0;
-            INT64    currentUnfilteredOffset = 0;
-            INT64    row = 0;
-            INT64    filteredOut = 0;
-            INT64*   pArrayOffsets = pKing->pArrayOffsets;
-            INT64*   pOriginalArrayOffsets = pKing->pOriginalArrayOffsets;
-            INT64*   pOriginalLengths = pKing->pOriginalLengths;
+            int64_t    currentOffset = 0;
+            int64_t    currentUnfilteredOffset = 0;
+            int64_t    row = 0;
+            int64_t    filteredOut = 0;
+            int64_t*   pArrayOffsets = pKing->pArrayOffsets;
+            int64_t*   pOriginalArrayOffsets = pKing->pOriginalArrayOffsets;
+            int64_t*   pOriginalLengths = pKing->pOriginalLengths;
 
             SDS_ARRAY_BLOCK* pMasterBlock = &pKing->KingBlock;
             //LOGGING("master %p ", pMasterBlock);
 
-            INT32 mask = SDS_FLAGS_ORIGINAL_CONTAINER;
-            BOOL  isFilterable = FALSE;           
+            int32_t mask = SDS_FLAGS_ORIGINAL_CONTAINER;
+            bool  isFilterable = FALSE;           
 
             if (pFilterInfo && 
                (pKing->ArrayEnum & mask) == mask &&
@@ -6846,7 +6846,7 @@ public:
             // These create gaps that are often filled in with invalids
             // For every valid file there is SDS_ARRAY_BLOCK
             // If the filetype is 2 and the enum is 1 (SDS_FLAGS_STACKABLE)
-            for (int f = 0; f < FileCount; f++) {
+            for (int32_t f = 0; f < FileCount; f++) {
                SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[f];
                if (pSDSDecompress->IsFileValid) {
 
@@ -6866,7 +6866,7 @@ public:
                      isCompatible = IsArrayCompatible(pKing->ColName, pMasterBlock, pArrayBlock, FALSE);
                   }
 
-                  INT64 calcLength = 0;
+                  int64_t calcLength = 0;
                   if (!pArrayBlock || pOriginalLengths[row] == 0) {
                      // NO IO PACKET (GAP)
                      LOGGING(">>> gap fill for row: %lld   col: %lld  name: %s\n", row, col, pKing->ColName);
@@ -6883,7 +6883,7 @@ public:
                   if (isFilterable) {
                      filterTrueCount = 0;
                      if (currentUnfilteredOffset < boolMaskLength) {
-                        INT64 bLength = calcLength;
+                        int64_t bLength = calcLength;
                         if (currentUnfilteredOffset + calcLength > boolMaskLength)
                            bLength = boolMaskLength - currentUnfilteredOffset;
 
@@ -6894,7 +6894,7 @@ public:
                         else {
                            // First pass calculate how many true values in bool mask
                            filterTrueCount =
-                              SumBooleanMask((INT8*)pReadCallbacks->Filter.pBoolMask + currentUnfilteredOffset, bLength);
+                              SumBooleanMask((int8_t*)pReadCallbacks->Filter.pBoolMask + currentUnfilteredOffset, bLength);
                         }
                      }
                      pFilterInfo[row].TrueCount = filterTrueCount;
@@ -6943,7 +6943,7 @@ public:
             // Calculate how many rows to allocate based on all the stacking
             rowLengthToAlloc = currentOffset;
             if (reserveSpace > 0.0) {
-               rowLengthToAlloc += (INT64)(currentOffset * reserveSpace);
+               rowLengthToAlloc += (int64_t)(currentOffset * reserveSpace);
             }
 
             //CreateFilter(row, pReadCallbacks->Filter);
@@ -6958,15 +6958,15 @@ public:
             // TODO: -- allocate one big array and fixup IO PACKETS
 
             SDS_ALLOCATE_ARRAY   sdsArrayCallback;
-            INT64                dimensions[SDS_MAX_DIMS];
-            INT64                strides[SDS_MAX_DIMS];
-            INT64                oneRowSize = pMasterBlock->ItemSize;
+            int64_t                dimensions[SDS_MAX_DIMS];
+            int64_t                strides[SDS_MAX_DIMS];
+            int64_t                oneRowSize = pMasterBlock->ItemSize;
 
             // Use a destination info we allocated
             sdsArrayCallback.pDestInfo = &pManyDestInfo[col];
             sdsArrayCallback.ndim = pMasterBlock->NDim;
 
-            for (int j = 0; j < SDS_MAX_DIMS; j++) {
+            for (int32_t j = 0; j < SDS_MAX_DIMS; j++) {
                dimensions[j] = pMasterBlock->Dimensions[j];
                strides[j] = pMasterBlock->Strides[j];
             }
@@ -6985,11 +6985,11 @@ public:
             sdsArrayCallback.pDestInfo->pArrayObject = NULL;
 
             // TODO: oneRowSize not correct for multidimensional
-            for (int j = 1; j < pMasterBlock->NDim; j++) {
+            for (int32_t j = 1; j < pMasterBlock->NDim; j++) {
                oneRowSize *= dimensions[j];
             }
 
-            BOOL wasFiltered = FALSE;
+            bool wasFiltered = FALSE;
 
             // Caller will fill info pArrayObject and pData
             // pData is valid for shared memory
@@ -7000,9 +7000,9 @@ public:
                // NOTE: use absolute value of last stride vs first stride to determine C or F
                if (pMasterBlock->NDim > 1 && pMasterBlock->Flags  &  SDS_ARRAY_F_CONTIGUOUS) {
                   //printf("!!!likely internal error with fortran array > dim 1 and upgrading dtype!\n");
-                  INT64 isize = pMasterBlock->ItemSize;
+                  int64_t isize = pMasterBlock->ItemSize;
                   strides[0] = isize;
-                  for (int j = 1; j < pMasterBlock->NDim; j++) {
+                  for (int32_t j = 1; j < pMasterBlock->NDim; j++) {
                      strides[j] = dimensions[j - 1] * strides[j - 1];
                   }
                }
@@ -7032,7 +7032,7 @@ public:
 
             // PASS #2... build IOPackets
             // Loop over all files
-            for (int f = 0; f < FileCount; f++) {
+            for (int32_t f = 0; f < FileCount; f++) {
                SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[f];
                if (pSDSDecompress->IsFileValid) {
 
@@ -7077,7 +7077,7 @@ public:
 
                   //printf("array offset %lld\n", pArrayOffsets[row]);
 
-                  INT64 gapLength = pArrayOffsets[row + 1] - pArrayOffsets[row];
+                  int64_t gapLength = pArrayOffsets[row + 1] - pArrayOffsets[row];
 
                   // Check for gap
                   if (!pArrayBlock || pOriginalLengths[row] == 0) {
@@ -7143,12 +7143,12 @@ public:
 
          // Now build a hash of all the valid filenames
          // Also.. how homogenous are the files... all datasets?  all structs?
-         for (INT64 col = 0; col < TotalUniqueColumns; col++) {
+         for (int64_t col = 0; col < TotalUniqueColumns; col++) {
             // Only one king, get the first file that had this column
             SDS_COLUMN_KING*     pKing = &ColumnVector[col];
             SDSDecompressFile*   pSDSDecompress = pSDSDecompressFile[pKing->FileRow];
             SDSArrayInfo*        pDestInfo = &pManyDestInfo[col];
-            INT64*               pArrayOffsets = pKing->pArrayOffsets;
+            int64_t*               pArrayOffsets = pKing->pArrayOffsets;
 
             if (pSDSDecompress == NULL) {
                printf("!!!internal error in final multistack loop\n");
@@ -7173,8 +7173,8 @@ public:
             }
          }
 
-         INT64 vrow = 0;
-         for (int f = 0; f < FileCount; f++) {
+         int64_t vrow = 0;
+         for (int32_t f = 0; f < FileCount; f++) {
             SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[f];
             if (pSDSDecompress->IsFileValid) {
                pMultiCallbackFileInfo[vrow].Filename = pSDSDecompress->FileName;
@@ -7200,7 +7200,7 @@ public:
 
          // Check if we expanded becaue we found extra sections
          if (pSDSDecompressFileExtra) {
-            for (INT64 i = 0; i < FileCount; i++) {
+            for (int64_t i = 0; i < FileCount; i++) {
                delete pSDSDecompressFileExtra[i];
             }
             WORKSPACE_FREE(pSDSDecompressFileExtra);
@@ -7230,7 +7230,7 @@ extern "C" {
    // metaData -- block of bytes to store as metadata
    // metaDataSize -- 
    //
-   DllExport BOOL SDSWriteFile(
+   DllExport int32_t SDSWriteFile(
       const char *fileName,
       const char *shareName,   // can be NULL
       SDS_STRING_LIST *folderName,  // can be NULL
@@ -7304,8 +7304,8 @@ extern "C" {
       SDS_STRING_LIST*     pInclusionList,      // may be set to NULL
       SDS_STRING_LIST*     pFolderInclusionList,      // may be set to NULL
       SDS_STRING_LIST*     pSectionInclusionList,      // may be set to NULL
-      INT64                fileCount,
-      int                  multiMode,
+      int64_t                fileCount,
+      int32_t                  multiMode,
       SDS_READ_CALLBACKS*  pReadCallbacks)
    {
       void* result = NULL;
@@ -7341,7 +7341,7 @@ extern "C" {
             else {
                // Read file header
                SDS_FILE_HEADER tempFileHeader;
-               INT64 result =
+               int64_t result =
                   ReadFileHeader(fileHandle, &tempFileHeader, 0, pMultiRead[0].pFileName);
 
                if (result != 0) {
@@ -7366,7 +7366,7 @@ extern "C" {
          // Allocate an array of all the files we need to open
          SDSDecompressFile** pSDSDecompressFile = (SDSDecompressFile**)WORKSPACE_ALLOC(sizeof(void*) * fileCount);
 
-         for (INT64 i = 0; i < fileCount; i++) {
+         for (int64_t i = 0; i < fileCount; i++) {
             LOGGING("...%s\n", pMultiRead[i].pFileName);
             pSDSDecompressFile[i] = new SDSDecompressFile(pMultiRead[i].pFileName, &includeList, i, NULL, &folderList, &sectionsList, multiMode == SDS_MULTI_MODE_CONCAT_MANY ? SDS_MULTI_MODE_CONCAT_MANY : COMPRESSION_MODE_INFO);
          }
@@ -7381,7 +7381,7 @@ extern "C" {
          }
 
          // Shut it down
-         for (INT64 i = 0; i < fileCount; i++) {
+         for (int64_t i = 0; i < fileCount; i++) {
             delete pSDSDecompressFile[i];
          }
 
@@ -7397,7 +7397,7 @@ extern "C" {
       return g_errorbuffer;
    }
 
-   DllExport BOOL CloseSharedMemory(void* pMapStruct) {
+   DllExport int32_t CloseSharedMemory(void* pMapStruct) {
       PMAPPED_VIEW_STRUCT pMappedStruct = (PMAPPED_VIEW_STRUCT)pMapStruct;
       if (pMappedStruct) {
          UtilSharedMemoryEnd(pMappedStruct);
@@ -7406,14 +7406,14 @@ extern "C" {
       return FALSE;
    }
 
-   DllExport BOOL CloseDecompressFile(void* pInput) {      
+   DllExport int32_t CloseDecompressFile(void* pInput) {      
       SDSDecompressFile* pSDSDecompressFile = (SDSDecompressFile * )pInput;
       delete pSDSDecompressFile;
       return TRUE;
    }
 
    //DllExport void SDSClearBuffers() {
-   //   for (int i = 0; i < SDS_MAX_CORES; i++) {
+   //   for (int32_t i = 0; i < SDS_MAX_CORES; i++) {
    //      if (g_DecompressContext[i] != NULL) {
    //         ZSTD_freeDCtx(g_DecompressContext[i]);
    //         g_DecompressContext[i] = NULL;

--- a/src/SDSFile.cpp
+++ b/src/SDSFile.cpp
@@ -298,22 +298,22 @@ static size_t DecompressDataPartial(int32_t core, int32_t compMode, void* dst, s
 static bool CompressIsError(int32_t compMode, size_t code) {
    if (ZSTD_isError(code)) {
       SetErr_Format(SDS_VALUE_ERROR, "Decompression error: %s", ZSTD_getErrorName(code));
-      return TRUE;
+      return true;
    }
    else {
-      return FALSE;
+      return false;
    }
 
 }
 
 // check to see if any errors were recorded
-// Returns TRUE if there was an error
+// Returns true if there was an error
 //static bool CheckErrors() {
 //
 //   if (g_lastexception) {
-//      return TRUE;
+//      return true;
 //   }
-//   return FALSE;
+//   return false;
 //}
 
 
@@ -387,7 +387,7 @@ const char* GetLastErrorMessage(
 
 
 SDS_EVENT_HANDLE SDS_CREATE_EVENTHANDLE() {
-   return CreateEvent(NULL, TRUE, FALSE, NULL);
+   return CreateEvent(NULL, true, false, NULL);
 }
 void SDS_DESTROY_EVENTHANDLE(SDS_EVENT_HANDLE handle) {
    CloseHandle(handle);
@@ -954,7 +954,7 @@ public:
    // hr < 0 on failure
    HRESULT MapExisting() {
       HRESULT hr =
-         SharedMemoryCopy(SharedMemoryName, &pMapStruct, TRUE);
+         SharedMemoryCopy(SharedMemoryName, &pMapStruct, true);
 
       if (hr > 0) {
          AddSharedMemory(SharedMemoryName, pMapStruct, NULL);
@@ -1125,7 +1125,7 @@ public:
                // replace bang
                *pHasBang = BANG_CHAR;
 
-               // if we matched return TRUE
+               // if we matched return true
                if (InclusionList.find(newitem) != InclusionList.end()) {
                   return 1;
                }
@@ -1166,7 +1166,7 @@ public:
 
                LOGGING("Failed to match, has sep %s   folder: %s\n", item.c_str(), newitem.c_str());
 
-               // if we matched return TRUE
+               // if we matched return true
                if (InclusionList.find(newitem) != InclusionList.end()) {
                   return 1;
                }
@@ -1257,7 +1257,7 @@ DecompressWithFilter(
    int64_t lastData = (bytesPerRow * lastRow);
 
    // Check if user just wants the very first bytes
-   // All set to TRUE in mask
+   // All set to true in mask
    if (rowOffset ==0 && lastRow <= lastPossibleRow && lastRow == pFilter->BoolMaskTrueCount && lastData <= uncompressedSize) {
       int64_t firstBand = 0;
       int64_t firstData = bytesPerRow * firstBand;
@@ -1319,11 +1319,11 @@ DecompressWithFilter(
       // Make sure something to read
       //if (pFilter->pFilterInfo && pFilter->pFilterInfo[stackIndex].TrueCount > 0) {
       if (pFilter->BoolMaskTrueCount > 0) {
-         bool uncompressedRead = FALSE;
+         bool uncompressedRead = false;
 
          if (compressedSize == uncompressedSize) {
             // this data was saved uncompressed
-            uncompressedRead = TRUE;
+            uncompressedRead = true;
             result = compressedSize;
          }
          else {
@@ -1333,7 +1333,7 @@ DecompressWithFilter(
          }
 
          if (result == compressedSize) {
-            // Copy all TRUE rows
+            // Copy all true rows
             bool*    pMask = pFilter->pBoolMask + rowOffset;
 
             //printf("allocating temp buffer of %lld bytes", uncompressedSize);
@@ -1490,7 +1490,7 @@ ReadAndDecompressBandWithFilter(
          sectionLength = boolLength - rowOffset;
       }
 
-      // Copy all TRUE rows
+      // Copy all true rows
       bool*    pMask = pFilter->pBoolMask + rowOffset;
       int64_t trueCount = SumBooleanMask((int8_t*)pMask, sectionLength);
 
@@ -1529,7 +1529,7 @@ ReadAndDecompressBandWithFilter(
             core,
             compMode);
 
-         // TODO change based on how many TRUE values in the mask
+         // TODO change based on how many true values in the mask
          destBandBuffer += (trueCount * bytesPerRow);
 
       }
@@ -1565,12 +1565,12 @@ ReadAndDecompressArrayBlockWithFilter(
 ) {
 
    int64_t result = -1;
-   bool didAlloc = FALSE;
+   bool didAlloc = false;
 
    if (!tempBuffer) {
       LOGGING("Allocating tempbuffer of %lld\n", pBlockInfo->ArrayCompressedSize);
       tempBuffer = WORKSPACE_ALLOC(pBlockInfo->ArrayCompressedSize);
-      didAlloc = TRUE;
+      didAlloc = true;
    }
 
    // All boolean masks come here
@@ -2438,7 +2438,7 @@ bool DecompressFileArray(void* pstCompressArraysV, int32_t core, int64_t t) {
       }
    }
 
-   return TRUE;
+   return true;
 }
 
 
@@ -2644,7 +2644,7 @@ bool CompressFileArray(void* pstCompressArraysV, int32_t core, int64_t t) {
       }
    }
 
-   return TRUE;
+   return true;
 }
 
 
@@ -2991,7 +2991,7 @@ bool SDSWriteFileInternal(
       }
    }
 
-   return TRUE;
+   return true;
 }
 
 
@@ -3062,7 +3062,7 @@ void CopyFromBlockToInfo(SDS_ARRAY_BLOCK*  pBlock, SDSArrayInfo* pDestInfo) {
 
 
 struct SDS_COMPATIBLE {
-   int8_t                 IsCompatible;  // set to FALSE if conversion required
+   int8_t                 IsCompatible;  // set to false if conversion required
    int8_t                 NeedsStringFixup;  // set to 1 if conversion required, or in 2 for mtlab conversion
    int8_t                 NeedsConversion;  // if flag set, dtype conversion called
    int8_t                 NeedsRotation;
@@ -3178,7 +3178,7 @@ bool IsNameIncluded(
       if (!pInclude || pInclude->IsEmpty()) {
          // we have no column name included
          if (!pFolderName || pFolderName->IsEmpty()) {
-            return TRUE;
+            return true;
          }
 
          // we have a folder name but no column name (any match works)
@@ -3195,28 +3195,28 @@ bool IsNameIncluded(
          if (pStart >= nameToCheck) {
             if (*pStart == '/') {
                // pure folder name -- if it matches, it contains meta that we need
-               if (pFolderName->IsIncluded(nameToCheck)) return TRUE;
+               if (pFolderName->IsIncluded(nameToCheck)) return true;
             }
          }
          
       }
       else {
          // just a name -- no folder -- probably not allowed
-         //return FALSE;
+         //return false;
       }
 
       if ((!pInclude || pInclude->IsIncluded(nameToCheck)) &&
          (!pFolderName || pFolderName->IsIncluded(nameToCheck))) {
-         return TRUE;
+         return true;
       }
    }
    else {
       if (!pInclude || pInclude->IsIncluded(nameToCheck)) {
-         return TRUE;
+         return true;
       }
 
    }
-   return FALSE;
+   return false;
 }
 
 
@@ -3227,7 +3227,7 @@ bool PossiblyShrinkArray(
    SDS_READ_CALLBACKS*  pReadCallbacks,
    bool                 isStackable
 ) {
-   bool wasFiltered = FALSE;
+   bool wasFiltered = false;
 
    // Categoricals will not be in original container
    int32_t mask = SDS_FLAGS_ORIGINAL_CONTAINER;
@@ -3235,7 +3235,7 @@ bool PossiblyShrinkArray(
       if (pArrayCallback->sdsFlags & mask) {
          // Did they pass a fancy index or a bool index?
          if (pReadCallbacks->Filter.pBoolMask && pReadCallbacks->Filter.BoolMaskTrueCount >= 0 && isStackable) {
-            wasFiltered = TRUE;
+            wasFiltered = true;
             int64_t dim0Length = pArrayCallback->dims[0];
             int64_t newLength = pReadCallbacks->Filter.BoolMaskTrueCount;
 
@@ -3306,8 +3306,8 @@ public:
    SDSSectionName cSectionName;
 
    // Set to true when file header is read (does not work for shared memory file)
-   bool           IsFileValid = FALSE;
-   bool           IsFileValidAndNotFilteredOut = FALSE;
+   bool           IsFileValid = false;
+   bool           IsFileValidAndNotFilteredOut = false;
 
    //------------------------------------------------
    // constructor
@@ -3334,14 +3334,14 @@ public:
 
    //-----------------------------------------------------------
    // Caller must fill in pDestInfo->pData because memory will be read into
-   //// returns TRUE if array allocated
+   //// returns true if array allocated
    //bool CallAllocateArray(SDS_READ_CALLBACKS* pReadCallbacks, SDS_ALLOCATE_ARRAY *pAllocateArray) {
 
    //   if (pReadCallbacks->AllocateArrayCallback) {
    //      pReadCallbacks->AllocateArrayCallback(pAllocateArray);
-   //      return TRUE;
+   //      return true;
    //   }
-   //   return FALSE;
+   //   return false;
    //}
 
 
@@ -3396,7 +3396,7 @@ public:
       pDestInfo->pArrayObject = NULL;
       pDestInfo->pData = NULL;
 
-      bool wasFiltered = FALSE;
+      bool wasFiltered = false;
 
       //LOGGING("Checking to allocate name %s\n", pAllocateArray->pArrayName);
       // Include exclude check
@@ -3405,7 +3405,7 @@ public:
 
          //-----------------------------------
          // Caller will fill info pArrayObject and pData
-         // NOTE: this routine can filter names (will return FALSE if filtered out)
+         // NOTE: this routine can filter names (will return false if filtered out)
          // pData is valid for shared memory
          if (pReadCallbacks->AllocateArrayCallback) {
 
@@ -3447,7 +3447,7 @@ public:
          pIOPacket->pReadCallbacks = pReadCallbacks;
          pIOPacket->pBlockInfo = &pArrayBlocks[t];
          pIOPacket->pMasterBlock = NULL;
-         pIOPacket->Compatible = { TRUE, FALSE, FALSE, FALSE };
+         pIOPacket->Compatible = { true, false, false, false };
          pIOPacket->ArrayOffset = 0;
          pIOPacket->OriginalArrayOffset = 0;
          pIOPacket->StackPosition = 0;
@@ -3472,7 +3472,7 @@ public:
             fileType == SDS_FILE_TYPE_ARRAY);
 
          // callback into python or matlab to allocate memory
-         AllocateOneArray(t, pReadCallbacks, &pDestInfo[t], FALSE, oneFile, fileTypeStackable);
+         AllocateOneArray(t, pReadCallbacks, &pDestInfo[t], false, oneFile, fileTypeStackable);
 
          // next io packet to build
          pIOPacket++;
@@ -3697,7 +3697,7 @@ public:
    //  ppArrayBlock (currently allocated)
    //
    // Returns:
-   //   TRUE or FALSE.  if TRUE and NULL passed in then can call GetMetaData()
+   //   true or false.  if true and NULL passed in then can call GetMetaData()
    //   
    //
    bool DecompressMetaData(
@@ -3722,7 +3722,7 @@ public:
 
          if (!metaDataCompressed) {
             SetErr_Format(SDS_VALUE_ERROR, "Decompression error in metaDataCompressedsize: %lld", metaCompressedSize);
-            return FALSE;
+            return false;
          }
 
          // Read in compressed data into our buffer: metaDataCompressed
@@ -3731,7 +3731,7 @@ public:
          if (bytesRead != metaCompressedSize) {
             WORKSPACE_FREE(metaDataCompressed);
             SetErr_Format(SDS_VALUE_ERROR, "Decompression error in bytesRead: %lld", metaCompressedSize);
-            return FALSE;
+            return false;
          }
 
          int64_t metaUncompressedSize = pFileHeader->TotalMetaUncompressedSize;
@@ -3745,7 +3745,7 @@ public:
             // allocate a string object
             if (!metaDataUncompressed) {
                SetErr_Format(SDS_VALUE_ERROR, "Decompression error meta: could not allocate meta string %lld", metaUncompressedSize);
-               return FALSE;
+               return false;
             }
 
             // get the memory of the pystring
@@ -3760,7 +3760,7 @@ public:
 
          if (CompressIsError(COMPRESSION_TYPE_ZSTD, cSize) || cSize != metaUncompressedSize) {
             SetErr_Format(SDS_VALUE_ERROR, "Decompression error meta: length mismatch -> decomp %llu != %llu [header]", (uint64_t)cSize, metaUncompressedSize);
-            return FALSE;
+            return false;
          }
 
       }
@@ -3779,7 +3779,7 @@ public:
             // allocate a string object
             if (!metaDataUncompressed) {
                SetErr_Format(SDS_VALUE_ERROR, "Decompression error meta: could not allocate meta string %lld", metaUncompressedSize);
-               return FALSE;
+               return false;
             }
          }
 
@@ -3788,12 +3788,12 @@ public:
       }
 
       LOGGING("out decompress meta\n");
-      return TRUE;
+      return true;
    }
 
    //------------------------------------------------
-   // Returns FALSE on failure
-   // Returns TRUE on success
+   // Returns false on failure
+   // Returns true on success
    // 
    // Reads from File and decompresses into shared memory
    // Call EndDecompressedFile() when done
@@ -3808,13 +3808,13 @@ public:
          // This will allocate pArrayBlocks
          if (!AllocateArrayBlocks()) {
             SetErr_Format(SDS_VALUE_ERROR, "Decompression error in pArrayBlock: %lld", pFileHeader->ArrayBlockSize);
-            return FALSE;
+            return false;
          }
 
          int64_t bytesRead = DefaultFileIO.FileReadChunk(NULL, SDSFile, pArrayBlocks, pFileHeader->ArrayBlockSize, pFileHeader->ArrayBlockOffset);
          if (bytesRead != pFileHeader->ArrayBlockSize) {
             SetErr_Format(SDS_VALUE_ERROR, "Decompression error in ArrayBlockSize: %lld", pFileHeader->ArrayBlockSize);
-            return FALSE;
+            return false;
          }
 
          // Calculate size of shared memory
@@ -3910,7 +3910,7 @@ public:
 
                // MORE WORK TO DO 
                SDS_READ_DECOMPRESS_ARRAYS* pstCompressArrays =
-                  AllocDecompressArrays(pReadCallbacks, arrayCount, TRUE, oneFile, fileTypeStackable);
+                  AllocDecompressArrays(pReadCallbacks, arrayCount, true, oneFile, fileTypeStackable);
 
                // Set all the cores working memory to zero
                int32_t numCores = g_cMathWorker->WorkerThreadCount + 1;
@@ -3944,20 +3944,20 @@ public:
 
                pMemoryFileHeader->ArraysWritten = arrayCount;
                LOGGING("End fill array block %lld\n", arrayCount);;
-               return TRUE;
+               return true;
             }
          }
       }
       else {
          SetErr_Format(SDS_VALUE_ERROR, "SDS file was null when copying into shared memory\n");
       }
-      return FALSE;
+      return false;
    }
 
 
    //------------------------------------------------
-   // Returns FALSE on failure
-   // Returns TRUE on success
+   // Returns false on failure
+   // Returns true on success
    // 
    // Calls EndDecompressedFile() when done
    bool CopyIntoSharedMemory(SDS_READ_CALLBACKS* pReadCallbacks, const char* fileName, SDSIncludeExclude* pFolderName, int32_t core) {
@@ -3972,7 +3972,7 @@ public:
          EndDecompressedFile();
          return bResult;
       }
-      return FALSE;
+      return false;
    }
 
 
@@ -4040,7 +4040,7 @@ public:
 
 
    //===============================================
-   // returns TRUE/FALSE
+   // returns true/false
    // stops early if Mode == COMPRESSION_MODE_INFO
    // new ver 4.3: handles filter=
    bool DecompressFileInternal(SDS_READ_CALLBACKS* pReadCallbacks, int32_t core, int64_t startOffset) {
@@ -4094,13 +4094,13 @@ public:
          LOGGING("Arrays to read %lld  %p\n", tupleSize, pArrayBlocks);
 
          // If we got this far, the file is good
-         IsFileValid = TRUE;
-         IsFileValidAndNotFilteredOut = TRUE;
+         IsFileValid = true;
+         IsFileValidAndNotFilteredOut = true;
 
          // -- STOP EARLY IF THE USER JUST WANTS THE INFORMATION -----------------
          // Leave the files open in case they want to read arrays later
          if (Mode == COMPRESSION_MODE_INFO) {
-            return TRUE;
+            return true;
          }
 
          int32_t fileType = pFileHeader->FileType;
@@ -4112,7 +4112,7 @@ public:
          pstCompressArrays = AllocDecompressArrays(
             pReadCallbacks, 
             tupleSize, 
-            FALSE, 
+            false, 
             pFileHeader->FileType == SDS_FILE_TYPE_ONEFILE,
             fileTypeStackable
          );
@@ -4150,7 +4150,7 @@ public:
             DefaultFileIO.DestroyEventHandle(pstCompressArrays->eventHandles[j]);
          }
 
-         return TRUE;
+         return true;
       }
       else {
          //  This overwrites real error
@@ -4164,7 +4164,7 @@ public:
       if (g_errorbuffer[0] == 0) {
          SetErr_Format(SDS_VALUE_ERROR, "ExitDecompress called for error when opening file %s\n", FileName);
       }
-      return FALSE;
+      return false;
    }
 
 
@@ -4191,14 +4191,14 @@ public:
 
          // Check for previous existence first
          HRESULT result = DefaultMemoryIO.MapExisting();
-         bool bResult = TRUE;
+         bool bResult = true;
 
          if (result < 0) {
             LOGGING("Failed to find existing share name %s\n", DefaultMemoryIO.SharedMemoryName);
 
             if (Mode == COMPRESSION_MODE_INFO) {
                // When the user just want the file information, we do not need to copy the file into shared memory yet
-               bResult = FALSE;
+               bResult = false;
             }
             else {
                bResult = CopyIntoSharedMemory(pReadCallbacks, FileName, pFolderName, core);
@@ -4617,24 +4617,24 @@ SDS_WHICH_DTYPE WhichDType(int32_t dtype)
 
    if (dtype <= SDS_LONGDOUBLE) {
       if (dtype >= SDS_FLOAT) {
-         retVal.w.isFloat = TRUE;
+         retVal.w.isFloat = true;
       }
       else {
          // Odd dtypes below floats are ints
          if (dtype & 1 || dtype == 0) {
-            retVal.w.isInt = TRUE;
+            retVal.w.isInt = true;
          }
          else {
-            retVal.w.isUInt = TRUE;
+            retVal.w.isUInt = true;
          }
       }
    }
    else {
       if (dtype == SDS_STRING || dtype == SDS_UNICODE) {
-         retVal.w.isString = TRUE;
+         retVal.w.isString = true;
       }
       else {
-         retVal.w.isUnknown = TRUE;
+         retVal.w.isUnknown = true;
       }
    }
    return retVal;
@@ -5228,9 +5228,9 @@ SDS_COMPATIBLE IsArrayCompatible(
    int32_t odtype = FixupDType(pArrayBlock->DType, pArrayBlock->ItemSize);
 
    SDS_COMPATIBLE  c;
-   c.IsCompatible = TRUE;
-   c.NeedsConversion = FALSE;
-   c.NeedsRotation = FALSE;
+   c.IsCompatible = true;
+   c.NeedsConversion = false;
+   c.NeedsRotation = false;
    c.NeedsStringFixup = 0;
 
    if (mdtype != odtype) {
@@ -5242,7 +5242,7 @@ SDS_COMPATIBLE IsArrayCompatible(
       // If they are in the same class.. we can convert
       if (wmdtype.whole == wodtype.whole) {
          // String to UNICODE happens here
-         c.NeedsConversion = TRUE;
+         c.NeedsConversion = true;
          LOGGING("step1 conversion %s  %d  %d  masteritemsize:%d vs  %d  length: %lld %lld\n", colName, odtype, mdtype, pMasterArrayBlock->ItemSize, pArrayBlock->ItemSize, pMasterArrayBlock->Dimensions[0], pArrayBlock->Dimensions[0]);
          // pick the higher type
          if (odtype > mdtype) {
@@ -5270,13 +5270,13 @@ SDS_COMPATIBLE IsArrayCompatible(
 
          // Float to int32_t or uint?
          if (cwhole.w.isFloat && (cwhole.w.isInt || cwhole.w.isUInt)) {
-            c.NeedsConversion = TRUE;
+            c.NeedsConversion = true;
             LOGGING("Conversion: possible upgrade to float32/64 from int/uint32_t for col %s  %d to %d\n", colName, mdtype, odtype);
 
             if (doFixup) {
                // does the master have the float?
                if (mdtype > odtype) {
-                  if (odtype >= SDS_int32_t && mdtype < SDS_DOUBLE) {
+                  if (odtype >= SDS_INT && mdtype < SDS_DOUBLE) {
                      // MUST BE ATLEAST FLOAT64!! (auto upgrade)
                      // upgrade the dtype
                      UpgradeType(pMasterArrayBlock, SDS_DOUBLE, 0);
@@ -5288,7 +5288,7 @@ SDS_COMPATIBLE IsArrayCompatible(
                }
                else {
 
-                  if (mdtype >= SDS_int32_t && odtype < SDS_DOUBLE) {
+                  if (mdtype >= SDS_INT && odtype < SDS_DOUBLE) {
                      // MUST BE ATLEAST FLOAT64!! (auto upgrade)
                      // upgrade the dtype
                      UpgradeType(pMasterArrayBlock, SDS_DOUBLE, 0);
@@ -5304,8 +5304,8 @@ SDS_COMPATIBLE IsArrayCompatible(
          }
          else
             if (cwhole.w.isUInt && cwhole.w.isInt) {
-               bool handleInt64ToUInt64 = TRUE;
-               c.NeedsConversion = TRUE;
+               bool handleInt64ToUInt64 = true;
+               c.NeedsConversion = true;
                LOGGING("Conversion: int32_t /  uint32_t for col %s  %d to %d  fixup: %d\n", colName, mdtype, odtype, doFixup);
 
                if (doFixup) {
@@ -5322,7 +5322,7 @@ SDS_COMPATIBLE IsArrayCompatible(
                      if (handleInt64ToUInt64) {
                         printf("Warning: ignoring sign loss going to from int/uint64 for col: %s\n", colName);
                         // flip it back off
-                        c.NeedsConversion = FALSE;
+                        c.NeedsConversion = false;
                      }
                      else {
                         // This is the old code
@@ -5350,7 +5350,7 @@ SDS_COMPATIBLE IsArrayCompatible(
             else {
                // NOTE possible string to unicode conversion here.. unicode
                LOGGING("!!!Incompat due to dtypes %d %d\n", mdtype, odtype);
-               c.IsCompatible = FALSE;
+               c.IsCompatible = false;
             }
       }
 
@@ -5376,18 +5376,18 @@ SDS_COMPATIBLE IsArrayCompatible(
          // dtypes MATCH, and are NOT STRINGS, but itemsize does not match (is this a void)?
          if (pMasterArrayBlock->ItemSize != pArrayBlock->ItemSize) {
             LOGGING("!!!Incompat due to itemsize\n");
-            c.IsCompatible = FALSE;
+            c.IsCompatible = false;
          }
    }
    if (pMasterArrayBlock->NDim != pArrayBlock->NDim) {
       LOGGING("!!!Incompat due to ndim %d not macthing\n", pMasterArrayBlock->NDim);
-      c.IsCompatible = FALSE;
+      c.IsCompatible = false;
    }
    if (pMasterArrayBlock->NDim > 1) {
       for (int32_t i = 1; i < pMasterArrayBlock->NDim; i++) {
          if (pMasterArrayBlock->Dimensions[i] != pArrayBlock->Dimensions[i]) {
             LOGGING("!!!Incompat due to dim %d not macthing\n", i);
-            c.IsCompatible = FALSE;
+            c.IsCompatible = false;
          }
       }
       int32_t mflag = (pMasterArrayBlock->Flags & SDS_ARRAY_F_CONTIGUOUS);
@@ -5395,7 +5395,7 @@ SDS_COMPATIBLE IsArrayCompatible(
 
       if (mflag != oflag) {
          // possibly incompatible
-         c.NeedsRotation = TRUE;
+         c.NeedsRotation = true;
       }
    }
    return c;
@@ -5453,7 +5453,7 @@ bool FinishRotationalFixup(
    void*          tempBuffer) {
 
    if (!tempBuffer || !origBuffer) {
-      return FALSE;
+      return false;
    }
 
    SDS_ARRAY_BLOCK*        pMasterBlock = pIOPacket->pMasterBlock;
@@ -5503,7 +5503,7 @@ bool FinishRotationalFixup(
          }
       }
    WORKSPACE_FREE(tempBuffer);
-   return TRUE;
+   return true;
 
 }
 
@@ -5559,7 +5559,7 @@ bool DecompressMultiArray(
    if (pBlockInfo == NULL || !pIOPacket->Compatible.IsCompatible) {
 
       GapFillAny(pDestInfo, destBuffer, pIOPacket);
-      return TRUE;
+      return true;
    }
 
    // Make sure we have a valid buffer
@@ -5609,7 +5609,7 @@ bool DecompressMultiArray(
          int64_t slaveItemSize = GetBytesPerRow(pBlockInfo);
 
          //  If no bytes to read..
-         if (slaveItemSize == 0) return TRUE;
+         if (slaveItemSize == 0) return true;
 
          if ((pMasterBlock && pMasterBlock->Flags & SDS_ARRAY_FILTERED) || (pBlockInfo->Flags & SDS_ARRAY_FILTERED)) {
             //printf("filtering on for %lld\n", t);
@@ -5687,7 +5687,7 @@ bool DecompressMultiArray(
    else {
       LOG_THREAD("!!bad destBuffer\n");
    }
-   return TRUE;
+   return true;
 }
 
 
@@ -5908,7 +5908,7 @@ public:
 
          // For strings, if the width increased, we update the king block
          SDS_COMPATIBLE compat =
-            IsArrayCompatible(columnName, &ColumnVector[colPos].KingBlock, pArrayBlock, TRUE);
+            IsArrayCompatible(columnName, &ColumnVector[colPos].KingBlock, pArrayBlock, true);
 
          if (compat.NeedsRotation) {
             // cannot handle
@@ -5938,7 +5938,7 @@ public:
       }
 
       // track last valid row?
-      LastRow = (INT)fileRow;
+      LastRow = (int32_t)fileRow;
    }
 
 
@@ -5977,7 +5977,7 @@ public:
       if (pSDSDecompressFile->IsFileValid && pSDSDecompressFile->Mode == SDS_MULTI_MODE_CONCAT_MANY) {
          pSDSDecompressFile->FileSize = DefaultFileIO.FileSize(pSDSDecompressFile->FileName);
       }
-      return TRUE;
+      return true;
    }
 
    //===========================================
@@ -6032,7 +6032,7 @@ public:
                pArrayInfo,
                pReadCallbacks,
                tupleSize,
-               FALSE);
+               false);
 
             pReadFinalCallback[f].pArrayInfo = pArrayInfo;
             currentPos += tupleSize;
@@ -6089,12 +6089,12 @@ public:
 
       int64_t origArrayBlockOffset = pFileHeader->ArrayBlockOffset;
       SDS_FILE_HANDLE inFile = pSDSDecompress->SDSFile;
-      bool hasSections = FALSE;
+      bool hasSections = false;
       int64_t localOffset = 0;
 
       if (pFileHeader->SectionBlockOffset) {
          LOGGING("!!warning file %s has section within section when concat\n", pSDSDecompress->FileName);
-         hasSections = TRUE;
+         hasSections = true;
       }
 
       // end of file might be larger due to padding... when it is, cap to filesize
@@ -6628,10 +6628,10 @@ public:
       // Now build a hash of all the valid filenames
       // Also.. how homogenous are the files... all datasets?  all structs?
       for (int32_t t = 0; t < FileCount; t++) {
-         bool isStruct = FALSE;
-         bool isDataset = FALSE;
-         bool isArray = FALSE;
-         bool isOneFile = FALSE;
+         bool isStruct = false;
+         bool isDataset = false;
+         bool isArray = false;
+         bool isOneFile = false;
 
          SDSDecompressFile* pSDSDecompress = pSDSDecompressFile[t];
          if (pSDSDecompress->IsFileValid) {
@@ -6736,7 +6736,7 @@ public:
       //   SetErr_Format(SDS_VALUE_ERROR, "MultiDecompress error -- all the filetypes must be the same type (struct or dataset or array)\nFilename: %s\n", pFirstFileName);
       //   goto EXIT_EARLY;
       //}
-      bool isGood = FALSE;
+      bool isGood = false;
 
       if (validCount == 0) {
          SetErr_Format(SDS_VALUE_ERROR, "MultiDecompress error -- none of the files were valid: %s\n", pFirstFileName);
@@ -6751,7 +6751,7 @@ public:
          SetErr_Format(SDS_VALUE_ERROR, "MultiDecompress error -- detected a dimension fixup problem %s\n", pFirstFileName);
       }
       else {
-         isGood = TRUE;
+         isGood = true;
       }
 
       if (isGood) {
@@ -6830,7 +6830,7 @@ public:
             //LOGGING("master %p ", pMasterBlock);
 
             int32_t mask = SDS_FLAGS_ORIGINAL_CONTAINER;
-            bool  isFilterable = FALSE;           
+            bool  isFilterable = false;           
 
             if (pFilterInfo && 
                (pKing->ArrayEnum & mask) == mask &&
@@ -6838,7 +6838,7 @@ public:
                fileTypeStackable) {
 
                // only the first column that is stackable is used to calculate
-               isFilterable = TRUE;
+               isFilterable = true;
             }
 
             // PASS #1...
@@ -6858,12 +6858,12 @@ public:
 
                   //LOGGING("{%d} {%p} ", f, pArrayBlock);
                   // TODO -- CHECK MASTER BLOCK??
-                  SDS_COMPATIBLE isCompatible = { TRUE, FALSE, FALSE, FALSE };
+                  SDS_COMPATIBLE isCompatible = { true, false, false, false };
 
                   // The array might be missing in another file
                   // This happens when users add new rows
                   if (pArrayBlock) {
-                     isCompatible = IsArrayCompatible(pKing->ColName, pMasterBlock, pArrayBlock, FALSE);
+                     isCompatible = IsArrayCompatible(pKing->ColName, pMasterBlock, pArrayBlock, false);
                   }
 
                   int64_t calcLength = 0;
@@ -6903,7 +6903,7 @@ public:
 
                      // Keep track of how many completely filtered out
                      if (filterTrueCount == 0) {
-                        pSDSDecompress->IsFileValidAndNotFilteredOut = FALSE;
+                        pSDSDecompress->IsFileValidAndNotFilteredOut = false;
                         filteredOut++;
                      }                     
 
@@ -6989,7 +6989,7 @@ public:
                oneRowSize *= dimensions[j];
             }
 
-            bool wasFiltered = FALSE;
+            bool wasFiltered = false;
 
             // Caller will fill info pArrayObject and pData
             // pData is valid for shared memory
@@ -7057,7 +7057,7 @@ public:
                   pIOPacket->CompMode = COMPRESSION_MODE_DECOMPRESS;
 
                   // TODO -- CHECK MASTER BLOCK??
-                  pIOPacket->Compatible = { TRUE, FALSE, FALSE, FALSE };
+                  pIOPacket->Compatible = { true, false, false, false };
                   pIOPacket->ArrayOffset = pArrayOffsets[row];
                   pIOPacket->OriginalArrayOffset = pOriginalArrayOffsets[row];
 
@@ -7072,7 +7072,7 @@ public:
                   // The array might be missing in another file
                   // This happens when they add new rows
                   if (pArrayBlock) {
-                     pIOPacket->Compatible = IsArrayCompatible(pKing->ColName, pMasterBlock, pArrayBlock, FALSE);
+                     pIOPacket->Compatible = IsArrayCompatible(pKing->ColName, pMasterBlock, pArrayBlock, false);
                   }
 
                   //printf("array offset %lld\n", pArrayOffsets[row]);
@@ -7401,15 +7401,15 @@ extern "C" {
       PMAPPED_VIEW_STRUCT pMappedStruct = (PMAPPED_VIEW_STRUCT)pMapStruct;
       if (pMappedStruct) {
          UtilSharedMemoryEnd(pMappedStruct);
-         return TRUE;
+         return true;
       }
-      return FALSE;
+      return false;
    }
 
    DllExport int32_t CloseDecompressFile(void* pInput) {      
       SDSDecompressFile* pSDSDecompressFile = (SDSDecompressFile * )pInput;
       delete pSDSDecompressFile;
-      return TRUE;
+      return true;
    }
 
    //DllExport void SDSClearBuffers() {

--- a/src/SDSFile.h
+++ b/src/SDSFile.h
@@ -359,7 +359,7 @@ struct SDS_FILE_HEADER {
    }
 
    // only valid after file header has been filled in
-   INT64    GetEndOfFileOffset() {
+   int64_t    GetEndOfFileOffset() {
       return TotalArrayCompressedSize + ArrayFirstOffset;
    }
 };
@@ -791,7 +791,7 @@ extern "C" {
 
    typedef bool(*SDS_WRITE_FILE)(const char*, const char*, SDS_WRITE_INFO*, SDS_WRITE_CALLBACKS*);
    typedef void*(*SDS_READ_FILE)(const char*, const char*, SDS_READ_INFO*, SDS_READ_CALLBACKS*);
-   typedef void*(*SDS_READ_MANY_FILES)(SDS_MULTI_READ*, SDS_STRING_LIST*, INT64, int, SDS_READ_CALLBACKS*);
+   typedef void*(*SDS_READ_MANY_FILES)(SDS_MULTI_READ*, SDS_STRING_LIST*, int64_t, int, SDS_READ_CALLBACKS*);
    typedef char*(*SDS_GET_LAST_ERROR)();
    typedef void(*SDS_CLEAR_BUFFERS)();
 }

--- a/src/SDSFile.h
+++ b/src/SDSFile.h
@@ -847,7 +847,7 @@ int32_t _SDSWriteFile(
          return g_fpWriteFile(fileName, shareName, pWriteInfo, pWriteCallbacks);
       }
    }
-   return FALSE;
+   return false;
 }
 
 //===================================================================

--- a/src/SDSFile.h
+++ b/src/SDSFile.h
@@ -1,5 +1,4 @@
 #pragma once
-#pragma once
 #include <vector>
 
 
@@ -253,29 +252,29 @@ enum SDS_TYPES {
 struct SDS_ARRAY_BLOCK {
 
    //----- offset 0 -----
-   INT16       HeaderTag;
-   INT16       HeaderLength;
+   int16_t       HeaderTag;
+   int16_t       HeaderLength;
 
-   UINT8       Magic;  // See compression magic
-   INT8        CompressionType;
-   INT8        DType;
-   INT8        NDim;
+   uint8_t       Magic;  // See compression magic
+   int8_t        CompressionType;
+   int8_t        DType;
+   int8_t        NDim;
 
-   //----- offset 8 -----
-   INT32       ItemSize;
-   INT32       Flags;
+   //----- offset 8 ----- // BUGBUG All these offsets are wrong, this struct has default member alignments.
+   int32_t       ItemSize;
+   int32_t       Flags;
 
    //----- offset 16 -----
    // no more than 5 dims
-   INT64       Dimensions[SDS_MAX_DIMS];
-   INT64       Strides[SDS_MAX_DIMS];
+   int64_t       Dimensions[SDS_MAX_DIMS];
+   int64_t       Strides[SDS_MAX_DIMS];
 
-   INT64       ArrayDataOffset;     // Start of data in file                          
+   int64_t       ArrayDataOffset;     // Start of data in file                          
                                     // If banding, then (UncompressedSize + (BandSize-1)) / BandSize => # of bands
-   INT64       ArrayCompressedSize;
-   INT64       ArrayUncompressedSize;
-   INT32       ArrayBandCount;      // 0=no banding
-   INT32       ArrayBandSize;       // 0=no banding
+   int64_t       ArrayCompressedSize;
+   int64_t       ArrayUncompressedSize;
+   int32_t       ArrayBandCount;      // 0=no banding
+   int32_t       ArrayBandSize;       // 0=no banding
 
 };
 
@@ -283,75 +282,75 @@ struct SDS_ARRAY_BLOCK {
 // At offset 0 of the file is this header
 struct SDS_FILE_HEADER {
 
-   UINT32      SDSHeaderMagic;
-   INT16       VersionHigh;
-   INT16       VersionLow;
+   uint32_t      SDSHeaderMagic;
+   int16_t       VersionHigh;
+   int16_t       VersionLow;
 
-   INT16       CompMode;
-   INT16       CompType;
-   INT32       CompLevel;
+   int16_t       CompMode;
+   int16_t       CompType;
+   int16_t       CompLevel;
 
    //----- offset 16 -----
-   INT64       NameBlockSize;
-   INT64       NameBlockOffset;
-   INT64       NameBlockCount;
+   int64_t       NameBlockSize;
+   int64_t       NameBlockOffset;
+   int64_t       NameBlockCount;
 
-   INT16       FileType;  // see SDS_FILE_TYPE
-   INT16       StackType;  // see SDS_STACK_TYPE
-   INT32       AuthorId;  // see SDS_AUTHOR_ID
+   int16_t       FileType;  // see SDS_FILE_TYPE
+   int16_t       StackType;  // see SDS_STACK_TYPE
+   int32_t       AuthorId;  // see SDS_AUTHOR_ID
 
    //----- offset 48 -----
-   INT64       MetaBlockSize;
-   INT64       MetaBlockOffset;
+   int64_t       MetaBlockSize;
+   int64_t       MetaBlockOffset;
 
    //----- offset 64 -----
-   INT64       TotalMetaCompressedSize;
-   INT64       TotalMetaUncompressedSize;
+   int64_t       TotalMetaCompressedSize;
+   int64_t       TotalMetaUncompressedSize;
 
    //----- offset 80 -----
-   INT64       ArrayBlockSize;
-   INT64       ArrayBlockOffset;
+   int64_t       ArrayBlockSize;
+   int64_t       ArrayBlockOffset;
 
    //----- offset 96 -----
-   INT64       ArraysWritten;
-   INT64       ArrayFirstOffset;
+   int64_t       ArraysWritten;
+   int64_t       ArrayFirstOffset;
 
    //----- offset 112 -----
-   INT64       TotalArrayCompressedSize;        // Includes the SDS_PADDING, next relative offset to write to
-   INT64       TotalArrayUncompressedSize;
+   int64_t       TotalArrayCompressedSize;        // Includes the SDS_PADDING, next relative offset to write to
+   int64_t       TotalArrayUncompressedSize;
 
    //----- offset 128 -----
    //------------- End of Version 4.1 ---------
    //------------- Version 4.3 starts here ----
-   INT64       BandBlockSize;       // 00 if nothing
-   INT64       BandBlockOffset;     // 00
-   INT64       BandBlockCount;      // Number of names
-   INT64       BandSize;            // How many elements before creating another band
+   int64_t       BandBlockSize;       // 00 if nothing
+   int64_t       BandBlockOffset;     // 00
+   int64_t       BandBlockCount;      // Number of names
+   int64_t       BandSize;            // How many elements before creating another band
 
    //----- offset 160 -----
    //------------- End of Version 4.3 ---------
    //------------- Version 4.4 starts here ----
-   INT64       SectionBlockSize;    // how many bytes valid data
-   INT64       SectionBlockOffset;  // points to section directory if it exists (often NULL if file was never appended)
+   int64_t       SectionBlockSize;    // how many bytes valid data
+   int64_t       SectionBlockOffset;  // points to section directory if it exists (often NULL if file was never appended)
                                     // if exists was often the LastFileOffset when an append operation was done
                                     // Then can read that offset to get a list of
                                     // NAMES\0\NAME2\0
-   INT64       SectionBlockCount;   // number of names (number of sections total) (often 0 if never appended)
-   INT64       SectionBlockReservedSize;   // total size of what we reserved for this block (so we can append names)
+   int64_t       SectionBlockCount;   // number of names (number of sections total) (often 0 if never appended)
+   int64_t       SectionBlockReservedSize;   // total size of what we reserved for this block (so we can append names)
 
    //----- offset 192 -----
-   INT64       FileOffset;          // this file offset within the file
-   UINT64      TimeStampUTCNanos;   // time stamp when file was last written (0s indicate no time stamp)
+   int64_t       FileOffset;          // this file offset within the file
+   uint64_t      TimeStampUTCNanos;   // time stamp when file was last written (0s indicate no time stamp)
 
    //----- offset 208 -----
-   char        Reserved[512 - 208];
+   char        Reserved[512 - 208]; //BUGBUG This should be done using align statements, not magic number math with incorrect arguments.
 
    //-----------------------------
    // function to multithreaded safe calculate the next array offset to write to
    // returns the relative file offset (has added pFileHeader->ArrayFirstOffset)
-   INT64       AddArrayCompressedSize(INT64 cSize) {
-      INT64 padSize = SDS_PAD_NUMBER(cSize);
-      INT64 fileOffset = InterlockedAdd64(&TotalArrayCompressedSize, padSize) - padSize;
+   int64_t       AddArrayCompressedSize(int64_t cSize) {
+      int64_t padSize = SDS_PAD_NUMBER(cSize);
+      int64_t fileOffset = InterlockedAdd64(&TotalArrayCompressedSize, padSize) - padSize;
 
       // Calculate file offset location where arrays are stored
       fileOffset += ArrayFirstOffset;
@@ -371,13 +370,13 @@ public:
    // Section data created when user appends to a file with section name
    char*          pSectionData = NULL;
    const char**   pSectionNames = NULL;
-   INT64*         pSectionOffsets = NULL;
-   INT64          SectionCount = 0;
-   INT64          SectionOffset = 0;
+   int64_t*         pSectionOffsets = NULL;
+   int64_t          SectionCount = 0;
+   int64_t          SectionOffset = 0;
 
    // For creating one when it was missing (first time appended)
    const char* g_firstsectioname = "0";
-   INT64       g_firstsectionoffset = 0;
+   int64_t       g_firstsectionoffset = 0;
    char        g_firstsectiondata[10] = { '0',0,0,0,0,0,0,0,0,0 };
 
    //-----------------------------------------------------------
@@ -385,29 +384,30 @@ public:
    // Returns sizeof new section
    // Returns pointer in *pListNames
    // NOTE: caller must WORKSPACE_FREE *pListNames
-   INT64
+   int64_t
       BuildSectionNamesAndOffsets(
          char** pListNames,                // Returned
          const char*  pNewSectionName,
-         INT64  newSectionOffset           // 0 Allowed
+         int64_t  newSectionOffset           // 0 Allowed
       );
-   void AllocateSectionData(INT64 sectionBlockCount, INT64 sectionSize);
+   void AllocateSectionData(int64_t sectionBlockCount, int64_t sectionSize);
 
    void DeleteSectionData();
-   void MakeListSections(const INT64 sectionBlockCount, const INT64 sectionByteSize);
+   void MakeListSections(const int64_t sectionBlockCount, const int64_t sectionByteSize);
    char* MakeFirstSectionName();
    char* ReadListSections(SDS_FILE_HANDLE SDSFile, SDS_FILE_HEADER *pFileHeader);
    ~SDSSectionName();
 };
 
 //------------ PAD TO 512 ----------------------
-// 4 of these (4*128) can fit in 512
+// 4 of these (4*128) can fit in 512 
 // TJD: NOT USED YET
+// BUGBUG: EST: Needs alignment / corrected padding work
 struct SDS_FOLDER_HEADER {
-   INT64       FolderHeaderOffset;     // points to SDS_FILE_HEADER
-   INT64       FolderCreateTimeUTC;
-   INT8        FolderType;             // 0 for now SDS_FILE_TYPE_UNKNOWN, etc.
-   INT8        FolderNameLength;       // up to 110 chars
+   int64_t       FolderHeaderOffset;     // points to SDS_FILE_HEADER
+   int64_t       FolderCreateTimeUTC;
+   int8_t        FolderType;             // 0 for now SDS_FILE_TYPE_UNKNOWN, etc.
+   int8_t        FolderNameLength;       // up to 110 chars
    char        FolderName[128 - 16 -2];
 };
 
@@ -422,45 +422,45 @@ struct SDSArrayInfo {
    char*       pData;
 
    // total number of items
-   INT64       ArrayLength;
+   int64_t    ArrayLength;
 
    // total number of items * itemsize
-   INT64       NumBytes;
+   int64_t       NumBytes;
 
    // see SDS_TYPES which follow numpy dtypes
-   INT32       NumpyDType;
+   int32_t       NumpyDType;
 
    // Number of dimensions (not to exceed 3 currently)
-   INT32       NDim;
+   int32_t       NDim;
 
    // Width in bytes of one row
-   INT32       ItemSize;
+   int32_t       ItemSize;
 
    // See SDS_FLAGS which are same as numpy flags
-   INT32       Flags;
+   int32_t       Flags;
 
    // no more than SDS_MAX_DIMS dims
-   INT64       Dimensions[SDS_MAX_DIMS];
-   INT64       Strides[SDS_MAX_DIMS];
+   int64_t       Dimensions[SDS_MAX_DIMS];
+   int64_t       Strides[SDS_MAX_DIMS];
 
 };
 
 //---------------------------------------------------------------------
 // NOTE: filter or mask must be passed
 struct SDSFilterInfo {
-   INT64    TrueCount;  // If zero, dont bother reading in data
-   INT64    RowOffset;  // sum of all previous True Count
+   int64_t    TrueCount;  // If zero, dont bother reading in data
+   int64_t    RowOffset;  // sum of all previous True Count
 };
 
 struct SDS_FILTER {
-   //INT32*                           pFancyMask;
-   //INT64                            FancyLength;         // length of the index array as well as final array
+   //int32_t*                           pFancyMask;
+   //int64_t                            FancyLength;         // length of the index array as well as final array
 
    // if BoolMaskLength == BoolMaskTrueCount and BoolMaskLength < 100
    // we assume this is looking at the header (first 5, 10, 100 rows)
    bool*                            pBoolMask;
-   INT64                            BoolMaskLength;      // length of bool mask (but not final array)
-   INT64                            BoolMaskTrueCount;   // length of final array
+   int64_t                            BoolMaskLength;      // length of bool mask (but not final array)
+   int64_t                            BoolMaskTrueCount;   // length of final array
    SDSFilterInfo*                   pFilterInfo;         // allocated on the fly when stacking
 };
 
@@ -479,14 +479,14 @@ struct SDS_WRITE_COMPRESS_ARRAYS {
    // Used when going to shared memory
    class SharedMemory*  pMemoryIO;
 
-   INT64                totalHeaders;
-   INT16                compMode;
-   INT16                compType;
-   INT32                compLevel;
+   int64_t                totalHeaders;
+   int16_t                compMode;
+   int16_t                compType;
+   int32_t                compLevel;
 
    // Per core allocations
    void*                pCoreMemory[SDS_MAX_THREADS];
-   INT64                pCoreMemorySize[SDS_MAX_THREADS];
+   int64_t                pCoreMemorySize[SDS_MAX_THREADS];
    SDS_EVENT_HANDLE     eventHandles[SDS_MAX_THREADS];
 
    // See: compMode value -- COMPRESSIOM_MODE_SHAREDMEMORY
@@ -517,14 +517,14 @@ struct SDS_READ_DECOMPRESS_ARRAYS {
    // Used when going to shared memory
    class SharedMemory*  pMemoryIO;
 
-   INT64                totalHeaders;
-   INT16                compMode;
-   INT16                compType;
-   INT32                compLevel;
+   int64_t                totalHeaders;
+   int16_t                compMode;
+   int16_t                compType;
+   int32_t                compLevel;
 
    // Per core allocations
    void*                pCoreMemory[SDS_MAX_THREADS];
-   INT64                pCoreMemorySize[SDS_MAX_THREADS];
+   int64_t                pCoreMemorySize[SDS_MAX_THREADS];
    SDS_EVENT_HANDLE     eventHandles[SDS_MAX_THREADS];
 
    // See: compMode value -- COMPRESSIOM_MODE_SHAREDMEMORY
@@ -539,7 +539,7 @@ struct SDS_READ_DECOMPRESS_ARRAYS {
 struct SDS_STACK_CALLBACK_FILES {
    const char*       Filename;
    const char*       MetaData;
-   INT64             MetaDataSize;
+   int64_t             MetaDataSize;
    SDS_FILE_HEADER*  pFileHeader;
 };
 
@@ -549,9 +549,9 @@ struct SDS_STACK_CALLBACK {
 
    const char*       ArrayName;
    void *            pArrayObject;
-   INT64*            pArrayOffsets;
+   int64_t*            pArrayOffsets;
    SDS_ARRAY_BLOCK*  pArrayBlock;
-   INT32             ArrayEnum;
+   int32_t             ArrayEnum;
 };
 
 
@@ -561,17 +561,17 @@ struct SDS_STACK_CALLBACK {
 struct SDS_FINAL_CALLBACK {
    SDS_FILE_HEADER*  pFileHeader;
 
-   INT32             mode;                      // info or decompress
-   INT32             reserved1;
+   int32_t             mode;                      // info or decompress
+   int32_t             reserved1;
 
-   INT64             arraysWritten;
+   int64_t             arraysWritten;
    SDS_ARRAY_BLOCK*  pArrayBlocks;
    SDSArrayInfo*     pArrayInfo;
 
    //SDS_READ_DECOMPRESS_ARRAYS*  pstCompressArrays;
 
    char*             metaData;
-   INT64             metaSize;
+   int64_t             metaSize;
 
    char*             nameData;                  // array name data
    SDSSectionName*   pSectionName;              // if the file has section, else NULL
@@ -584,8 +584,8 @@ struct SDS_SHARED_MEMORY_CALLBACK {
    SDS_FILE_HEADER*  pFileHeader;
    char*             baseOffset;
 
-   INT32             mode;
-   INT32             reserved1;
+   int32_t             mode;
+   int32_t             reserved1;
    void*             pSDSDecompressFile;
 
    // used to close memory/file handles
@@ -600,15 +600,15 @@ struct SDS_ALLOCATE_ARRAY {
    //void*          pExclusionList;
 
    // Tells caller how to allocate
-   int            ndim;
-   INT64*         dims;
-   INT32          numpyType;
-   INT64          itemsize;
+   int32_t            ndim;
+   int64_t*         dims;
+   int32_t          numpyType;
+   int64_t          itemsize;
    char*          data;
-   INT32          numpyFlags;
-   INT64*         strides;
+   int32_t          numpyFlags;
+   int64_t*         strides;
    const char*    pArrayName;
-   INT32          sdsFlags;     //  see SDS_FLAGS_ORIGINAL_CONTAINER, etc.
+   int32_t          sdsFlags;     //  see SDS_FLAGS_ORIGINAL_CONTAINER, etc.
 };
 
 
@@ -616,20 +616,20 @@ struct SDS_ALLOCATE_ARRAY {
 // Callbacks
 
 // Called at the end of reading a file
-typedef void*(*SDS_READ_FINAL_CALLBACK)(SDS_FINAL_CALLBACK* pSDSFinalCallback, INT64 finalCount);
+typedef void*(*SDS_READ_FINAL_CALLBACK)(SDS_FINAL_CALLBACK* pSDSFinalCallback, int64_t finalCount);
 
 // Called at the end of reading a stacked file
 typedef void*(*SDS_STACK_FINAL_CALLBACK)(
    SDS_STACK_CALLBACK* pSDSFinalCallback, 
-   INT64 finalCount, 
+   int64_t finalCount, 
    SDS_STACK_CALLBACK_FILES* pSDSFileInfo, 
    SDS_FILTER*    pSDSFilter,
-   INT64 fileCount);
+   int64_t fileCount);
 
 // Only called when reading from shared memory
 typedef void*(*SDS_READ_SHARED_MEMORY_CALLBACK) (SDS_SHARED_MEMORY_CALLBACK* pSDSMemoryCallback);
 
-//examples PyArrayObject* AllocateNumpyArray(int ndim, npy_intp* dims, INT32 numpyType, INT64 itemsize, char* data, INT32 numpyFlags, npy_intp* strides) {
+//examples PyArrayObject* AllocateNumpyArray(int ndim, npy_intp* dims, int32_t numpyType, int64_t itemsize, char* data, int32_t numpyFlags, npy_intp* strides) {
 // Copy all information into pDestInfo
 // Called at the beginning of reading a file
 // if pData return as NULL, data is assume to be EXCLUDED
@@ -670,7 +670,7 @@ struct SDS_READ_CALLBACKS {
 
    bool                             MustExist;
    bool                             Dummy1;
-   INT16                            Dummy2;
+   int16_t                            Dummy2;
    // new for filtering
    SDS_FILTER                       Filter;
 
@@ -680,7 +680,7 @@ struct SDS_READ_CALLBACKS {
 };
 
 struct SDS_READ_INFO {
-   INT32 mode;       // = COMPRESSION_MODE_COMPRESS_FILE,
+   int32_t mode;       // = COMPRESSION_MODE_COMPRESS_FILE,
 };
 
 
@@ -693,40 +693,40 @@ struct SDS_WRITE_CALLBACKS {
 struct SDS_WRITE_INFO {
    // arrays to save information
    SDSArrayInfo* aInfo;
-   INT64 arrayCount;
+   int64_t arrayCount;
 
    // meta information
    const char *metaData;
-   UINT32 metaDataSize;
+   uint32_t metaDataSize;
 
    // names of arrays information
    char* pListNames;
-   INT64 listNameSize;    // total byte size (store in memory)
-   INT64 listNameCount;   // number of names
+   int64_t listNameSize;    // total byte size (store in memory)
+   int64_t listNameCount;   // number of names
 
                           // compressed or uncompressed
-   INT32 mode;       // = COMPRESSION_MODE_COMPRESS_FILE,
-   INT32 compType;   // = COMPRESSION_TYPE_ZSTD,
-   INT32 level;      // = ZSTD_CLEVEL_DEFAULT;
+   int32_t mode;       // = COMPRESSION_MODE_COMPRESS_FILE,
+   int32_t compType;   // = COMPRESSION_TYPE_ZSTD,
+   int32_t level;      // = ZSTD_CLEVEL_DEFAULT;
 
-   INT32 sdsFileType; // = SDS_FILE_TYPE_STRUCT
-   INT32 sdsAuthorId; // = SDS_AUTHOR_IS
+   int32_t sdsFileType; // = SDS_FILE_TYPE_STRUCT
+   int32_t sdsAuthorId; // = SDS_AUTHOR_IS
 
-   BOOL  appendFileHeadersMode;  // True if appending to existing file
-   BOOL  appendRowsMode;         // Appending rows only
-   BOOL  appendColumnsMode;      // Appending columns only (code not written yet)
-   BOOL  appendReserved1;
+   bool  appendFileHeadersMode;  // True if appending to existing file
+   bool  appendRowsMode;         // Appending rows only
+   bool  appendColumnsMode;      // Appending columns only (code not written yet)
+   bool  appendReserved1;
 
-   INT64 bandSize;    // banding divides a column into chunks (set to 0 for no banding)
+   int64_t bandSize;    // banding divides a column into chunks (set to 0 for no banding)
 
    const char* sectionName;
-   INT64       sectionNameSize;
+   int64_t       sectionNameSize;
 };
 
 struct SDS_MULTI_READ {
    const char*          pFileName;
    SDS_STRING_LIST*     pFolderName;
-   INT64                Index;
+   int64_t                Index;
    SDS_FINAL_CALLBACK   FinalCallback;
 };
 
@@ -748,7 +748,7 @@ extern "C" {
    //-------------------------------------------------
    // Main API to write SDS file
    // File only
-   DllExport BOOL SDSWriteFile(
+   DllExport int32_t SDSWriteFile(
       const char *fileName,
       const char *shareName,  // can be NULL
       SDS_STRING_LIST *folderName,
@@ -775,21 +775,21 @@ extern "C" {
       SDS_STRING_LIST*     pInclusionList,      // may be set to NULL
       SDS_STRING_LIST*     pFolderList,      // may be set to NULL
       SDS_STRING_LIST*     pSectionsName,    // can be NULL
-      INT64                fileCount,
-      int                  multiMode,           // see SDS_MULTI
+      int64_t                fileCount,
+      int32_t                  multiMode,           // see SDS_MULTI
       SDS_READ_CALLBACKS*  pReadCallbacks);
 
 
    DllExport char* SDSGetLastError();
 
-   DllExport BOOL CloseSharedMemory(void* pMapStruct);
+   DllExport int32_t CloseSharedMemory(void* pMapStruct);
 
-   DllExport BOOL CloseDecompressFile(void* pSDSDecompressFile);
+   DllExport int32_t CloseDecompressFile(void* pSDSDecompressFile);
 
    // no longer supported
    //DllExport void SDSClearBuffers();
 
-   typedef BOOL(*SDS_WRITE_FILE)(const char*, const char*, SDS_WRITE_INFO*, SDS_WRITE_CALLBACKS*);
+   typedef bool(*SDS_WRITE_FILE)(const char*, const char*, SDS_WRITE_INFO*, SDS_WRITE_CALLBACKS*);
    typedef void*(*SDS_READ_FILE)(const char*, const char*, SDS_READ_INFO*, SDS_READ_CALLBACKS*);
    typedef void*(*SDS_READ_MANY_FILES)(SDS_MULTI_READ*, SDS_STRING_LIST*, INT64, int, SDS_READ_CALLBACKS*);
    typedef char*(*SDS_GET_LAST_ERROR)();
@@ -825,7 +825,7 @@ void _LazyLoad(const char* dllLoadPath) {
 // For matlab which does not statically link to the DLL
 // Load DLL on demand
 // dllLoadPath may be null, it will try to load from normal paths
-BOOL _SDSWriteFile(
+int32_t _SDSWriteFile(
    const char* dllLoadPath,
    const char *fileName,
    const char *shareName,  // can be NULL
@@ -881,8 +881,8 @@ void* _SDSReadManyFiles(
    const char* dllLoadPath,
    SDS_MULTI_READ*      pMultiRead,
    SDS_STRING_LIST*     pInclusionList,      // may be set to NULL
-   INT64                fileCount,
-   int                  multiMode,           // see SDS_MULTI
+   int64_t                fileCount,
+   int32_t                  multiMode,           // see SDS_MULTI
    SDS_READ_CALLBACKS*  pReadCallbacks) {
 
    // Lazy DLL load

--- a/src/SharedMemory.cpp
+++ b/src/SharedMemory.cpp
@@ -52,7 +52,7 @@ CheckWindowsPrivilege(const char* pPrivilegeName)
       printf("OpenProcessToken error %u\n", e);
       hResult = HRESULT_FROM_WIN32(e);
       LogWarningLE(hResult);
-      return FALSE;
+      return false;
    }
 
    if (!LookupPrivilegeValue(NULL, pPrivilegeName, &luid))
@@ -63,7 +63,7 @@ CheckWindowsPrivilege(const char* pPrivilegeName)
       printf("LookupPrivilegeValue error %u\n", e);
       hResult = HRESULT_FROM_WIN32(e);
       LogWarningLE(hResult);
-      return FALSE;
+      return false;
    }
 
    privilegeSet.PrivilegeCount = 1;
@@ -96,7 +96,7 @@ BOOL SetPrivilege(
       &luid))        // receives LUID of privilege
    {
       printf("LookupPrivilegeValue error: %u\n", GetLastError());
-      return FALSE;
+      return false;
    }
 
    tp.PrivilegeCount = 1;
@@ -110,24 +110,24 @@ BOOL SetPrivilege(
 
    if (!AdjustTokenPrivileges(
       hToken,
-      FALSE,
+      false,
       &tp,
       sizeof(TOKEN_PRIVILEGES),
       (PTOKEN_PRIVILEGES)NULL,
       (PDWORD)NULL))
    {
       printf("AdjustTokenPrivileges error: %u\n", GetLastError());
-      return FALSE;
+      return false;
    }
 
    if (GetLastError() == ERROR_NOT_ALL_ASSIGNED)
 
    {
       printf("The token does not have the specified privilege. \n");
-      return FALSE;
+      return false;
    }
 
-   return TRUE;
+   return true;
 }
 
 
@@ -144,13 +144,13 @@ CheckWindowsSharedMemoryPrerequisites(const char* pMappingName)
 
       // More work to do here
       if (OpenProcessToken(GetCurrentProcess(), TOKEN_ALL_ACCESS, &currentToken)) {
-         BOOL newResult = SetPrivilege(currentToken, pPrivilegeName, TRUE);
+         BOOL newResult = SetPrivilege(currentToken, pPrivilegeName, true);
          CloseHandle(currentToken);
          return newResult;
       }
-      return FALSE;
+      return false;
    }
-   return TRUE;
+   return true;
 }
 
 //------------------------------------------------------------------------------------------
@@ -177,7 +177,7 @@ UtilSharedMemoryBegin(
 
    if (!CheckWindowsSharedMemoryPrerequisites(pMappingName))
    {
-      hResult = S_FALSE;
+      hResult = S_false;
       return -(hResult);
    }
 
@@ -284,7 +284,7 @@ UtilSharedNumaMemoryBegin(
 
    if (!CheckWindowsSharedMemoryPrerequisites(pMappingName))
    {
-      hResult = S_FALSE;
+      hResult = S_false;
       return -(hResult);
    }
 
@@ -369,7 +369,7 @@ UtilSharedNumaMemoryBegin(
 // The pReturnStruct will be valid if the call succeeded
 // if bTest = true, it will not complain if it cannot find shared memory
 // if returns S_OK you are mapped
-// returns S_FALSE if it does not exist yet 
+// returns S_false if it does not exist yet 
 HRESULT
 UtilSharedMemoryCopy(
    const char*              pMappingName,
@@ -401,7 +401,7 @@ UtilSharedMemoryCopy(
    pMappedViewStruct->MapHandle =
       OpenFileMapping(
          FILE_MAP_ALL_ACCESS,
-         FALSE,
+         false,
          pMappingName);
 
    //printf("Result from OpenFileMaApping %s -- %p\n", pMappingName, pMappedViewStruct->MapHandle);
@@ -460,12 +460,12 @@ UtilSharedMemoryEnd(
       return(E_POINTER);
    }
 
-   if (UnmapViewOfFile(pMappedViewStruct->BaseAddress) == FALSE) {
+   if (UnmapViewOfFile(pMappedViewStruct->BaseAddress) == false) {
       hResult = HRESULT_FROM_WIN32(GetLastError());
       return (hResult);
    }
 
-   if (CloseHandle(pMappedViewStruct->MapHandle) == FALSE) {
+   if (CloseHandle(pMappedViewStruct->MapHandle) == false) {
       hResult = HRESULT_FROM_WIN32(GetLastError());
       return (hResult);
    }
@@ -497,7 +497,7 @@ UtilMappedViewReadBegin(
 
    if (!CheckWindowsSharedMemoryPrerequisites(pMappingName)) 
    {
-      return -(S_FALSE);
+      return -(S_false);
    }
 
    //
@@ -636,12 +636,12 @@ UtilMappedViewReadEnd(
       return(E_POINTER);
    }
 
-   if (UnmapViewOfFile(pMappedViewStruct->BaseAddress) == FALSE) {
+   if (UnmapViewOfFile(pMappedViewStruct->BaseAddress) == false) {
       hResult = HRESULT_FROM_WIN32(GetLastError());
       return (hResult);
    }
 
-   if (CloseHandle(pMappedViewStruct->MapHandle) == FALSE) {
+   if (CloseHandle(pMappedViewStruct->MapHandle) == false) {
       hResult = HRESULT_FROM_WIN32(GetLastError());
       return (hResult);
    }
@@ -683,7 +683,7 @@ UtilMappedViewWriteBegin(
 
    if (!CheckWindowsSharedMemoryPrerequisites(pMappingName))
    {
-      return -(S_FALSE);
+      return -(S_false);
    }
 
    //
@@ -822,7 +822,7 @@ UtilMappedViewWriteBegin(
 HRESULT
 UtilSharedMemoryBegin(
    const char*          pMappingName,
-   INT64                size,
+   int64_t                size,
    PMAPPED_VIEW_STRUCT *pReturnStruct) {
 
    // NULL indicates failure - default to that.
@@ -918,18 +918,18 @@ HRESULT
 UtilSharedMemoryCopy(
    const char*          pMappingName,
    PMAPPED_VIEW_STRUCT *pReturnStruct,
-   BOOL                 bTest) {
+   bool                 bTest) {
 
    // NULL indicates failure - default to that.
    *pReturnStruct = NULL;
    errno = 0;
-   BOOL bCanOnlyRead = FALSE;
+   bool bCanOnlyRead = false;
 
    LOGGING("Trying to open shared memory %s.\n", pMappingName);
    int     fd = shm_open(pMappingName, O_RDWR, 0666);
 
    if (fd <= 0) {
-      bCanOnlyRead = TRUE;
+      bCanOnlyRead = true;
       fd = shm_open(pMappingName, O_RDONLY, 0666);
    }
 

--- a/src/SharedMemory.cpp
+++ b/src/SharedMemory.cpp
@@ -39,7 +39,7 @@ CheckWindowsPrivilege(const char* pPrivilegeName)
    HANDLE         hCurrentProccess;
    HANDLE         hProcessToken = NULL;
    HRESULT        hResult;
-   bool           bResult;
+   BOOL           bResult;
 
    hResult = S_OK;
 
@@ -177,7 +177,7 @@ UtilSharedMemoryBegin(
 
    if (!CheckWindowsSharedMemoryPrerequisites(pMappingName))
    {
-      hResult = S_false;
+      hResult = S_FALSE;
       return -(hResult);
    }
 
@@ -284,7 +284,7 @@ UtilSharedNumaMemoryBegin(
 
    if (!CheckWindowsSharedMemoryPrerequisites(pMappingName))
    {
-      hResult = S_false;
+      hResult = S_FALSE;
       return -(hResult);
    }
 
@@ -369,7 +369,7 @@ UtilSharedNumaMemoryBegin(
 // The pReturnStruct will be valid if the call succeeded
 // if bTest = true, it will not complain if it cannot find shared memory
 // if returns S_OK you are mapped
-// returns S_false if it does not exist yet 
+// returns S_FALSE if it does not exist yet 
 HRESULT
 UtilSharedMemoryCopy(
    const char*              pMappingName,
@@ -497,7 +497,7 @@ UtilMappedViewReadBegin(
 
    if (!CheckWindowsSharedMemoryPrerequisites(pMappingName)) 
    {
-      return -(S_false);
+      return -(S_FALSE);
    }
 
    //
@@ -683,7 +683,7 @@ UtilMappedViewWriteBegin(
 
    if (!CheckWindowsSharedMemoryPrerequisites(pMappingName))
    {
-      return -(S_false);
+      return -(S_FALSE);
    }
 
    //

--- a/src/SharedMemory.cpp
+++ b/src/SharedMemory.cpp
@@ -918,7 +918,7 @@ HRESULT
 UtilSharedMemoryCopy(
    const char*          pMappingName,
    PMAPPED_VIEW_STRUCT *pReturnStruct,
-   bool                 bTest) {
+   int                 bTest) {
 
    // NULL indicates failure - default to that.
    *pReturnStruct = NULL;

--- a/src/SharedMemory.cpp
+++ b/src/SharedMemory.cpp
@@ -31,7 +31,7 @@ void LogWarningLE(HRESULT error) {
 // Checks Windows policy settings if the current process has
 // the privilege enabled.
 // 
-BOOL
+bool
 CheckWindowsPrivilege(const char* pPrivilegeName)
 {
    LUID           luid;
@@ -39,7 +39,7 @@ CheckWindowsPrivilege(const char* pPrivilegeName)
    HANDLE         hCurrentProccess;
    HANDLE         hProcessToken = NULL;
    HRESULT        hResult;
-   BOOL           bResult;
+   bool           bResult;
 
    hResult = S_OK;
 
@@ -81,10 +81,10 @@ CheckWindowsPrivilege(const char* pPrivilegeName)
 
 
 //------------------------------------------------------------------------------------------
-BOOL SetPrivilege(
+bool SetPrivilege(
    HANDLE hToken,          // access token handle
    LPCTSTR lpszPrivilege,  // name of privilege to enable/disable
-   BOOL bEnablePrivilege   // to enable or disable privilege
+   bool bEnablePrivilege   // to enable or disable privilege
 )
 {
    TOKEN_PRIVILEGES tp;
@@ -133,7 +133,7 @@ BOOL SetPrivilege(
 
 //------------------------------------------------------------------------------------------
 //
-BOOL
+bool
 CheckWindowsSharedMemoryPrerequisites(const char* pMappingName)
 {
    const char* pPrivilegeName = "SeCreateGlobalPrivilege";
@@ -144,7 +144,7 @@ CheckWindowsSharedMemoryPrerequisites(const char* pMappingName)
 
       // More work to do here
       if (OpenProcessToken(GetCurrentProcess(), TOKEN_ALL_ACCESS, &currentToken)) {
-         BOOL newResult = SetPrivilege(currentToken, pPrivilegeName, true);
+         bool newResult = SetPrivilege(currentToken, pPrivilegeName, true);
          CloseHandle(currentToken);
          return newResult;
       }

--- a/src/SharedMemory.h
+++ b/src/SharedMemory.h
@@ -9,33 +9,33 @@ struct MAPPED_VIEW_STRUCT
    void*    BaseAddress;         // Past RCF Header
    void*    MapHandle;
    void*    FileHandle;
-   INT64    FileSize;
+   int64_t    FileSize;
    void*    pSharedMemoryHeader;
-   INT64    RealFileSize;        // Includes RCF Header size
-   INT64    RefCount;
+   int64_t    RealFileSize;        // Includes RCF Header size
+   int64_t    RefCount;
 };
 
 
 HRESULT
 UtilSharedMemoryBegin(
    const char*          pMappingName,
-   INT64                Size,
+   int64_t                Size,
    PMAPPED_VIEW_STRUCT *pReturnStruct);
 
 
 HRESULT
 UtilSharedNumaMemoryBegin(
    const char*          pMappingName,
-   INT64                Size,
-   DWORD                nndPreferred,        // preferred numa node
-   LPVOID               lpBaseAddress,
+   int64_t                Size,
+   uint32_t                nndPreferred,        // preferred numa node
+   void*               lpBaseAddress,
    PMAPPED_VIEW_STRUCT *pReturnStruct);
 
 HRESULT
 UtilSharedMemoryCopy(
    const char*          pMappingName,
    PMAPPED_VIEW_STRUCT *pReturnStruct,
-   BOOL                 bTest);
+   bool                 bTest);
 
 HRESULT
 UtilSharedMemoryEnd(
@@ -58,8 +58,8 @@ HRESULT
 UtilMappedViewWriteBegin(
    const char*          pszFilename,
    PMAPPED_VIEW_STRUCT *pReturnStruct,
-   DWORD                dwMaxSizeHigh,
-   DWORD                dwMaxSizeLow);
+   uint32_t                dwMaxSizeHigh,
+   uint32_t                dwMaxSizeLow);
 
 
 #else
@@ -72,22 +72,22 @@ struct MAPPED_VIEW_STRUCT
 
    void*    BaseAddress;         
    int      FileHandle;
-   INT64    FileSize;
-   INT64    RefCount;
+   int64_t    FileSize;
+   int64_t    RefCount;
 
 };
 
 HRESULT
 UtilSharedMemoryBegin(
    const char*           pMappingName,
-   INT64                Size,
+   int64_t                Size,
    PMAPPED_VIEW_STRUCT *pReturnStruct);
 
 HRESULT
 UtilSharedMemoryCopy(
    const char*          pMappingName,
    PMAPPED_VIEW_STRUCT *pReturnStruct,
-   BOOL                 bTest);
+   bool                 bTest);
 
 HRESULT
 UtilSharedMemoryEnd(

--- a/src/SharedMemory.h
+++ b/src/SharedMemory.h
@@ -35,7 +35,7 @@ HRESULT
 UtilSharedMemoryCopy(
    const char*          pMappingName,
    PMAPPED_VIEW_STRUCT *pReturnStruct,
-   bool                 bTest);
+   int                 bTest);
 
 HRESULT
 UtilSharedMemoryEnd(
@@ -87,7 +87,7 @@ HRESULT
 UtilSharedMemoryCopy(
    const char*          pMappingName,
    PMAPPED_VIEW_STRUCT *pReturnStruct,
-   bool                 bTest);
+   int                 bTest);
 
 HRESULT
 UtilSharedMemoryEnd(

--- a/src/Sort.cpp
+++ b/src/Sort.cpp
@@ -1792,7 +1792,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
       //}
 
       // BUG BUG doing lexsort on two arrays: string, int.  Once sorted, resorting does not work.
-      if (TRUE || STRING_LT(pValue + (*pm)*strlen, pValue + (*pm-1)*strlen, strlen)) {
+      if (true || STRING_LT(pValue + (*pm)*strlen, pValue + (*pm-1)*strlen, strlen)) {
 
          //printf("%lld %lld %lld %lld\n", (int64_t)pValue[*pl], (int64_t)pValue[*(pm - 1)], (int64_t)pValue[*pm], (int64_t)pValue[*(pr - 1)]);
          //printf("%lld %lld %lld %lld %lld\n", (int64_t)*pl, (int64_t)*(pm - 2), (int64_t)*(pm - 1), (int64_t)*pm, (int64_t)*(pr - 1));
@@ -1844,7 +1844,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
       UINDEX *pi, *pj, *pk, *pm;
       pm = pl + ((pr - pl) >> 1);
 
-      if (TRUE || UNICODE_LT(pValue + (*pm)*strlen, pValue + (*pm - 1)*strlen, strlen)) {
+      if (true || UNICODE_LT(pValue + (*pm)*strlen, pValue + (*pm - 1)*strlen, strlen)) {
 
          //printf("%lld %lld %lld %lld\n", (int64_t)pValue[*pl], (int64_t)pValue[*(pm - 1)], (int64_t)pValue[*pm], (int64_t)pValue[*(pr - 1)]);
          //printf("%lld %lld %lld %lld %lld\n", (int64_t)*pl, (int64_t)*(pm - 2), (int64_t)*(pm - 1), (int64_t)*pm, (int64_t)*(pr - 1));
@@ -1896,7 +1896,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
       pm = pl + ((pr - pl) >> 1);
 
       // BUG BUG doing lexsort on two arrays: string, int.  Once sorted, resorting does not work.
-      if (TRUE || VOID_LT(pValue + (*pm)*strlen, pValue + (*pm - 1)*strlen, strlen)) {
+      if (true || VOID_LT(pValue + (*pm)*strlen, pValue + (*pm - 1)*strlen, strlen)) {
 
          memcpy(pWorkSpace, pl, (pm - pl) * sizeof(UINDEX));
 
@@ -1971,7 +1971,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
 
       // quickcheck to see if we have to copy
       // BUG BUG doing lexsort on two arrays: string, int.  Once sorted, resorting does not work.
-      if (TRUE || COMPARE_LT(pValue[*pm], pValue[*(pm - 1)])) {
+      if (true || COMPARE_LT(pValue[*pm], pValue[*(pm - 1)])) {
 
          //printf("%lld %lld %lld %lld\n", (int64_t)pValue[*pl], (int64_t)pValue[*(pm - 1)], (int64_t)pValue[*pm], (int64_t)pValue[*(pr - 1)]);
          //printf("%lld %lld %lld %lld %lld\n", (int64_t)*pl, (int64_t)*(pm - 2), (int64_t)*(pm - 1), (int64_t)*pm, (int64_t)*(pr - 1));
@@ -2035,7 +2035,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    //  Concurrent callback from multiple threads
    static bool ParMergeThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
       MERGE_STEP_ONE_CALLBACK* Callback = (MERGE_STEP_ONE_CALLBACK*)pstWorkerItem->WorkCallbackArg;
-      bool didSomeWork = FALSE;
+      bool didSomeWork = false;
 
       int64_t index;
       int64_t workBlock;
@@ -2172,7 +2172,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
          }
 
          // Indicate we completed a block
-         didSomeWork = TRUE;
+         didSomeWork = true;
 
          // tell others we completed this work block
          pstWorkerItem->CompleteWorkBlock();
@@ -2326,7 +2326,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
                callbackArg->strlen,
                callbackArg->sortType);
 
-            return TRUE;
+            return true;
          };
 
          g_cMathWorker->DoMultiThreadedWork((int)cutOffLength, lambdaPSCallback, &psort);
@@ -2443,7 +2443,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
             }
 
             // This will notify the worker threads of a new work item
-            g_cMathWorker->WorkMain(pWorkItem, stParMergeCallback.MergeBlocks, 0, 1, FALSE);
+            g_cMathWorker->WorkMain(pWorkItem, stParMergeCallback.MergeBlocks, 0, 1, false);
 
          }
 
@@ -3099,14 +3099,14 @@ PyObject* IsSorted(PyObject *self, PyObject *args) {
          }
          int result = cb->pSortedFunc(cb->pDataIn1 + (start * cb->ItemSize), length, cb->ItemSize);
 
-         // on success, return TRUE 
-         if (result) return TRUE;
+         // on success, return true 
+         if (result) return true;
 
-         // on failure, set the failure flag and return FALSE
+         // on failure, set the failure flag and return false
          cb->IsSorted = 0;
       }
 
-      return FALSE;
+      return false;
    };
 
    // A zero length array is considered sorted
@@ -3168,7 +3168,7 @@ static bool ARangeCallback(void* callbackArgT, int core, int64_t start, int64_t 
       pDataOut[i] = i;
    }
 
-   return TRUE;
+   return true;
 }
 
 
@@ -3311,7 +3311,7 @@ PyObject* LexSort(PyObject *self, PyObject *args, PyObject *kwargs) {
 
          if (pCutOffs) {
             // Turn off caching of large memory allocs
-            g_cMathWorker->NoCaching = TRUE;
+            g_cMathWorker->NoCaching = true;
          }
 
          // When multiple arrays are passed, we sort in order of how it is passed
@@ -3323,7 +3323,7 @@ PyObject* LexSort(PyObject *self, PyObject *args, PyObject *kwargs) {
          }
 
          if (pCutOffs) {
-            g_cMathWorker->NoCaching = FALSE;
+            g_cMathWorker->NoCaching = false;
          }
          return (PyObject*)result;
       }
@@ -3706,7 +3706,7 @@ static PyObject* GroupFromLexSortInternal(
       int64_t*         pUniqueCounts = (int64_t*)PyArray_BYTES(uniqueCounts);
 
       // Turn off caching of large memory allocs
-      g_cMathWorker->NoCaching = TRUE;
+      g_cMathWorker->NoCaching = true;
 
       PLOGGING("partition version col: %lld  %p  %p  %p\n", cutOffLength, pToSort, pToSort + arrayLength, pValues);
 
@@ -3780,11 +3780,11 @@ static PyObject* GroupFromLexSortInternal(
             0,       //callbackArg->base_index, fix for countout
             callbackArg->strlen);
 
-         return TRUE;
+         return true;
       };
 
       g_cMathWorker->DoMultiThreadedWork((int)cutOffLength, lambdaPSCallback, &pgroup);
-      g_cMathWorker->NoCaching = FALSE;
+      g_cMathWorker->NoCaching = false;
 
       // TODO: make global routine
       int64_t totalUniques = 0;
@@ -3971,7 +3971,7 @@ static PyObject* GroupFromLexSortInternal(
 
          }
 
-         return TRUE;
+         return true;
       };
       g_cMathWorker->DoMultiThreadedWork((int)cutOffLength, lambdaPGADDCallback, &pgroupadd);
 

--- a/src/Sort.cpp
+++ b/src/Sort.cpp
@@ -2667,7 +2667,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
       case NPY_INT16:
          SortInPlace<int16_t>(pDataIn1, arraySize1, mode);
          break;
-      CASE_NPY_INT:
+      CASE_NPY_INT32:
          SortInPlace<int32_t>(pDataIn1, arraySize1, mode);
          break;
       CASE_NPY_INT64:
@@ -2679,7 +2679,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
       case NPY_UINT16:
          SortInPlace<uint16_t>(pDataIn1, arraySize1, mode);
          break;
-      CASE_NPY_UINT:
+      CASE_NPY_UINT32:
          SortInPlace<uint32_t>(pDataIn1, arraySize1, mode);
          break;
       CASE_NPY_UINT64:
@@ -2753,7 +2753,7 @@ PyObject* SortInPlaceIndirect(PyObject *self, PyObject *args) {
    int64_t sortSize = ArrayLength(inSort);
 
 
-   if (arrayType1 == NPY_INT && sortType == NPY_INT) {
+   if (arrayType1 == NPY_INT32 && sortType == NPY_INT32) {
       int32_t* pDataIn = (int32_t*)PyArray_BYTES(inArr1);
       int32_t* pSort = (int32_t*)PyArray_BYTES(inSort);
 
@@ -2768,7 +2768,7 @@ PyObject* SortInPlaceIndirect(PyObject *self, PyObject *args) {
 
       WORKSPACE_FREE(inverseSort);
    }
-   else if (arrayType1 == NPY_INT && sortType == NPY_INT64) {
+   else if (arrayType1 == NPY_INT32 && sortType == NPY_INT64) {
       int32_t* pDataIn = (int32_t*)PyArray_BYTES(inArr1);
       int64_t* pSort = (int64_t*)PyArray_BYTES(inSort);
 
@@ -2876,7 +2876,7 @@ static void SortIndex(
    case NPY_INT16:
       SortIndex<int16_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
-   CASE_NPY_INT:
+   CASE_NPY_INT32:
       SortIndex<int32_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
    CASE_NPY_INT64:
@@ -2888,7 +2888,7 @@ static void SortIndex(
    case NPY_UINT16:
       SortIndex<uint16_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
-   CASE_NPY_UINT:
+   CASE_NPY_UINT32:
       SortIndex<uint32_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
    CASE_NPY_UINT64:
@@ -3034,7 +3034,7 @@ PyObject* IsSorted(PyObject *self, PyObject *args) {
    case NPY_INT16:
       pSortedFunc = IsSorted<int16_t>;
       break;
-   CASE_NPY_INT:
+   CASE_NPY_INT32:
       pSortedFunc = IsSorted<int32_t>;
       break;
    CASE_NPY_INT64:
@@ -3046,7 +3046,7 @@ PyObject* IsSorted(PyObject *self, PyObject *args) {
    case NPY_UINT16:
       pSortedFunc = IsSorted<uint16_t>;
       break;
-   CASE_NPY_UINT:
+   CASE_NPY_UINT32:
       pSortedFunc = IsSorted<uint32_t>;
       break;
    CASE_NPY_UINT64:
@@ -3188,8 +3188,8 @@ static PyArrayObject* GetKwargIndex(PyObject *kwargs, int64_t& indexLength, int 
          CASE_NPY_INT64:
             dtype = NPY_INT64;
             return pStartIndex;
-         CASE_NPY_INT:
-            dtype = NPY_INT;
+         CASE_NPY_INT32:
+            dtype = NPY_INT32;
             return pStartIndex;
          default:
             printf("Bad index dtype... make sure int64_t or int32_t\n");
@@ -3265,7 +3265,7 @@ PyObject* LexSort(PyObject *self, PyObject *args, PyObject *kwargs) {
             return NULL;
          }
 
-         if (sizeof(UINDEX) == 4 && indexDType != NPY_INT) {
+         if (sizeof(UINDEX) == 4 && indexDType != NPY_INT32) {
             PyErr_Format(PyExc_ValueError, "LexSort 'index' is not int32_t");
             return NULL;
          }
@@ -3276,7 +3276,7 @@ PyObject* LexSort(PyObject *self, PyObject *args, PyObject *kwargs) {
          Py_IncRef((PyObject*)result);
       }
       else {
-         result = AllocateLikeNumpyArray(mlp.aInfo[0].pObject, sizeof(UINDEX) == 4 ? NPY_INT : NPY_INT64);
+         result = AllocateLikeNumpyArray(mlp.aInfo[0].pObject, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
       }
 
       if (result) {
@@ -3680,9 +3680,9 @@ static PyObject* GroupFromLexSortInternal(
    // TODO: Change this to use type npy_intp and check for overflow.
    int64_t worstCase = indexLength + 1 + cutOffLength;
 
-   PyArrayObject* const keys = AllocateNumpyArray(1, (npy_intp*)&indexLengthValues, sizeof(UINDEX) == 4 ? NPY_INT : NPY_INT64);
-   PyArrayObject* const first = AllocateNumpyArray(1, (npy_intp*)&indexLength, sizeof(UINDEX) == 4 ? NPY_INT : NPY_INT64);
-   PyArrayObject* const count = AllocateNumpyArray(1, (npy_intp*)&worstCase, sizeof(UINDEX) == 4 ? NPY_INT : NPY_INT64);
+   PyArrayObject* const keys = AllocateNumpyArray(1, (npy_intp*)&indexLengthValues, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
+   PyArrayObject* const first = AllocateNumpyArray(1, (npy_intp*)&indexLength, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
+   PyArrayObject* const count = AllocateNumpyArray(1, (npy_intp*)&worstCase, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
 
    // Make sure allocations succeeded
    if (!keys || !first || !count)
@@ -3797,10 +3797,10 @@ static PyObject* GroupFromLexSortInternal(
 
       // TODO: fix up keys
       //parallel add?
-      PyArrayObject* firstReduced = AllocateNumpyArray(1, (npy_intp*)&totalUniques, INDEX_SIZE == 4 ? NPY_INT : NPY_INT64);
+      PyArrayObject* firstReduced = AllocateNumpyArray(1, (npy_intp*)&totalUniques, INDEX_SIZE == 4 ? NPY_INT32 : NPY_INT64);
 
       totalUniques++;
-      PyArrayObject* countReduced = AllocateNumpyArray(1, (npy_intp*)&totalUniques, INDEX_SIZE == 4 ? NPY_INT : NPY_INT64);
+      PyArrayObject* countReduced = AllocateNumpyArray(1, (npy_intp*)&totalUniques, INDEX_SIZE == 4 ? NPY_INT32 : NPY_INT64);
 
       // ANOTHER PARALEL ROUTINE to copy
       struct stPGROUPADD {
@@ -4006,12 +4006,12 @@ static PyObject* GroupFromLexSortInternal(
       // now we know the actual unique counts
       // memcpy..
       // also count invalid bin
-      PyArrayObject* firstReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, sizeof(UINDEX) == 4 ? NPY_INT : NPY_INT64);
+      PyArrayObject* firstReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
       int64_t copySize = sizeof(UINDEX) * uniqueCount;
       memcpy(PyArray_BYTES(firstReduced), pFirstOut, copySize);
 
       uniqueCount++;
-      PyArrayObject* countReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, sizeof(UINDEX) == 4 ? NPY_INT : NPY_INT64);
+      PyArrayObject* countReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
       copySize = sizeof(UINDEX) * uniqueCount;
       // reduced
       memcpy(PyArray_BYTES(countReduced), pCountOut, copySize);
@@ -4070,7 +4070,7 @@ PyObject* GroupFromLexSort(PyObject *self, PyObject *args, PyObject *kwargs) {
    void* pValues = PyArray_BYTES(inArrValues);
 
    switch (dtype) {
-   CASE_NPY_INT:
+   CASE_NPY_INT32:
       return GroupFromLexSortInternal<int32_t>(kwargs, (int32_t*)pIndex, arrLength, arrLengthValues,  pValues, itemSize);
       break;
 

--- a/src/Sort.cpp
+++ b/src/Sort.cpp
@@ -15,7 +15,7 @@
 //#define TSWAP(A, i, j) { T tmp = A[i]; A[i] = A[j]; A[j] = tmp; }
 //
 //template <typename T>
-//void sort(T* A, INT64 left, INT64 right) {
+//void sort(T* A, int64_t left, int64_t right) {
 //   if (right > left) {
 //      // Choose outermost elements as pivots
 //      if (A[left] > A[right]) TSWAP(A, left, right);
@@ -23,7 +23,7 @@
 //      T p = A[left], q = A[right];
 //
 //      // Partition A according to invariant below
-//      INT64 l = left + 1, g = right - 1, k = l;
+//      int64_t l = left + 1, g = right - 1, k = l;
 //      while (k <= g) {
 //         if (A[k] < p) {
 //            TSWAP(A, k, l);
@@ -57,7 +57,7 @@
 #define NPY_ENOMEM 1
 #define NPY_ECOMP 2
 
-static __inline int npy_get_msb(UINT64 unum)
+static __inline int npy_get_msb(uint64_t unum)
 {
    int depth_limit = 0;
    while (unum >>= 1) {
@@ -80,14 +80,14 @@ static __inline int npy_get_msb(UINT64 unum)
 __inline bool COMPARE_LT(float X, float Y)   { return (X < Y || (Y != Y && X == X)); }
 __inline bool COMPARE_LT(double X, double Y) { return (X < Y || (Y != Y && X == X)); }
 __inline bool COMPARE_LT(long double X, long double Y) { return (X < Y || (Y != Y && X == X)); }
-__inline bool COMPARE_LT(INT32 X, INT32 Y)   { return (X < Y); }
-__inline bool COMPARE_LT(INT64 X, INT64 Y)   { return (X < Y); }
-__inline bool COMPARE_LT(UINT32 X, UINT32 Y) { return (X < Y); }
-__inline bool COMPARE_LT(UINT64 X, UINT64 Y) { return (X < Y); }
-__inline bool COMPARE_LT(INT8 X, INT8 Y) { return (X < Y); }
-__inline bool COMPARE_LT(INT16 X, INT16 Y) { return (X < Y); }
-__inline bool COMPARE_LT(UINT8 X, UINT8 Y) { return (X < Y); }
-__inline bool COMPARE_LT(UINT16 X, UINT16 Y) { return (X < Y); }
+__inline bool COMPARE_LT(int32_t X, int32_t Y)   { return (X < Y); }
+__inline bool COMPARE_LT(int64_t X, int64_t Y)   { return (X < Y); }
+__inline bool COMPARE_LT(uint32_t X, uint32_t Y) { return (X < Y); }
+__inline bool COMPARE_LT(uint64_t X, uint64_t Y) { return (X < Y); }
+__inline bool COMPARE_LT(int8_t X, int8_t Y) { return (X < Y); }
+__inline bool COMPARE_LT(int16_t X, int16_t Y) { return (X < Y); }
+__inline bool COMPARE_LT(uint8_t X, uint8_t Y) { return (X < Y); }
+__inline bool COMPARE_LT(uint16_t X, uint16_t Y) { return (X < Y); }
 
 NPY_INLINE static int
 STRING_LT(const char *s1, const char *s2, size_t len)
@@ -138,13 +138,13 @@ VOID_LT(const char *s1, const char *s2, size_t len)
       }
       return 0;
    case 2:
-      if (*(UINT16*)c1 != *(UINT16*)c2) {
-         return *(UINT16*)c1 < *(UINT16*)c2;
+      if (*(uint16_t*)c1 != *(uint16_t*)c2) {
+         return *(uint16_t*)c1 < *(uint16_t*)c2;
       }
       return 0;
    case 3:
-      if (*(UINT16*)c1 != *(UINT16*)c2) {
-         return *(UINT16*)c1 < *(UINT16*)c2;
+      if (*(uint16_t*)c1 != *(uint16_t*)c2) {
+         return *(uint16_t*)c1 < *(uint16_t*)c2;
       }
       c1 += 2;
       c2 += 2;
@@ -153,13 +153,13 @@ VOID_LT(const char *s1, const char *s2, size_t len)
       }
       return 0;
    case 4:
-      if (*(UINT32*)c1 != *(UINT32*)c2) {
-         return *(UINT32*)c1 < *(UINT32*)c2;
+      if (*(uint32_t*)c1 != *(uint32_t*)c2) {
+         return *(uint32_t*)c1 < *(uint32_t*)c2;
       }
       return 0;
    case 5:
-      if (*(UINT32*)c1 != *(UINT32*)c2) {
-         return *(UINT32*)c1 < *(UINT32*)c2;
+      if (*(uint32_t*)c1 != *(uint32_t*)c2) {
+         return *(uint32_t*)c1 < *(uint32_t*)c2;
       }
       c1 += 4;
       c2 += 4;
@@ -168,23 +168,23 @@ VOID_LT(const char *s1, const char *s2, size_t len)
       }
       return 0;
    case 6:
-      if (*(UINT32*)c1 != *(UINT32*)c2) {
-         return *(UINT32*)c1 < *(UINT32*)c2;
+      if (*(uint32_t*)c1 != *(uint32_t*)c2) {
+         return *(uint32_t*)c1 < *(uint32_t*)c2;
       }
       c1 += 4;
       c2 += 4;
-      if (*(UINT16*)c1 != *(UINT16*)c2) {
-         return *(UINT16*)c1 < *(UINT16*)c2;
+      if (*(uint16_t*)c1 != *(uint16_t*)c2) {
+         return *(uint16_t*)c1 < *(uint16_t*)c2;
       }
       return 0;
    case 7:
-      if (*(UINT32*)c1 != *(UINT32*)c2) {
-         return *(UINT32*)c1 < *(UINT32*)c2;
+      if (*(uint32_t*)c1 != *(uint32_t*)c2) {
+         return *(uint32_t*)c1 < *(uint32_t*)c2;
       }
       c1 += 4;
       c2 += 4;
-      if (*(UINT16*)c1 != *(UINT16*)c2) {
-         return *(UINT16*)c1 < *(UINT16*)c2;
+      if (*(uint16_t*)c1 != *(uint16_t*)c2) {
+         return *(uint16_t*)c1 < *(uint16_t*)c2;
       }
       c1 += 2;
       c2 += 2;
@@ -193,16 +193,16 @@ VOID_LT(const char *s1, const char *s2, size_t len)
       }
       return 0;
    case 8:
-      if (*(UINT64*)c1 != *(UINT64*)c2) {
-         return *(UINT64*)c1 < *(UINT64*)c2;
+      if (*(uint64_t*)c1 != *(uint64_t*)c2) {
+         return *(uint64_t*)c1 < *(uint64_t*)c2;
       }
       return 0;
    default:
    {
       // compare 8 bytes at a time
       while (len > 8) {
-         if (*(UINT64*)c1 != *(UINT64*)c2) {
-            return *(UINT64*)c1 < *(UINT64*)c2;
+         if (*(uint64_t*)c1 != *(uint64_t*)c2) {
+            return *(uint64_t*)c1 < *(uint64_t*)c2;
          }
          c1 += 8;
          c2 += 8;
@@ -215,13 +215,13 @@ VOID_LT(const char *s1, const char *s2, size_t len)
          }
          return 0;
       case 2:
-         if (*(UINT16*)c1 != *(UINT16*)c2) {
-            return *(UINT16*)c1 < *(UINT16*)c2;
+         if (*(uint16_t*)c1 != *(uint16_t*)c2) {
+            return *(uint16_t*)c1 < *(uint16_t*)c2;
          }
          return 0;
       case 3:
-         if (*(UINT16*)c1 != *(UINT16*)c2) {
-            return *(UINT16*)c1 < *(UINT16*)c2;
+         if (*(uint16_t*)c1 != *(uint16_t*)c2) {
+            return *(uint16_t*)c1 < *(uint16_t*)c2;
          }
          c1 += 2;
          c2 += 2;
@@ -230,13 +230,13 @@ VOID_LT(const char *s1, const char *s2, size_t len)
          }
          return 0;
       case 4:
-         if (*(UINT32*)c1 != *(UINT32*)c2) {
-            return *(UINT32*)c1 < *(UINT32*)c2;
+         if (*(uint32_t*)c1 != *(uint32_t*)c2) {
+            return *(uint32_t*)c1 < *(uint32_t*)c2;
          }
          return 0;
       case 5:
-         if (*(UINT32*)c1 != *(UINT32*)c2) {
-            return *(UINT32*)c1 < *(UINT32*)c2;
+         if (*(uint32_t*)c1 != *(uint32_t*)c2) {
+            return *(uint32_t*)c1 < *(uint32_t*)c2;
          }
          c1 += 4;
          c2 += 4;
@@ -245,23 +245,23 @@ VOID_LT(const char *s1, const char *s2, size_t len)
          }
          return 0;
       case 6:
-         if (*(UINT32*)c1 != *(UINT32*)c2) {
-            return *(UINT32*)c1 < *(UINT32*)c2;
+         if (*(uint32_t*)c1 != *(uint32_t*)c2) {
+            return *(uint32_t*)c1 < *(uint32_t*)c2;
          }
          c1 += 4;
          c2 += 4;
-         if (*(UINT16*)c1 != *(UINT16*)c2) {
-            return *(UINT16*)c1 < *(UINT16*)c2;
+         if (*(uint16_t*)c1 != *(uint16_t*)c2) {
+            return *(uint16_t*)c1 < *(uint16_t*)c2;
          }
          return 0;
       case 7:
-         if (*(UINT32*)c1 != *(UINT32*)c2) {
-            return *(UINT32*)c1 < *(UINT32*)c2;
+         if (*(uint32_t*)c1 != *(uint32_t*)c2) {
+            return *(uint32_t*)c1 < *(uint32_t*)c2;
          }
          c1 += 4;
          c2 += 4;
-         if (*(UINT16*)c1 != *(UINT16*)c2) {
-            return *(UINT16*)c1 < *(UINT16*)c2;
+         if (*(uint16_t*)c1 != *(uint16_t*)c2) {
+            return *(uint16_t*)c1 < *(uint16_t*)c2;
          }
          c1 += 2;
          c2 += 2;
@@ -270,8 +270,8 @@ VOID_LT(const char *s1, const char *s2, size_t len)
          }
          return 0;
       case 8:
-         if (*(UINT64*)c1 != *(UINT64*)c2) {
-            return *(UINT64*)c1 < *(UINT64*)c2;
+         if (*(uint64_t*)c1 != *(uint64_t*)c2) {
+            return *(uint64_t*)c1 < *(uint64_t*)c2;
          }
          return 0;
       default:
@@ -297,12 +297,12 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
       }
       return 0;
    case 2:
-      if (*(UINT16*)c1 != *(UINT16*)c2) {
+      if (*(uint16_t*)c1 != *(uint16_t*)c2) {
          return 1;
       }
       return 0;
    case 3:
-      if (*(UINT16*)c1 != *(UINT16*)c2) {
+      if (*(uint16_t*)c1 != *(uint16_t*)c2) {
          return 1;
       }
       c1 += 2;
@@ -312,12 +312,12 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
       }
       return 0;
    case 4:
-      if (*(UINT32*)c1 != *(UINT32*)c2) {
+      if (*(uint32_t*)c1 != *(uint32_t*)c2) {
          return 1;
       }
       return 0;
    case 5:
-      if (*(UINT32*)c1 != *(UINT32*)c2) {
+      if (*(uint32_t*)c1 != *(uint32_t*)c2) {
          return 1;
       }
       c1 += 4;
@@ -327,22 +327,22 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
       }
       return 0;
    case 6:
-      if (*(UINT32*)c1 != *(UINT32*)c2) {
+      if (*(uint32_t*)c1 != *(uint32_t*)c2) {
          return 1;
       }
       c1 += 4;
       c2 += 4;
-      if (*(UINT16*)c1 != *(UINT16*)c2) {
+      if (*(uint16_t*)c1 != *(uint16_t*)c2) {
          return 1;
       }
       return 0;
    case 7:
-      if (*(UINT32*)c1 != *(UINT32*)c2) {
+      if (*(uint32_t*)c1 != *(uint32_t*)c2) {
          return 1;
       }
       c1 += 4;
       c2 += 4;
-      if (*(UINT16*)c1 != *(UINT16*)c2) {
+      if (*(uint16_t*)c1 != *(uint16_t*)c2) {
          return 1;
       }
       c1 += 2;
@@ -352,14 +352,14 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
       }
       return 0;
    case 8:
-      if (*(UINT64*)c1 != *(UINT64*)c2) {
+      if (*(uint64_t*)c1 != *(uint64_t*)c2) {
          return 1;
       }
       return 0;
    default:
    {
       while (len > 8) {
-         if (*(UINT64*)c1 != *(UINT64*)c2) {
+         if (*(uint64_t*)c1 != *(uint64_t*)c2) {
             return 1;
          }
          c1 += 8;
@@ -373,12 +373,12 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
          }
          return 0;
       case 2:
-         if (*(UINT16*)c1 != *(UINT16*)c2) {
+         if (*(uint16_t*)c1 != *(uint16_t*)c2) {
             return 1;
          }
          return 0;
       case 3:
-         if (*(UINT16*)c1 != *(UINT16*)c2) {
+         if (*(uint16_t*)c1 != *(uint16_t*)c2) {
             return 1;
          }
          c1 += 2;
@@ -388,12 +388,12 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
          }
          return 0;
       case 4:
-         if (*(UINT32*)c1 != *(UINT32*)c2) {
+         if (*(uint32_t*)c1 != *(uint32_t*)c2) {
             return 1;
          }
          return 0;
       case 5:
-         if (*(UINT32*)c1 != *(UINT32*)c2) {
+         if (*(uint32_t*)c1 != *(uint32_t*)c2) {
             return 1;
          }
          c1 += 4;
@@ -403,22 +403,22 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
          }
          return 0;
       case 6:
-         if (*(UINT32*)c1 != *(UINT32*)c2) {
+         if (*(uint32_t*)c1 != *(uint32_t*)c2) {
             return 1;
          }
          c1 += 4;
          c2 += 4;
-         if (*(UINT16*)c1 != *(UINT16*)c2) {
+         if (*(uint16_t*)c1 != *(uint16_t*)c2) {
             return 1;
          }
          return 0;
       case 7:
-         if (*(UINT32*)c1 != *(UINT32*)c2) {
+         if (*(uint32_t*)c1 != *(uint32_t*)c2) {
             return 1;
          }
          c1 += 4;
          c2 += 4;
-         if (*(UINT16*)c1 != *(UINT16*)c2) {
+         if (*(uint16_t*)c1 != *(uint16_t*)c2) {
             return 1;
          }
          c1 += 2;
@@ -428,7 +428,7 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
          }
          return 0;
       case 8:
-         if (*(UINT64*)c1 != *(UINT64*)c2) {
+         if (*(uint64_t*)c1 != *(uint64_t*)c2) {
             return 1;
          }
          return 0;
@@ -485,8 +485,8 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
 //}
 
 
-#define INT32_LT(_X_,_Y_) (_X_ < _Y_)
-#define INT32_SWAP(_X_,_Y_) { INT32 temp; temp=_X_; _X_=_Y_; _Y_=temp;}
+#define int32_t_LT(_X_,_Y_) (_X_ < _Y_)
+#define int32_t_SWAP(_X_,_Y_) { int32_t temp; temp=_X_; _X_=_Y_; _Y_=temp;}
 #define INTP_SWAP(_X_,_Y_) { auto temp=_X_; _X_=_Y_; _Y_=temp;}
 
 //#define T_SWAP(_X_, _Y_) { auto temp;  temp = _X_; _X_ = _Y_; _Y_ = temp; }
@@ -495,14 +495,14 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
 
 ////--------------------------------------------------------------------------------------
 //static int
-//orig_quicksort_(INT32 *start, INT64 num)
+//orig_quicksort_(int32_t *start, int64_t num)
 //{
-//   INT32 vp;
-//   INT32 *pl = start;
-//   INT32 *pr = pl + num - 1;
-//   INT32 *stack[PYA_QS_STACK];
-//   INT32 **sptr = stack;
-//   INT32 *pm, *pi, *pj, *pk;
+//   int32_t vp;
+//   int32_t *pl = start;
+//   int32_t *pr = pl + num - 1;
+//   int32_t *stack[PYA_QS_STACK];
+//   int32_t **sptr = stack;
+//   int32_t *pm, *pi, *pj, *pk;
 //   int depth[PYA_QS_STACK];
 //   int * psdepth = depth;
 //   int cdepth = npy_get_msb(num) * 2;
@@ -515,23 +515,23 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
 //      while ((pr - pl) > SMALL_QUICKSORT) {
 //         /* quicksort partition */
 //         pm = pl + ((pr - pl) >> 1);
-//         if (INT32_LT(*pm, *pl)) INT32_SWAP(*pm, *pl);
-//         if (INT32_LT(*pr, *pm)) INT32_SWAP(*pr, *pm);
-//         if (INT32_LT(*pm, *pl)) INT32_SWAP(*pm, *pl);
+//         if (int32_t_LT(*pm, *pl)) int32_t_SWAP(*pm, *pl);
+//         if (int32_t_LT(*pr, *pm)) int32_t_SWAP(*pr, *pm);
+//         if (int32_t_LT(*pm, *pl)) int32_t_SWAP(*pm, *pl);
 //         vp = *pm;
 //         pi = pl;
 //         pj = pr - 1;
-//         INT32_SWAP(*pm, *pj);
+//         int32_t_SWAP(*pm, *pj);
 //         for (;;) {
-//            do ++pi; while (INT32_LT(*pi, vp));
-//            do --pj; while (INT32_LT(vp, *pj));
+//            do ++pi; while (int32_t_LT(*pi, vp));
+//            do --pj; while (int32_t_LT(vp, *pj));
 //            if (pi >= pj) {
 //               break;
 //            }
-//            INT32_SWAP(*pi, *pj);
+//            int32_t_SWAP(*pi, *pj);
 //         }
 //         pk = pr - 1;
-//         INT32_SWAP(*pi, *pk);
+//         int32_t_SWAP(*pi, *pk);
 //         /* push largest partition on stack */
 //         if (pi - pl < pr - pi) {
 //            *sptr++ = pi + 1;
@@ -551,7 +551,7 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
 //         vp = *pi;
 //         pj = pi;
 //         pk = pi - 1;
-//         while (pj > pl && INT32_LT(vp, *pk)) {
+//         while (pj > pl && int32_t_LT(vp, *pk)) {
 //            *pj-- = *pk--;
 //         }
 //         *pj = vp;
@@ -570,15 +570,15 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
 //
 //
 //static int
-//orig_aquicksort_(INT32 *vv, INT64* tosort, INT64 num)
+//orig_aquicksort_(int32_t *vv, int64_t* tosort, int64_t num)
 //{
-//   INT32 *v = vv;
-//   INT32 vp;
-//   INT64 *pl = tosort;
-//   INT64 *pr = tosort + num - 1;
-//   INT64 *stack[PYA_QS_STACK];
-//   INT64 **sptr = stack;
-//   INT64 *pm, *pi, *pj, *pk, vi;
+//   int32_t *v = vv;
+//   int32_t vp;
+//   int64_t *pl = tosort;
+//   int64_t *pr = tosort + num - 1;
+//   int64_t *stack[PYA_QS_STACK];
+//   int64_t **sptr = stack;
+//   int64_t *pm, *pi, *pj, *pk, vi;
 //   int depth[PYA_QS_STACK];
 //   int * psdepth = depth;
 //   int cdepth = npy_get_msb(num) * 2;
@@ -592,16 +592,16 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
 //      while ((pr - pl) > SMALL_QUICKSORT) {
 //         /* quicksort partition */
 //         pm = pl + ((pr - pl) >> 1);
-//         if (INT32_LT(v[*pm], v[*pl])) INTP_SWAP(*pm, *pl);
-//         if (INT32_LT(v[*pr], v[*pm])) INTP_SWAP(*pr, *pm);
-//         if (INT32_LT(v[*pm], v[*pl])) INTP_SWAP(*pm, *pl);
+//         if (int32_t_LT(v[*pm], v[*pl])) INTP_SWAP(*pm, *pl);
+//         if (int32_t_LT(v[*pr], v[*pm])) INTP_SWAP(*pr, *pm);
+//         if (int32_t_LT(v[*pm], v[*pl])) INTP_SWAP(*pm, *pl);
 //         vp = v[*pm];
 //         pi = pl;
 //         pj = pr - 1;
 //         INTP_SWAP(*pm, *pj);
 //         for (;;) {
-//            do ++pi; while (INT32_LT(v[*pi], vp));
-//            do --pj; while (INT32_LT(vp, v[*pj]));
+//            do ++pi; while (int32_t_LT(v[*pi], vp));
+//            do --pj; while (int32_t_LT(vp, v[*pj]));
 //            if (pi >= pj) {
 //               break;
 //            }
@@ -629,7 +629,7 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
 //         vp = v[vi];
 //         pj = pi;
 //         pk = pi - 1;
-//         while (pj > pl && INT32_LT(vp, v[*pk])) {
+//         while (pj > pl && int32_t_LT(vp, v[*pk])) {
 //            *pj-- = *pk--;
 //         }
 //         *pj = vi;
@@ -656,10 +656,10 @@ BINARY_LT(const char *s1, const char *s2, size_t len)
 //-----------------------------------------------------------------------------------------------
 template <typename T>
 /*static*/ int
-heapsort_(T *start, INT64 n)
+heapsort_(T *start, int64_t n)
 {
    T     tmp, *a;
-   INT64 i, j, l;
+   int64_t i, j, l;
 
    /* The array needs to be offset by one for heapsort indexing */
    a = (T *)start - 1;
@@ -815,7 +815,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    // N.B. This function isn't static like the others because it's used in a couple of places in GroupBy.cpp.
    template <typename T>
    /*static*/ int
-   quicksort_(T *start, INT64 num)
+   quicksort_(T *start, int64_t num)
    {
       T vp;
       T *pl = start;
@@ -1115,7 +1115,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    //-----------------------------------------------------------------------------------------------
    template <typename T>
    /*static*/ int 
-   mergesort_(T *start, INT64 num)
+   mergesort_(T *start, int64_t num)
    {
       T *pl, *pr, *pw;
 
@@ -1138,7 +1138,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    // TJD NOTE: Does not appear much faster
    template <typename T>
    static int 
-   mergesort_binary_norecursion(T *start, INT64 num)
+   mergesort_binary_norecursion(T *start, int64_t num)
    {
       T *pl, *pr, *pw, *pm, *pk, *pi, *pj;
 
@@ -1201,7 +1201,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
 
       // START MERGING ----------------------------------
       //----------------------------------------------------------------
-      INT64 startSize = SMALL_MERGESORT;
+      int64_t startSize = SMALL_MERGESORT;
 
       pEnd = start + num;
       pl = start;
@@ -1272,7 +1272,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
 
 // TD NOTE: Jan 2018 -- the memcpy improves float sorting slightly, it does not improve INT copying for some reason...
 #ifndef USE_MEMCPY
-         INT64 diff = pm - pj;
+         int64_t diff = pm - pj;
          memcpy(pi, pj, diff * sizeof(T));
          pi += diff;
          pj += diff;
@@ -1324,7 +1324,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    //-----------------------------------------------------------------------------------------------
    template <typename T>
    static int 
-   mergesort_float(T *start, INT64 num)
+   mergesort_float(T *start, int64_t num)
    {
       T *pl, *pr, *pw;
 
@@ -1345,7 +1345,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    //-----------------------------------------------------------------------------------------------
   template <typename UINDEX>
   static void
-  amergesort0_string(UINDEX *pl, UINDEX *pr, const char *strItem, UINDEX *pw, INT64 strlen)
+  amergesort0_string(UINDEX *pl, UINDEX *pr, const char *strItem, UINDEX *pw, int64_t strlen)
    {
       const char* vp;
       UINDEX vi, *pi, *pj, *pk, *pm;
@@ -1392,7 +1392,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
   //-----------------------------------------------------------------------------------------------
   template <typename UINDEX>
   static void
-  amergesort0_unicode(UINDEX *pl, UINDEX *pr, const char *strItem, UINDEX *pw, INT64 strlen)
+  amergesort0_unicode(UINDEX *pl, UINDEX *pr, const char *strItem, UINDEX *pw, int64_t strlen)
   {
      const char* vp;
      UINDEX vi, *pi, *pj, *pk, *pm;
@@ -1440,7 +1440,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
   //-----------------------------------------------------------------------------------------------
   template <typename UINDEX>
   static void
-  amergesort0_void(UINDEX *pl, UINDEX *pr, const char *strItem, UINDEX *pw, INT64 strlen)
+  amergesort0_void(UINDEX *pl, UINDEX *pr, const char *strItem, UINDEX *pw, int64_t strlen)
   {
      const char* vp;
      UINDEX vi, *pi, *pj, *pk, *pm;
@@ -1488,8 +1488,8 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    template <typename T, typename UINDEX> 
    static void
    // T= data type == float32/float64
-   // UINDEX = INT32 or INT64
-   amergesort0_float(UINDEX *pl, UINDEX *pr, T *v, UINDEX *pw, INT64 strlen=0)
+   // UINDEX = int32_t or int64_t
+   amergesort0_float(UINDEX *pl, UINDEX *pr, T *v, UINDEX *pw, int64_t strlen=0)
    {
       T vp;
       UINDEX vi, *pi, *pj, *pk, *pm;
@@ -1506,8 +1506,8 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
          {
             // MERGES DATA, memcpy
 #ifdef USE_MEMCPY
-            //INT64 bytescopy = (pm - pl) * sizeof(UINDEX);
-            //aligned_block_copy_backwards((INT64*)pw, (INT64*)pl, bytescopy);
+            //int64_t bytescopy = (pm - pl) * sizeof(UINDEX);
+            //aligned_block_copy_backwards((int64_t*)pw, (int64_t*)pl, bytescopy);
             //   
             memcpy(pw, pl, (pm-pl) * sizeof(UINDEX));
 
@@ -1561,7 +1561,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
 
    //-----------------------------------------------------------------------------------------------
    // T= data type == int16,int32,uint32,int64.uint64
-   // UINDEX = INT32 or INT64
+   // UINDEX = int32_t or int64_t
    template <typename T, typename UINDEX>
    static void 
    amergesort0_(UINDEX *pl, UINDEX *pr, T *v, UINDEX *pw)
@@ -1663,7 +1663,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    // Called to combine the result of the left and right merge
    template <typename UINDEX>
    static void
-   ParMergeString(void* pValue1, void* pToSort1, INT64 totalLen, INT64 strlen, void* pWorkSpace1) {
+   ParMergeString(void* pValue1, void* pToSort1, int64_t totalLen, int64_t strlen, void* pWorkSpace1) {
       UINDEX *pl, *pr;
 
       UINDEX* pWorkSpace = (UINDEX*)pWorkSpace1;
@@ -1682,7 +1682,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    // Called to combine the result of the left and right merge
    template <typename UINDEX>
    static void
-   ParMergeUnicode(void* pValue1, void* pToSort1, INT64 totalLen, INT64 strlen, void* pWorkSpace1) {
+   ParMergeUnicode(void* pValue1, void* pToSort1, int64_t totalLen, int64_t strlen, void* pWorkSpace1) {
       UINDEX *pl, *pr;
 
       UINDEX* pWorkSpace = (UINDEX*)pWorkSpace1;
@@ -1700,7 +1700,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    // Called to combine the result of the left and right merge
    template <typename UINDEX>
    static void
-   ParMergeVoid(void* pValue1, void* pToSort1, INT64 totalLen, INT64 strlen, void* pWorkSpace1) {
+   ParMergeVoid(void* pValue1, void* pToSort1, int64_t totalLen, int64_t strlen, void* pWorkSpace1) {
       UINDEX *pl, *pr;
 
       UINDEX* pWorkSpace = (UINDEX*)pWorkSpace1;
@@ -1718,7 +1718,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    // Called to combine the result of the left and right merge
    template <typename T, typename UINDEX>
    static void
-   ParMergeNormal(void* pValue1, void* pToSort1, INT64 totalLen, INT64 strlen, void* pWorkSpace1) {
+   ParMergeNormal(void* pValue1, void* pToSort1, int64_t totalLen, int64_t strlen, void* pWorkSpace1) {
       UINDEX *pl, *pr;
 
       UINDEX* pWorkSpace = (UINDEX*)pWorkSpace1;
@@ -1736,7 +1736,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    // Called to combine the result of the left and right merge
    template <typename T, typename UINDEX> 
    static void
-   ParMergeFloat(void* pValue1, void* pToSort1, INT64 totalLen, INT64 strlen, void* pWorkSpace1) {
+   ParMergeFloat(void* pValue1, void* pToSort1, int64_t totalLen, int64_t strlen, void* pWorkSpace1) {
       UINDEX *pl, *pr;
 
       UINDEX* pWorkSpace = (UINDEX*)pWorkSpace1;
@@ -1756,7 +1756,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    // Called to combine the result of the left and right merge
    template <typename UINDEX>
    static void
-   ParMergeMergeString(void* pValue1, void* pToSort1, INT64 totalLen, INT64 strlen, void* pWorkSpace1) {
+   ParMergeMergeString(void* pValue1, void* pToSort1, int64_t totalLen, int64_t strlen, void* pWorkSpace1) {
       UINDEX *pl, *pr;
 
       UINDEX* pWorkSpace = (UINDEX*)pWorkSpace1;
@@ -1794,8 +1794,8 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
       // BUG BUG doing lexsort on two arrays: string, int.  Once sorted, resorting does not work.
       if (TRUE || STRING_LT(pValue + (*pm)*strlen, pValue + (*pm-1)*strlen, strlen)) {
 
-         //printf("%lld %lld %lld %lld\n", (INT64)pValue[*pl], (INT64)pValue[*(pm - 1)], (INT64)pValue[*pm], (INT64)pValue[*(pr - 1)]);
-         //printf("%lld %lld %lld %lld %lld\n", (INT64)*pl, (INT64)*(pm - 2), (INT64)*(pm - 1), (INT64)*pm, (INT64)*(pr - 1));
+         //printf("%lld %lld %lld %lld\n", (int64_t)pValue[*pl], (int64_t)pValue[*(pm - 1)], (int64_t)pValue[*pm], (int64_t)pValue[*(pr - 1)]);
+         //printf("%lld %lld %lld %lld %lld\n", (int64_t)*pl, (int64_t)*(pm - 2), (int64_t)*(pm - 1), (int64_t)*pm, (int64_t)*(pr - 1));
 
          memcpy(pWorkSpace, pl, (pm - pl) * sizeof(UINDEX));
 
@@ -1819,7 +1819,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
          //printf("last items %lld %lld %lld\n", pk[-3], pk[-2], pk[-1]);
       }
       else {
-         PLOGGING("**Already sorted string %lld\n", (INT64)(*pm));
+         PLOGGING("**Already sorted string %lld\n", (int64_t)(*pm));
 
       }
 
@@ -1831,7 +1831,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    // Called to combine the result of the left and right merge
    template <typename UINDEX>
    static void
-   ParMergeMergeUnicode(void* pValue1, void* pToSort1, INT64 totalLen, INT64 strlen, void* pWorkSpace1) {
+   ParMergeMergeUnicode(void* pValue1, void* pToSort1, int64_t totalLen, int64_t strlen, void* pWorkSpace1) {
       UINDEX *pl, *pr;
 
       UINDEX* pWorkSpace = (UINDEX*)pWorkSpace1;
@@ -1846,8 +1846,8 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
 
       if (TRUE || UNICODE_LT(pValue + (*pm)*strlen, pValue + (*pm - 1)*strlen, strlen)) {
 
-         //printf("%lld %lld %lld %lld\n", (INT64)pValue[*pl], (INT64)pValue[*(pm - 1)], (INT64)pValue[*pm], (INT64)pValue[*(pr - 1)]);
-         //printf("%lld %lld %lld %lld %lld\n", (INT64)*pl, (INT64)*(pm - 2), (INT64)*(pm - 1), (INT64)*pm, (INT64)*(pr - 1));
+         //printf("%lld %lld %lld %lld\n", (int64_t)pValue[*pl], (int64_t)pValue[*(pm - 1)], (int64_t)pValue[*pm], (int64_t)pValue[*(pr - 1)]);
+         //printf("%lld %lld %lld %lld %lld\n", (int64_t)*pl, (int64_t)*(pm - 2), (int64_t)*(pm - 1), (int64_t)*pm, (int64_t)*(pr - 1));
 
          memcpy(pWorkSpace, pl, (pm - pl) * sizeof(UINDEX));
 
@@ -1871,7 +1871,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
          //printf("last items %lld %lld %lld\n", pk[-3], pk[-2], pk[-1]);
       }
       else {
-         PLOGGING("**Already sorted unicode %lld\n", (INT64)(*pm));
+         PLOGGING("**Already sorted unicode %lld\n", (int64_t)(*pm));
 
 
       }
@@ -1882,7 +1882,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    // Called to combine the result of the left and right merge
    template <typename UINDEX>
    static void
-   ParMergeMergeVoid(void* pValue1, void* pToSort1, INT64 totalLen, INT64 strlen, void* pWorkSpace1) {
+   ParMergeMergeVoid(void* pValue1, void* pToSort1, int64_t totalLen, int64_t strlen, void* pWorkSpace1) {
       UINDEX *pl, *pr;
 
       UINDEX* pWorkSpace = (UINDEX*)pWorkSpace1;
@@ -1920,7 +1920,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
          //printf("last items %lld %lld %lld\n", pk[-3], pk[-2], pk[-1]);
       }
       else {
-         PLOGGING("**Already sorted void %lld\n", (INT64)(*pm));
+         PLOGGING("**Already sorted void %lld\n", (int64_t)(*pm));
 
       }
 
@@ -1929,12 +1929,12 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
 
    //---------------------------------------------------------------------------
    // Called to combine the result of the left and right merge
-   // T is type to sort -- INT32, Float64, etc.
-   // UINDEX is the argsort index -- INT32 or INT64 often
+   // T is type to sort -- int32_t, Float64, etc.
+   // UINDEX is the argsort index -- int32_t or int64_t often
    //
    template <typename T, typename UINDEX>
    static void
-   ParMergeMerge(void* pValue1, void* pToSort1, INT64 totalLen, INT64 strlen, void* pWorkSpace1) {
+   ParMergeMerge(void* pValue1, void* pToSort1, int64_t totalLen, int64_t strlen, void* pWorkSpace1) {
       UINDEX *pl, *pr;
 
       UINDEX* pWorkSpace = (UINDEX*)pWorkSpace1;
@@ -1973,8 +1973,8 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
       // BUG BUG doing lexsort on two arrays: string, int.  Once sorted, resorting does not work.
       if (TRUE || COMPARE_LT(pValue[*pm], pValue[*(pm - 1)])) {
 
-         //printf("%lld %lld %lld %lld\n", (INT64)pValue[*pl], (INT64)pValue[*(pm - 1)], (INT64)pValue[*pm], (INT64)pValue[*(pr - 1)]);
-         //printf("%lld %lld %lld %lld %lld\n", (INT64)*pl, (INT64)*(pm - 2), (INT64)*(pm - 1), (INT64)*pm, (INT64)*(pr - 1));
+         //printf("%lld %lld %lld %lld\n", (int64_t)pValue[*pl], (int64_t)pValue[*(pm - 1)], (int64_t)pValue[*pm], (int64_t)pValue[*(pr - 1)]);
+         //printf("%lld %lld %lld %lld %lld\n", (int64_t)*pl, (int64_t)*(pm - 2), (int64_t)*(pm - 1), (int64_t)*pm, (int64_t)*(pr - 1));
 
          memcpy(pWorkSpace, pl, (pm - pl) * sizeof(UINDEX));
 
@@ -1998,14 +1998,14 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
          //printf("last items %lld %lld %lld\n", pk[-3], pk[-2], pk[-1]);
       }
       else {
-         PLOGGING("**Already sorted %lld\n", (INT64)(*pm));
+         PLOGGING("**Already sorted %lld\n", (int64_t)(*pm));
       }
 
    }
 
 
-   typedef void(*MERGE_STEP_ONE)(void* pValue, void* pToSort, INT64 num, INT64 strlen, void* pWorkSpace);
-   typedef void(*MERGE_STEP_TWO)(void* pValue1, void* pToSort1, INT64 totalLen, INT64 strlen, void* pWorkSpace1);
+   typedef void(*MERGE_STEP_ONE)(void* pValue, void* pToSort, int64_t num, int64_t strlen, void* pWorkSpace);
+   typedef void(*MERGE_STEP_TWO)(void* pValue1, void* pToSort1, int64_t totalLen, int64_t strlen, void* pWorkSpace1);
    //--------------------------------------------------------------------
    struct MERGE_STEP_ONE_CALLBACK {
       MERGE_STEP_ONE MergeCallbackOne;
@@ -2013,19 +2013,19 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
 
       void* pValues;
       void* pToSort;
-      INT64 ArrayLength;
+      int64_t ArrayLength;
 
       // set to 0 if not a string, otherwise the string length
-      INT64 StrLen;
+      int64_t StrLen;
 
       void* pWorkSpace;
-      INT64 MergeBlocks;
-      INT64 TypeSizeInput;
-      INT64 TypeSizeOutput;
+      int64_t MergeBlocks;
+      int64_t TypeSizeInput;
+      int64_t TypeSizeOutput;
 
       // used to synchronize parallel merges
-      INT64 EndPositions[8];
-      INT64 Level[3];
+      int64_t EndPositions[8];
+      int64_t Level[3];
 
    } stParMergeCallback;
 
@@ -2033,12 +2033,12 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
 
    //------------------------------------------------------------------------------
    //  Concurrent callback from multiple threads
-   static BOOL ParMergeThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
+   static bool ParMergeThreadCallback(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
       MERGE_STEP_ONE_CALLBACK* Callback = (MERGE_STEP_ONE_CALLBACK*)pstWorkerItem->WorkCallbackArg;
-      BOOL didSomeWork = FALSE;
+      bool didSomeWork = FALSE;
 
-      INT64 index;
-      INT64 workBlock;
+      int64_t index;
+      int64_t workBlock;
 
 
       // As long as there is work to do
@@ -2049,17 +2049,17 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
          //PLOGGING("[%d] DoWork start loop -- %lld  index: %lld\n", core, workIndex, index);
 
          // the very first index starts at 0
-         INT64 pFirst = 0;
+         int64_t pFirst = 0;
          
          if (index >= 1) {
             pFirst = Callback->EndPositions[index - 1];
          }
 
-         INT64 pSecond = Callback->EndPositions[index];
+         int64_t pSecond = Callback->EndPositions[index];
          char* pToSort1 = (char*)(Callback->pToSort);
 
-         INT64 MergeSize = (pSecond - pFirst);
-         INT64 OffsetSize = pFirst;
+         int64_t MergeSize = (pSecond - pFirst);
+         int64_t OffsetSize = pFirst;
          PLOGGING("%d : MergeOne index: %llu  %lld  %lld  %lld\n", core, index, pFirst, MergeSize, OffsetSize);
 
          // Workspace uses half the size
@@ -2068,10 +2068,10 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
 
          Callback->MergeCallbackOne(Callback->pValues, pToSort1 + (OffsetSize * Callback->TypeSizeOutput), MergeSize, Callback->StrLen, pWorkSpace1);
 
-         INT64 bitshift = 1LL << index;
+         int64_t bitshift = 1LL << index;
          
          // Now find the buddy bit (adjacent bit)
-         INT64 buddy = 0;
+         int64_t buddy = 0;
          if (index & 1) {
             buddy = 1LL << (index-1);
          }
@@ -2080,7 +2080,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
          }
 
          // Get back which bits were set before the OR operation
-         INT64 result = FMInterlockedOr(&Callback->Level[0], bitshift);
+         int64_t result = FMInterlockedOr(&Callback->Level[0], bitshift);
 
          // Check if our buddy was already set
          PLOGGING("index: %lld  %lld %lld -- %s\n", index, buddy, (result & buddy), buddy == (result & buddy) ? "GOOD" : "WAIT");
@@ -2194,22 +2194,22 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    typedef int(*SINGLE_MERGESORT)(
       void*          pValuesT,
       void*          pToSortU,
-      INT64          arrayLength,
-      INT64          strlen,
+      int64_t          arrayLength,
+      int64_t          strlen,
       PAR_SORT_TYPE  sortType);
    
    //------------------------------------------------------------------------
    // single threaded version
    // T is the dtype int32/float32/float64/etc.
-   // UINDEX is either INT32 or INT64
+   // UINDEX is either int32_t or int64_t
    // Returns -1 on failure
    template <typename T, typename UINDEX>
    static int
    single_amergesort(
       void*          pValuesT,
       void*          pToSortU,
-      INT64          arrayLength,
-      INT64          strlen,
+      int64_t          arrayLength,
+      int64_t          strlen,
       PAR_SORT_TYPE  sortType)
    {
       T*             pValues = (T*)pValuesT;
@@ -2255,14 +2255,14 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    template <typename T, typename UINDEX> 
    static int
    par_amergesort(
-      INT64*         pCutOffs,      // May be NULL (if so no partitions)
-      INT64          cutOffLength,
+      int64_t*         pCutOffs,      // May be NULL (if so no partitions)
+      int64_t          cutOffLength,
 
       T*             pValues,
       UINDEX*        pToSort, 
 
-      INT64          arrayLength,
-      INT64          strlen, 
+      int64_t          arrayLength,
+      int64_t          strlen, 
       PAR_SORT_TYPE  sortType)
    {
       if (pCutOffs) {
@@ -2270,16 +2270,16 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
 
          struct stPSORT {
             SINGLE_MERGESORT  funcSingleMerge;
-            INT64*            pCutOffs;       // May be NULL (if so no partitions)
-            INT64             cutOffLength;
+            int64_t*            pCutOffs;       // May be NULL (if so no partitions)
+            int64_t             cutOffLength;
 
             char*             pValues;
             char*             pToSort;
-            INT64             strlen;
+            int64_t             strlen;
             PAR_SORT_TYPE     sortType;
 
-            INT64             sizeofT;
-            INT64             sizeofUINDEX;
+            int64_t             sizeofT;
+            int64_t             sizeofUINDEX;
 
          } psort;
 
@@ -2300,11 +2300,11 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
          }
 
          // Use threads per partition
-         auto lambdaPSCallback = [](void* callbackArgT, int core, INT64 workIndex) -> BOOL {
+         auto lambdaPSCallback = [](void* callbackArgT, int core, int64_t workIndex) -> bool {
             stPSORT* callbackArg = (stPSORT*)callbackArgT;
-            INT64 t = workIndex;
-            INT64 partLength;
-            INT64 partStart;
+            int64_t t = workIndex;
+            int64_t partLength;
+            int64_t partStart;
 
             if (t == 0) {
                partStart = 0;
@@ -2341,7 +2341,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
          // Allocate all memory up front?
          //UINDEX* pWorkSpace = (UINDEX*)WORKSPACE_FREE(((arrayLength / 2) + 256)* sizeof(UINDEX));
          void* pWorkSpace = NULL;
-         UINT64 allocSize = arrayLength * sizeof(UINDEX);
+         uint64_t allocSize = arrayLength * sizeof(UINDEX);
 
          //(UINDEX*)WORKSPACE_ALLOC(arrayLength * sizeof(UINDEX));
          pWorkSpace=WorkSpaceAllocLarge(allocSize);
@@ -2474,7 +2474,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    // TODO: Make multithreaded like
    template <typename T>
    static int
-   SortInPlace(void* pDataIn1, INT64 arraySize1, SORT_MODE mode) {
+   SortInPlace(void* pDataIn1, int64_t arraySize1, SORT_MODE mode) {
 
       int result = 0;
 
@@ -2506,7 +2506,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    // Sorts in place
    template <typename T>
    static int
-   SortInPlaceFloat(void* pDataIn1, INT64 arraySize1, SORT_MODE mode) {
+   SortInPlaceFloat(void* pDataIn1, int64_t arraySize1, SORT_MODE mode) {
 
       int result = 0;
 
@@ -2526,7 +2526,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
       }
 
       if (result != 0) {
-         printf("**Error sorting.  size %llu   mode %d\n", (INT64)arraySize1, mode);
+         printf("**Error sorting.  size %llu   mode %d\n", (int64_t)arraySize1, mode);
       }
 
       return result;
@@ -2536,7 +2536,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    template <typename T, typename UINDEX>
    static int
    SortIndex(
-      INT64* pCutOffs, INT64 cutOffLength, void* pDataIn1, UINDEX* toSort, UINDEX arraySize1, SORT_MODE mode) {
+      int64_t* pCutOffs, int64_t cutOffLength, void* pDataIn1, UINDEX* toSort, UINDEX arraySize1, SORT_MODE mode) {
 
       int result = 0;
 
@@ -2559,7 +2559,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
       }
 
       if (result != 0) {
-         printf("**Error sorting.  size %llu   mode %d\n", (INT64)arraySize1, mode);
+         printf("**Error sorting.  size %llu   mode %d\n", (int64_t)arraySize1, mode);
       }
 
       return result;
@@ -2570,7 +2570,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    //-----------------------------------------------------------------------------------------------
    template <typename T, typename UINDEX>
    static int
-   SortIndexFloat(INT64* pCutOffs, INT64 cutOffLength, void* pDataIn1, UINDEX* toSort, UINDEX arraySize1, SORT_MODE mode) {
+   SortIndexFloat(int64_t* pCutOffs, int64_t cutOffLength, void* pDataIn1, UINDEX* toSort, UINDEX arraySize1, SORT_MODE mode) {
 
       int result = 0;
 
@@ -2590,7 +2590,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
       }
 
       if (result != 0) {
-         printf("**Error sorting.  size %llu   mode %d\n", (INT64)arraySize1, mode);
+         printf("**Error sorting.  size %llu   mode %d\n", (int64_t)arraySize1, mode);
       }
 
       return result;
@@ -2600,7 +2600,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    //-----------------------------------------------------------------------------------------------
    template <typename UINDEX>
    static int
-   SortIndexString(INT64* pCutOffs, INT64 cutOffLength, const char* pDataIn1, UINDEX* toSort, UINDEX arraySize1, SORT_MODE mode, UINDEX strlen) {
+   SortIndexString(int64_t* pCutOffs, int64_t cutOffLength, const char* pDataIn1, UINDEX* toSort, UINDEX arraySize1, SORT_MODE mode, UINDEX strlen) {
 
       int result = 0;
       switch (mode) {
@@ -2618,7 +2618,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    //-----------------------------------------------------------------------------------------------
    template <typename UINDEX>
    static int
-   SortIndexUnicode(INT64* pCutOffs, INT64 cutOffLength, const char* pDataIn1, UINDEX* toSort, UINDEX arraySize1, SORT_MODE mode, UINDEX strlen) {
+   SortIndexUnicode(int64_t* pCutOffs, int64_t cutOffLength, const char* pDataIn1, UINDEX* toSort, UINDEX arraySize1, SORT_MODE mode, UINDEX strlen) {
 
       int result = 0;
       switch (mode) {
@@ -2635,7 +2635,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
    //-----------------------------------------------------------------------------------------------
    template <typename UINDEX>
    static int
-   SortIndexVoid(INT64* pCutOffs, INT64 cutOffLength, const char* pDataIn1, UINDEX* toSort, UINDEX arraySize1, SORT_MODE mode, UINDEX strlen) {
+   SortIndexVoid(int64_t* pCutOffs, int64_t cutOffLength, const char* pDataIn1, UINDEX* toSort, UINDEX arraySize1, SORT_MODE mode, UINDEX strlen) {
 
       int result = 0;
       switch (mode) {
@@ -2653,7 +2653,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
 
 //================================================================================================
 //===============================================================================
-   static void SortArray(void* pDataIn1, INT64 arraySize1, INT32 arrayType1, SORT_MODE mode) {
+   static void SortArray(void* pDataIn1, int64_t arraySize1, int32_t arrayType1, SORT_MODE mode) {
       switch (arrayType1) {
       case NPY_STRING:
          SortInPlace<char>(pDataIn1, arraySize1, mode);
@@ -2662,28 +2662,28 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
          SortInPlace<bool>(pDataIn1, arraySize1, mode);
          break;
       case NPY_INT8:
-         SortInPlace<INT8>(pDataIn1, arraySize1, mode);
+         SortInPlace<int8_t>(pDataIn1, arraySize1, mode);
          break;
       case NPY_INT16:
-         SortInPlace<INT16>(pDataIn1, arraySize1, mode);
+         SortInPlace<int16_t>(pDataIn1, arraySize1, mode);
          break;
       CASE_NPY_INT32:
-         SortInPlace<INT32>(pDataIn1, arraySize1, mode);
+         SortInPlace<int32_t>(pDataIn1, arraySize1, mode);
          break;
       CASE_NPY_INT64:
-         SortInPlace<INT64>(pDataIn1, arraySize1, mode);
+         SortInPlace<int64_t>(pDataIn1, arraySize1, mode);
          break;
       case NPY_UINT8:
-         SortInPlace<UINT8>(pDataIn1, arraySize1, mode);
+         SortInPlace<uint8_t>(pDataIn1, arraySize1, mode);
          break;
       case NPY_UINT16:
-         SortInPlace<UINT16>(pDataIn1, arraySize1, mode);
+         SortInPlace<uint16_t>(pDataIn1, arraySize1, mode);
          break;
       CASE_NPY_UINT32:
-         SortInPlace<UINT32>(pDataIn1, arraySize1, mode);
+         SortInPlace<uint32_t>(pDataIn1, arraySize1, mode);
          break;
       CASE_NPY_UINT64:
-         SortInPlace<UINT64>(pDataIn1, arraySize1, mode);
+         SortInPlace<uint64_t>(pDataIn1, arraySize1, mode);
          break;
       case NPY_FLOAT:
          SortInPlaceFloat<float>(pDataIn1, arraySize1, mode);
@@ -2711,11 +2711,11 @@ PyObject* SortInPlace(PyObject *self, PyObject *args) {
 
    if (!PyArg_ParseTuple(args, "O!i", &PyArray_Type, &inArr1, &sortMode)) return NULL;
 
-   INT32 arrayType1 = PyArray_TYPE(inArr1);
+   int32_t arrayType1 = PyArray_TYPE(inArr1);
    int ndim = PyArray_NDIM(inArr1);
    npy_intp* dims = PyArray_DIMS(inArr1);
 
-   INT64 arraySize1 = CalcArrayLength(ndim, dims);
+   int64_t arraySize1 = CalcArrayLength(ndim, dims);
    void* pDataIn1 = PyArray_BYTES(inArr1);
 
    //printf("Arary size %llu  type %d\n", arraySize1, arrayType1);
@@ -2746,18 +2746,18 @@ PyObject* SortInPlaceIndirect(PyObject *self, PyObject *args) {
 
    if (!PyArg_ParseTuple(args, "O!O!", &PyArray_Type, &inArr1, &PyArray_Type, &inSort)) return NULL;
 
-   INT32 arrayType1 = PyArray_TYPE(inArr1);
-   INT32 sortType = PyArray_TYPE(inSort);
+   int32_t arrayType1 = PyArray_TYPE(inArr1);
+   int32_t sortType = PyArray_TYPE(inSort);
 
-   INT64 arraySize1 = ArrayLength(inArr1);
-   INT64 sortSize = ArrayLength(inSort);
+   int64_t arraySize1 = ArrayLength(inArr1);
+   int64_t sortSize = ArrayLength(inSort);
 
 
    if (arrayType1 == NPY_INT32 && sortType == NPY_INT32) {
-      INT32* pDataIn = (INT32*)PyArray_BYTES(inArr1);
-      INT32* pSort = (INT32*)PyArray_BYTES(inSort);
+      int32_t* pDataIn = (int32_t*)PyArray_BYTES(inArr1);
+      int32_t* pSort = (int32_t*)PyArray_BYTES(inSort);
 
-      INT32* inverseSort = (INT32*)WORKSPACE_ALLOC(sortSize * sizeof(INT32));
+      int32_t* inverseSort = (int32_t*)WORKSPACE_ALLOC(sortSize * sizeof(int32_t));
       for (int i = 0; i < sortSize; i++) {
          inverseSort[pSort[i]] = i;
       }
@@ -2769,29 +2769,29 @@ PyObject* SortInPlaceIndirect(PyObject *self, PyObject *args) {
       WORKSPACE_FREE(inverseSort);
    }
    else if (arrayType1 == NPY_INT32 && sortType == NPY_INT64) {
-      INT32* pDataIn = (INT32*)PyArray_BYTES(inArr1);
-      INT64* pSort = (INT64*)PyArray_BYTES(inSort);
+      int32_t* pDataIn = (int32_t*)PyArray_BYTES(inArr1);
+      int64_t* pSort = (int64_t*)PyArray_BYTES(inSort);
 
-      INT64* inverseSort = (INT64*)WORKSPACE_ALLOC(sortSize * sizeof(INT64));
-      for (INT64 i = 0; i < sortSize; i++) {
+      int64_t* inverseSort = (int64_t*)WORKSPACE_ALLOC(sortSize * sizeof(int64_t));
+      for (int64_t i = 0; i < sortSize; i++) {
          inverseSort[pSort[i]] = i;
       }
 
       for (int i = 0; i < arraySize1; i++) {
-         pDataIn[i] = (INT32)inverseSort[pDataIn[i]];
+         pDataIn[i] = (int32_t)inverseSort[pDataIn[i]];
       }
       WORKSPACE_FREE(inverseSort);
 
    } else if (arrayType1 == NPY_INT64 && sortType == NPY_INT64) {
-      INT64* pDataIn = (INT64*)PyArray_BYTES(inArr1);
-      INT64* pSort = (INT64*)PyArray_BYTES(inSort);
+      int64_t* pDataIn = (int64_t*)PyArray_BYTES(inArr1);
+      int64_t* pSort = (int64_t*)PyArray_BYTES(inSort);
 
-      INT64* inverseSort = (INT64*)WORKSPACE_ALLOC(sortSize * sizeof(INT64));
-      for (INT64 i = 0; i < sortSize; i++) {
+      int64_t* inverseSort = (int64_t*)WORKSPACE_ALLOC(sortSize * sizeof(int64_t));
+      for (int64_t i = 0; i < sortSize; i++) {
          inverseSort[pSort[i]] = i;
       }
 
-      for (INT64 i = 0; i < arraySize1; i++) {
+      for (int64_t i = 0; i < arraySize1; i++) {
          pDataIn[i] = inverseSort[pDataIn[i]];
       }
       WORKSPACE_FREE(inverseSort);
@@ -2815,11 +2815,11 @@ PyObject* Sort(PyObject *self, PyObject *args) {
 
    if (!PyArg_ParseTuple(args, "O!i", &PyArray_Type, &inArr1, &sortMode)) return NULL;
 
-   INT32 arrayType1 = PyArray_TYPE(inArr1);
+   int32_t arrayType1 = PyArray_TYPE(inArr1);
    int ndim = PyArray_NDIM(inArr1);
    npy_intp* dims = PyArray_DIMS(inArr1);
 
-   INT64 arraySize1 = CalcArrayLength(ndim, dims);
+   int64_t arraySize1 = CalcArrayLength(ndim, dims);
 
    // The output is a boolean where the nth item was found
    PyArrayObject* duplicateArray = AllocateNumpyArray(ndim, dims, arrayType1);
@@ -2832,7 +2832,7 @@ PyObject* Sort(PyObject *self, PyObject *args) {
    void* pDataIn1 = PyArray_BYTES(inArr1);
    void* pDataOut1 = PyArray_BYTES(duplicateArray);
 
-   INT64 itemSize = NpyItemSize((PyObject*)inArr1);
+   int64_t itemSize = NpyItemSize((PyObject*)inArr1);
 
    memcpy(pDataOut1, pDataIn1, arraySize1 * itemSize);
 
@@ -2845,18 +2845,18 @@ PyObject* Sort(PyObject *self, PyObject *args) {
 
 //------------------------------------------------------------------------------------------
 // Internal and can be called from groupby
-// caller must allocate the pDataOut1 as INT64 with size arraySize1
-// UINDEX = INT32 or INT64
+// caller must allocate the pDataOut1 as int64_t with size arraySize1
+// UINDEX = int32_t or int64_t
 template <typename UINDEX>
 static void SortIndex(
-   INT64*      pCutOffs,
-   INT64       cutOffLength,
+   int64_t*      pCutOffs,
+   int64_t       cutOffLength,
 
    void*       pDataIn1,
    UINDEX      arraySize1, 
    UINDEX*     pDataOut1, 
    SORT_MODE   mode, 
-   INT32       arrayType1, 
+   int32_t       arrayType1, 
    UINDEX      strlen) {
 
    switch (arrayType1) {
@@ -2871,28 +2871,28 @@ static void SortIndex(
       break;
    case NPY_BOOL:
    case NPY_INT8:
-      SortIndex<INT8, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
+      SortIndex<int8_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
    case NPY_INT16:
-      SortIndex<INT16, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
+      SortIndex<int16_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
    CASE_NPY_INT32:
-      SortIndex<INT32, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
+      SortIndex<int32_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
    CASE_NPY_INT64:
-      SortIndex<INT64, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
+      SortIndex<int64_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
    case NPY_UINT8:
-      SortIndex<UINT8, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
+      SortIndex<uint8_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
    case NPY_UINT16:
-      SortIndex<UINT16, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
+      SortIndex<uint16_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
    CASE_NPY_UINT32:
-      SortIndex<UINT32, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
+      SortIndex<uint32_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
    CASE_NPY_UINT64:
-      SortIndex<UINT64, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
+      SortIndex<uint64_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
    case NPY_FLOAT:
       SortIndexFloat<float, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
@@ -2910,16 +2910,16 @@ static void SortIndex(
 }
 
 //================================================================================
-typedef int(*IS_SORTED_FUNC)(const char* pDataIn1, INT64 arraySize1, INT64 strlennotused);
+typedef int(*IS_SORTED_FUNC)(const char* pDataIn1, int64_t arraySize1, int64_t strlennotused);
 //-----------------------------------------------------------------------------------------------
 template <typename T>
 static int
-IsSortedFloat(const char* pDataIn1, INT64 arraySize1, INT64 strlennotused) {
+IsSortedFloat(const char* pDataIn1, int64_t arraySize1, int64_t strlennotused) {
 
    int result = 0;
    T* pData = (T*)pDataIn1;
 
-   INT64 i = arraySize1 - 1;
+   int64_t i = arraySize1 - 1;
 
    while ((i > 0) && (pData[i] != pData[i])) {
       i--;
@@ -2936,12 +2936,12 @@ IsSortedFloat(const char* pDataIn1, INT64 arraySize1, INT64 strlennotused) {
 //-----------------------------------------------------------------------------------------------
 template <typename T>
 static int
-IsSorted(const char* pDataIn1, INT64 arraySize1, INT64 strlennotused) {
+IsSorted(const char* pDataIn1, int64_t arraySize1, int64_t strlennotused) {
 
    int result = 0;
    T* pData = (T*)pDataIn1;
 
-   INT64 i = arraySize1 - 1;
+   int64_t i = arraySize1 - 1;
 
    while ((i > 0) && pData[i] >= pData[i - 1]) {
       i--;
@@ -2953,11 +2953,11 @@ IsSorted(const char* pDataIn1, INT64 arraySize1, INT64 strlennotused) {
 
 //-----------------------------------------------------------------------------------------------
 static int
-IsSortedString(const char* pData, INT64 arraySize1, INT64 strlen) {
+IsSortedString(const char* pData, int64_t arraySize1, int64_t strlen) {
 
    int result = 0;
 
-   INT64 i = arraySize1 - 1;
+   int64_t i = arraySize1 - 1;
 
    while ((i > 0) && !(STRING_LT(&pData[i*strlen], &pData[(i - 1)*strlen], strlen))) {
       i--;
@@ -2969,11 +2969,11 @@ IsSortedString(const char* pData, INT64 arraySize1, INT64 strlen) {
 
 //-----------------------------------------------------------------------------------------------
 static int
-IsSortedUnicode(const char* pData, INT64 arraySize1, INT64 strlen) {
+IsSortedUnicode(const char* pData, int64_t arraySize1, int64_t strlen) {
 
    int result = 0;
 
-   INT64 i = arraySize1 - 1;
+   int64_t i = arraySize1 - 1;
 
    while ((i > 0) && !(UNICODE_LT(&pData[i*strlen], &pData[(i - 1)*strlen], strlen))) {
       i--;
@@ -2984,11 +2984,11 @@ IsSortedUnicode(const char* pData, INT64 arraySize1, INT64 strlen) {
 
 //-----------------------------------------------------------------------------------------------
 static int
-IsSortedVoid(const char* pData, INT64 arraySize1, INT64 strlen) {
+IsSortedVoid(const char* pData, int64_t arraySize1, int64_t strlen) {
 
    int result = 0;
 
-   INT64 i = arraySize1 - 1;
+   int64_t i = arraySize1 - 1;
 
    while ((i > 0) && !(VOID_LT(&pData[i*strlen], &pData[(i - 1)*strlen], strlen))) {
       i--;
@@ -3007,50 +3007,50 @@ PyObject* IsSorted(PyObject *self, PyObject *args) {
 
    if (!PyArg_ParseTuple(args, "O!", &PyArray_Type, &inArr1)) return NULL;
 
-   INT32 arrayType1 = PyArray_TYPE(inArr1);
+   int32_t arrayType1 = PyArray_TYPE(inArr1);
    int ndim = PyArray_NDIM(inArr1);
    npy_intp* dims = PyArray_DIMS(inArr1);
 
-   INT64 itemSize = PyArray_ITEMSIZE(inArr1);
+   int64_t itemSize = PyArray_ITEMSIZE(inArr1);
 
    if (ndim != 1 || itemSize != PyArray_STRIDE(inArr1, 0)) {
       PyErr_Format(PyExc_ValueError, "IsSorted arrays must be one dimensional and contiguous.  ndim is %d\n", ndim);
       return NULL;
    }
 
-   INT64 arraySize1 = CalcArrayLength(ndim, dims);
+   int64_t arraySize1 = CalcArrayLength(ndim, dims);
    void* pDataIn1 = PyArray_BYTES(inArr1);
 
    LOGGING("issorted size %llu  type %d\n", arraySize1, arrayType1);
 
-   INT64 result = 0;
+   int64_t result = 0;
    IS_SORTED_FUNC pSortedFunc = NULL;
 
    switch (arrayType1) {
    case NPY_BOOL:
    case NPY_INT8:
-      pSortedFunc = IsSorted<INT8>;
+      pSortedFunc = IsSorted<int8_t>;
       break;
    case NPY_INT16:
-      pSortedFunc = IsSorted<INT16>;
+      pSortedFunc = IsSorted<int16_t>;
       break;
    CASE_NPY_INT32:
-      pSortedFunc = IsSorted<INT32>;
+      pSortedFunc = IsSorted<int32_t>;
       break;
    CASE_NPY_INT64:
-      pSortedFunc = IsSorted<INT64>;
+      pSortedFunc = IsSorted<int64_t>;
       break;
    case NPY_UINT8:
-      pSortedFunc = IsSorted<UINT8>;
+      pSortedFunc = IsSorted<uint8_t>;
       break;
    case NPY_UINT16:
-      pSortedFunc = IsSorted<UINT16>;
+      pSortedFunc = IsSorted<uint16_t>;
       break;
    CASE_NPY_UINT32:
-      pSortedFunc = IsSorted<UINT32>;
+      pSortedFunc = IsSorted<uint32_t>;
       break;
    CASE_NPY_UINT64:
-      pSortedFunc = IsSorted<UINT64>;
+      pSortedFunc = IsSorted<uint64_t>;
       break;
    case NPY_FLOAT:
       pSortedFunc = IsSortedFloat<float>;
@@ -3079,15 +3079,15 @@ PyObject* IsSorted(PyObject *self, PyObject *args) {
 
    // MT callback
    struct IsSortedCallbackStruct {
-      INT64             IsSorted;
+      int64_t             IsSorted;
       IS_SORTED_FUNC    pSortedFunc;
       const char*       pDataIn1;
-      INT64             ArraySize;
-      INT64             ItemSize;
+      int64_t             ArraySize;
+      int64_t             ItemSize;
    } stISCallback{ 1, pSortedFunc, (const char*)pDataIn1, arraySize1, itemSize };
 
    // This is the routine that will be called back from multiple threads
-   auto lambdaISCallback = [](void* callbackArgT, int core, INT64 start, INT64 length) -> BOOL {
+   auto lambdaISCallback = [](void* callbackArgT, int core, int64_t start, int64_t length) -> bool {
       IsSortedCallbackStruct* cb = (IsSortedCallbackStruct*)callbackArgT;
 
       // check if short circuited (any segment not sorted)
@@ -3129,9 +3129,9 @@ PyObject* IsSorted(PyObject *self, PyObject *args) {
 
 //===============================================================================
 // checks for kwargs cutoff
-// if exists, and is INT64, returns pointer and length of cutoffs
+// if exists, and is int64_t, returns pointer and length of cutoffs
 // cutoffLength of -1 indicates an error
-INT64* GetCutOffs(PyObject *kwargs, INT64& cutoffLength) {
+int64_t* GetCutOffs(PyObject *kwargs, int64_t& cutoffLength) {
    // Check for cutoffs kwarg to see if going into parallel mode
    if (kwargs && PyDict_Check(kwargs)) {
       PyArrayObject* pCutOffs = NULL;
@@ -3143,9 +3143,9 @@ INT64* GetCutOffs(PyObject *kwargs, INT64& cutoffLength) {
          switch (PyArray_TYPE(pCutOffs)) {
          CASE_NPY_INT64:
             cutoffLength = ArrayLength(pCutOffs);
-            return (INT64*)PyArray_BYTES(pCutOffs);
+            return (int64_t*)PyArray_BYTES(pCutOffs);
          default:
-            printf("Bad cutoff dtype... make sure INT64\n");
+            printf("Bad cutoff dtype... make sure int64_t\n");
             cutoffLength = -1;
             return NULL;
          }
@@ -3158,7 +3158,7 @@ INT64* GetCutOffs(PyObject *kwargs, INT64& cutoffLength) {
 //===============================================================================
 
 template<typename UINDEX>
-static BOOL ARangeCallback(void* callbackArgT, int core, INT64 start, INT64 length) {
+static bool ARangeCallback(void* callbackArgT, int core, int64_t start, int64_t length) {
 
    UINDEX* pDataOut = (UINDEX*)callbackArgT;
    UINDEX istart = (UINDEX)start;
@@ -3172,8 +3172,8 @@ static BOOL ARangeCallback(void* callbackArgT, int core, INT64 start, INT64 leng
 }
 
 
-// index must be INT32 or INT64
-static PyArrayObject* GetKwargIndex(PyObject *kwargs, INT64& indexLength, int &dtype) {
+// index must be int32_t or int64_t
+static PyArrayObject* GetKwargIndex(PyObject *kwargs, int64_t& indexLength, int &dtype) {
    // Check for 'index' kwarg to see if prime lexsort
    if (kwargs && PyDict_Check(kwargs)) {
       PyArrayObject* pStartIndex = NULL;
@@ -3192,7 +3192,7 @@ static PyArrayObject* GetKwargIndex(PyObject *kwargs, INT64& indexLength, int &d
             dtype = NPY_INT32;
             return pStartIndex;
          default:
-            printf("Bad index dtype... make sure INT64 or INT32\n");
+            printf("Bad index dtype... make sure int64_t or int32_t\n");
             indexLength = -1;
             return NULL;
          }
@@ -3228,29 +3228,29 @@ PyObject* LexSort(PyObject *self, PyObject *args, PyObject *kwargs) {
    CMultiListPrepare mlp(args);
 
    if (mlp.aInfo && mlp.tupleSize > 0) {
-      INT64    arraySize1 = mlp.totalRows;
+      int64_t    arraySize1 = mlp.totalRows;
 
-      INT64    cutOffLength = 0;
-      INT64*   pCutOffs = GetCutOffs(kwargs, cutOffLength);
+      int64_t    cutOffLength = 0;
+      int64_t*   pCutOffs = GetCutOffs(kwargs, cutOffLength);
 
       if (pCutOffs && pCutOffs[cutOffLength - 1] != arraySize1) {
          PyErr_Format(PyExc_ValueError, "LexSort last cutoff length does not match array length %lld", arraySize1);
          return NULL;
       }
       if (cutOffLength == -1) {
-         PyErr_Format(PyExc_ValueError, "LexSort 'cutoffs' must be an array of type INT64");
+         PyErr_Format(PyExc_ValueError, "LexSort 'cutoffs' must be an array of type int64_t");
          return NULL;
       }
 
       int indexDType = 0;
-      INT64 indexLength = 0;
+      int64_t indexLength = 0;
 
       PyArrayObject* index = GetKwargIndex(kwargs, indexLength, indexDType);
 
       PyArrayObject* result = NULL;
       
       if (indexLength == -1) {
-         PyErr_Format(PyExc_ValueError, "LexSort 'index' must be an array of type INT64 or INT32");
+         PyErr_Format(PyExc_ValueError, "LexSort 'index' must be an array of type int64_t or int32_t");
          return NULL;
       }
 
@@ -3261,12 +3261,12 @@ PyObject* LexSort(PyObject *self, PyObject *args, PyObject *kwargs) {
          }
 
          if (sizeof(UINDEX) == 8 && indexDType != NPY_INT64) {
-            PyErr_Format(PyExc_ValueError, "LexSort 'index' is not INT64");
+            PyErr_Format(PyExc_ValueError, "LexSort 'index' is not int64_t");
             return NULL;
          }
 
          if (sizeof(UINDEX) == 4 && indexDType != NPY_INT32) {
-            PyErr_Format(PyExc_ValueError, "LexSort 'index' is not INT32");
+            PyErr_Format(PyExc_ValueError, "LexSort 'index' is not int32_t");
             return NULL;
          }
 
@@ -3290,11 +3290,11 @@ PyObject* LexSort(PyObject *self, PyObject *args, PyObject *kwargs) {
             // For cutoffs, prep the indexes with 0:n for each partition
             UINDEX* pCounter = pDataOut;
 
-            INT64 startPos = 0;
-            for (INT64 j = 0; j < cutOffLength; j++) {
+            int64_t startPos = 0;
+            for (int64_t j = 0; j < cutOffLength; j++) {
 
-               INT64 endPos = pCutOffs[j];
-               INT64 partitionLength = endPos - startPos;
+               int64_t endPos = pCutOffs[j];
+               int64_t partitionLength = endPos - startPos;
                for (UINDEX i = 0; i < partitionLength; i++) {
                   *pCounter++ = i;
                }
@@ -3335,26 +3335,26 @@ PyObject* LexSort(PyObject *self, PyObject *args, PyObject *kwargs) {
 
 
 //===============================================================================
-// Returns INT32
+// Returns int32_t
 PyObject* LexSort32(PyObject *self, PyObject *args, PyObject *kwargs) {
 
-   return LexSort<INT32>(self, args, kwargs);
+   return LexSort<int32_t>(self, args, kwargs);
 }
 
 
 //===============================================================================
-// Returns INT64
+// Returns int64_t
 PyObject* LexSort64(PyObject *self, PyObject *args, PyObject *kwargs) {
 
-   return LexSort<INT64>(self, args, kwargs);
+   return LexSort<int64_t>(self, args, kwargs);
 }
 
 
 //===============================================================================
 //===============================================================================
 // checks for kwargs filter
-// if exists, and is BOOL, returns pointer and length of bool
-static bool* GetFilter(PyObject *kwargs, INT64& filterLength) {
+// if exists, and is bool, returns pointer and length of bool
+static bool* GetFilter(PyObject *kwargs, int64_t& filterLength) {
    // Check for cutoffs kwarg to see if going into parallel mode
    if (kwargs && PyDict_Check(kwargs)) {
       PyArrayObject* pFilter = NULL;
@@ -3375,7 +3375,7 @@ static bool* GetFilter(PyObject *kwargs, INT64& filterLength) {
 }
 
 
-static INT64 GetBaseIndex(PyObject *kwargs) {
+static int64_t GetBaseIndex(PyObject *kwargs) {
    if (kwargs && PyDict_Check(kwargs)) {
       PyObject* pBaseIndex = NULL;
       // Borrowed reference
@@ -3397,10 +3397,10 @@ static INT64 GetBaseIndex(PyObject *kwargs) {
 // Group via lexsort
 // CountOut
 //================================================================================
-//typedef INT64 *(GROUP_INDEX_FUNC)()
+//typedef int64_t *(GROUP_INDEX_FUNC)()
 
 template <typename T, typename UINDEX>
-static INT64 GroupIndexStep2(
+static int64_t GroupIndexStep2(
    void*       pDataIn1,
    UINDEX      arraySize1,
    UINDEX*     pDataIndexIn,
@@ -3408,7 +3408,7 @@ static INT64 GroupIndexStep2(
    UINDEX*     pFirstOut,
    UINDEX*     pCountOut,
    bool*       pFilter,
-   INT64       base_index,
+   int64_t       base_index,
    UINDEX      strlen = 0) {
 
    T*          pDataIn = (T*)pDataIn1;
@@ -3536,7 +3536,7 @@ static INT64 GroupIndexStep2(
 
 
 template <typename T, typename UINDEX>
-static INT64 GroupIndexStep2String(
+static int64_t GroupIndexStep2String(
    void*       pDataIn1,
    UINDEX      arraySize1,
    UINDEX*     pDataIndexIn,
@@ -3544,8 +3544,8 @@ static INT64 GroupIndexStep2String(
    UINDEX*     pFirstOut,
    UINDEX*     pCountOut,
    bool*       pFilter,
-   INT64       base_index,
-   INT64       strlen) {
+   int64_t       base_index,
+   int64_t       strlen) {
 
    T*          pDataIn = (T*)pDataIn1;
    UINDEX      curIndex = pDataIndexIn[0];
@@ -3582,35 +3582,35 @@ static INT64 GroupIndexStep2String(
    return curGroup;
 }
 
-typedef INT64(*GROUP_INDEX_FUNC)(
+typedef int64_t(*GROUP_INDEX_FUNC)(
    void*       pDataIn1,
-   INT64       arraySize1V,
+   int64_t       arraySize1V,
    void*       pDataIndexInV,
    void*       pGroupOutV,
    void*       pFirstOutV,
    void*       pCountOutV,
    bool*       pFilter,       // optional
-   INT64       base_index,
-   INT64       strlen);
+   int64_t       base_index,
+   int64_t       strlen);
 
 
 //------------------------------------------------------------------------------------------
 // Internal and can be called from groupby
-// caller must allocate the pGroupOut as INT32 or INT64 with size arraySize1
-// UINDEX = INT32 or INT64
+// caller must allocate the pGroupOut as int32_t or int64_t with size arraySize1
+// UINDEX = int32_t or int64_t
 template <typename UINDEX>
-static INT64 GroupIndex(
+static int64_t GroupIndex(
    void*       pDataIn1,
-   INT64       arraySize1V,
+   int64_t       arraySize1V,
    void*       pDataIndexInV,
    void*       pGroupOutV,
    void*       pFirstOutV,
    void*       pCountOutV,
    bool*       pFilter,       // optional
-   INT64       base_index,
-   INT64       strlen) {
+   int64_t       base_index,
+   int64_t       strlen) {
 
-   INT64       uniqueCount = 0;
+   int64_t       uniqueCount = 0;
 
    UINDEX*     pDataIndexIn = (UINDEX*)pDataIndexInV;
    UINDEX*     pGroupOut = (UINDEX*)pGroupOutV;
@@ -3621,19 +3621,19 @@ static INT64 GroupIndex(
    switch (strlen) {
    case 1:
       uniqueCount =
-         GroupIndexStep2<INT8, UINDEX>(pDataIn1, arraySize1, pDataIndexIn, pGroupOut, pFirstOut, pCountOut, pFilter, base_index, 0);
+         GroupIndexStep2<int8_t, UINDEX>(pDataIn1, arraySize1, pDataIndexIn, pGroupOut, pFirstOut, pCountOut, pFilter, base_index, 0);
       break;
    case 2:
       uniqueCount =
-         GroupIndexStep2<INT16, UINDEX>(pDataIn1, arraySize1, pDataIndexIn, pGroupOut, pFirstOut, pCountOut, pFilter, base_index, 0);
+         GroupIndexStep2<int16_t, UINDEX>(pDataIn1, arraySize1, pDataIndexIn, pGroupOut, pFirstOut, pCountOut, pFilter, base_index, 0);
       break;
    case 4:
       uniqueCount =
-         GroupIndexStep2<INT32, UINDEX>(pDataIn1, arraySize1, pDataIndexIn, pGroupOut, pFirstOut, pCountOut, pFilter, base_index, 0);
+         GroupIndexStep2<int32_t, UINDEX>(pDataIn1, arraySize1, pDataIndexIn, pGroupOut, pFirstOut, pCountOut, pFilter, base_index, 0);
       break;
    case 8:
       uniqueCount =
-         GroupIndexStep2<INT64, UINDEX>(pDataIn1, arraySize1, pDataIndexIn, pGroupOut, pFirstOut, pCountOut, pFilter, base_index, 0);
+         GroupIndexStep2<int64_t, UINDEX>(pDataIn1, arraySize1, pDataIndexIn, pGroupOut, pFirstOut, pCountOut, pFilter, base_index, 0);
       break;
    default:
       uniqueCount =
@@ -3657,20 +3657,20 @@ static PyObject* GroupFromLexSortInternal(
    void*       pValues,
    npy_intp    itemSizeValues) {
 
-   INT64    cutOffLength = 0;
-   INT64*   pCutOffs = GetCutOffs(kwargs, cutOffLength);
+   int64_t    cutOffLength = 0;
+   int64_t*   pCutOffs = GetCutOffs(kwargs, cutOffLength);
 
-   INT64    filterLength = 0;
+   int64_t    filterLength = 0;
    bool*    pFilter = GetFilter(kwargs, filterLength);
 
-   INT64    base_index = GetBaseIndex(kwargs);
+   int64_t    base_index = GetBaseIndex(kwargs);
 
 
    if (pCutOffs && pCutOffs[cutOffLength - 1] != indexLength) {
       return PyErr_Format(PyExc_ValueError, "GroupFromLexSort last cutoff length does not match array length %lld", indexLength);
    }
    if (cutOffLength == -1) {
-      return PyErr_Format(PyExc_ValueError, "GroupFromLexSort 'cutoffs' must be an array of type INT64");
+      return PyErr_Format(PyExc_ValueError, "GroupFromLexSort 'cutoffs' must be an array of type int64_t");
    }
    if (pFilter && filterLength != indexLength) {
       return PyErr_Format(PyExc_ValueError, "GroupFromLexSort filter length does not match array length %lld", indexLength);
@@ -3678,7 +3678,7 @@ static PyObject* GroupFromLexSortInternal(
 
    // The countout always reserves the zero bin (even for when base_index =0) for filtering out
    // TODO: Change this to use type npy_intp and check for overflow.
-   INT64 worstCase = indexLength + 1 + cutOffLength;
+   int64_t worstCase = indexLength + 1 + cutOffLength;
 
    PyArrayObject* const keys = AllocateNumpyArray(1, (npy_intp*)&indexLengthValues, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
    PyArrayObject* const first = AllocateNumpyArray(1, (npy_intp*)&indexLength, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
@@ -3698,12 +3698,12 @@ static PyObject* GroupFromLexSortInternal(
    UINDEX* pFirstOut = (UINDEX*)PyArray_BYTES(first);
    UINDEX* pCountOut = (UINDEX*)PyArray_BYTES(count);
 
-   INT64 uniqueCount = 0;
+   int64_t uniqueCount = 0;
    GROUP_INDEX_FUNC  gpfunc = GroupIndex<UINDEX>;
 
    if (pCutOffs) {
       PyArrayObject* uniqueCounts = AllocateNumpyArray(1, (npy_intp*)&cutOffLength, NPY_INT64);
-      INT64*         pUniqueCounts = (INT64*)PyArray_BYTES(uniqueCounts);
+      int64_t*         pUniqueCounts = (int64_t*)PyArray_BYTES(uniqueCounts);
 
       // Turn off caching of large memory allocs
       g_cMathWorker->NoCaching = TRUE;
@@ -3712,10 +3712,10 @@ static PyObject* GroupFromLexSortInternal(
 
       struct stPGROUP {
          GROUP_INDEX_FUNC  funcSingleGroup;
-         INT64*            pUniqueCounts;
+         int64_t*            pUniqueCounts;
 
-         INT64*            pCutOffs;   
-         INT64             cutOffLength;
+         int64_t*            pCutOffs;   
+         int64_t             cutOffLength;
 
          char*             pValues;
          char*             pIndex;
@@ -3723,9 +3723,9 @@ static PyObject* GroupFromLexSortInternal(
          char*             pFirstOut;
          char*             pCountOut;
          bool*             pFilter;
-         INT64             base_index;
-         INT64             strlen;
-         INT64             sizeofUINDEX;
+         int64_t             base_index;
+         int64_t             strlen;
+         int64_t             sizeofUINDEX;
 
       } pgroup;
 
@@ -3743,16 +3743,16 @@ static PyObject* GroupFromLexSortInternal(
       pgroup.pFilter = pFilter;
       pgroup.base_index = base_index;
       pgroup.strlen = itemSizeValues;
-      const INT64 INDEX_SIZE = (INT64)sizeof(UINDEX);
+      const int64_t INDEX_SIZE = (int64_t)sizeof(UINDEX);
 
       pgroup.sizeofUINDEX = INDEX_SIZE;
 
       // Use threads per partition
-      auto lambdaPSCallback = [](void* callbackArgT, int core, INT64 workIndex) -> BOOL {
+      auto lambdaPSCallback = [](void* callbackArgT, int core, int64_t workIndex) -> bool {
          stPGROUP* callbackArg = (stPGROUP*)callbackArgT;
-         INT64 t = workIndex;
-         INT64 partLength;
-         INT64 partStart;
+         int64_t t = workIndex;
+         int64_t partLength;
+         int64_t partStart;
 
          if (t == 0) {
             partStart = 0;
@@ -3765,7 +3765,7 @@ static PyObject* GroupFromLexSortInternal(
 
          PLOGGING("[%lld] start: %lld  length: %lld\n", t, partStart, partLength);
 
-         INT64 shift = 
+         int64_t shift = 
          // shift the data pointers to match the partition
          // call a single threaded merge
          callbackArg->pUniqueCounts[t]=
@@ -3787,7 +3787,7 @@ static PyObject* GroupFromLexSortInternal(
       g_cMathWorker->NoCaching = FALSE;
 
       // TODO: make global routine
-      INT64 totalUniques = 0;
+      int64_t totalUniques = 0;
       for (int i = 0; i < cutOffLength; i++) {
          totalUniques += pUniqueCounts[i];
          pUniqueCounts[i] = totalUniques;
@@ -3804,10 +3804,10 @@ static PyObject* GroupFromLexSortInternal(
 
       // ANOTHER PARALEL ROUTINE to copy
       struct stPGROUPADD {
-         INT64*            pUniqueCounts;
+         int64_t*            pUniqueCounts;
 
-         INT64*            pCutOffs;       // May be NULL (if so no partitions)
-         INT64             cutOffLength;
+         int64_t*            pCutOffs;       // May be NULL (if so no partitions)
+         int64_t             cutOffLength;
 
          char*             pIndex;
          char*             pKeyOut;
@@ -3818,8 +3818,8 @@ static PyObject* GroupFromLexSortInternal(
          char*             pCountReduced;
          bool*             pFilter;
 
-         INT64             base_index;
-         INT64             sizeofUINDEX;
+         int64_t             base_index;
+         int64_t             sizeofUINDEX;
 
       } pgroupadd;
 
@@ -3838,7 +3838,7 @@ static PyObject* GroupFromLexSortInternal(
       pgroupadd.pCountReduced = (char*)PyArray_BYTES(countReduced);
 
       // skip first value since reserved for zero bin (and assign it 0)
-      for (INT64 c = 0; c < INDEX_SIZE; c++) {
+      for (int64_t c = 0; c < INDEX_SIZE; c++) {
          *pgroupadd.pCountReduced++ = 0;
       }
 
@@ -3846,12 +3846,12 @@ static PyObject* GroupFromLexSortInternal(
       pgroupadd.sizeofUINDEX = sizeof(UINDEX);
 
       // Use threads per partition
-      auto lambdaPGADDCallback = [](void* callbackArgT, int core, INT64 workIndex) -> BOOL {
+      auto lambdaPGADDCallback = [](void* callbackArgT, int core, int64_t workIndex) -> bool {
          stPGROUPADD* callbackArg = (stPGROUPADD*)callbackArgT;
-         INT64 t = workIndex;
-         INT64 partLength;
-         INT64 partStart;
-         INT64 uniquesBefore;
+         int64_t t = workIndex;
+         int64_t partLength;
+         int64_t partStart;
+         int64_t uniquesBefore;
 
          if (t == 0) {
             partStart = 0;
@@ -3866,40 +3866,40 @@ static PyObject* GroupFromLexSortInternal(
          //printf("[%lld] start: %lld  length: %lld  ubefore: %lld\n", t, partStart, partLength, uniquesBefore);
 
          if (callbackArg->sizeofUINDEX == 4) {
-            INT32* pKey = (INT32*)callbackArg->pKeyOut;
+            int32_t* pKey = (int32_t*)callbackArg->pKeyOut;
 
             // the iGroup is fixed up
-            INT32* pIndex = (INT32*)callbackArg->pIndex;
+            int32_t* pIndex = (int32_t*)callbackArg->pIndex;
             
             // pFirst is reduced to iFirstKey (only the uniques)
-            INT32* pFirst = (INT32*)callbackArg->pFirstOut; 
-            INT32* pFirstReduced = (INT32*)callbackArg->pFirstReduced;  
+            int32_t* pFirst = (int32_t*)callbackArg->pFirstOut; 
+            int32_t* pFirstReduced = (int32_t*)callbackArg->pFirstReduced;  
 
             // becomes nCount and the very first is reserved for zero bin
             // holds all the uniques + 1 for the zero bin.
-            INT32* pCount = (INT32*)callbackArg->pCountOut;
-            INT32* pCountReduced = (INT32*)callbackArg->pCountReduced;
+            int32_t* pCount = (int32_t*)callbackArg->pCountOut;
+            int32_t* pCountReduced = (int32_t*)callbackArg->pCountReduced;
 
-            INT32  ubefore = (INT32)uniquesBefore;
+            int32_t  ubefore = (int32_t)uniquesBefore;
 
             if (t != 0) {
                pKey += partStart;
                pIndex += partStart;
 
-               for (INT64 i = 0; i < partLength; i++) {
-                  pKey[i] += ((INT32)ubefore + 1); // start at 1 (to reserve zero bin), becomes ikey
-                  pIndex[i] += (INT32)partStart;
+               for (int64_t i = 0; i < partLength; i++) {
+                  pKey[i] += ((int32_t)ubefore + 1); // start at 1 (to reserve zero bin), becomes ikey
+                  pIndex[i] += (int32_t)partStart;
                }
             }
             else {
                pKey += partStart;
 
-               for (INT64 i = 0; i < partLength; i++) {
-                  pKey[i] += ((INT32)partStart + 1); // start at 1, becomes ikey
+               for (int64_t i = 0; i < partLength; i++) {
+                  pKey[i] += ((int32_t)partStart + 1); // start at 1, becomes ikey
                }
             }
 
-            INT64 uniqueLength = callbackArg->pUniqueCounts[t] - uniquesBefore;
+            int64_t uniqueLength = callbackArg->pUniqueCounts[t] - uniquesBefore;
             //printf("first reduced %d %lld\n", ubefore, uniqueLength);
             pFirst += partStart;
             pFirstReduced += ubefore;
@@ -3910,49 +3910,49 @@ static PyObject* GroupFromLexSortInternal(
             // very first [0] is for zero bin
             //pCount++;
 
-            for (INT64 i = 0; i < uniqueLength; i++) {
-               pFirstReduced[i] = pFirst[i] + (INT32)partStart;
-               //printf("setting %lld ", (INT64)pCount[i]);
+            for (int64_t i = 0; i < uniqueLength; i++) {
+               pFirstReduced[i] = pFirst[i] + (int32_t)partStart;
+               //printf("setting %lld ", (int64_t)pCount[i]);
                pCountReduced[i] = pCount[i];
             }
 
          }
          else {
 
-            INT64* pKey = (INT64*)callbackArg->pKeyOut;
+            int64_t* pKey = (int64_t*)callbackArg->pKeyOut;
 
             // the iGroup is fixed up
-            INT64* pIndex = (INT64*)callbackArg->pIndex;
+            int64_t* pIndex = (int64_t*)callbackArg->pIndex;
 
             // pFirst is reduced to iFirstKey (only the uniques)
-            INT64* pFirst = (INT64*)callbackArg->pFirstOut;
-            INT64* pFirstReduced = (INT64*)callbackArg->pFirstReduced;
+            int64_t* pFirst = (int64_t*)callbackArg->pFirstOut;
+            int64_t* pFirstReduced = (int64_t*)callbackArg->pFirstReduced;
 
             // becomes nCount and the very first is reserved for zero bin
             // holds all the uniques + 1 for the zero bin.
-            INT64* pCount = (INT64*)callbackArg->pCountOut;
-            INT64* pCountReduced = (INT64*)callbackArg->pCountReduced;
+            int64_t* pCount = (int64_t*)callbackArg->pCountOut;
+            int64_t* pCountReduced = (int64_t*)callbackArg->pCountReduced;
 
-            INT64  ubefore = (INT64)uniquesBefore;
+            int64_t  ubefore = (int64_t)uniquesBefore;
 
             if (t != 0) {
                pKey += partStart;
                pIndex += partStart;
 
-               for (INT64 i = 0; i < partLength; i++) {
-                  pKey[i] += ((INT64)ubefore + 1); // start at 1 (to reserve zero bin), becomes ikey
-                  pIndex[i] += (INT64)partStart;
+               for (int64_t i = 0; i < partLength; i++) {
+                  pKey[i] += ((int64_t)ubefore + 1); // start at 1 (to reserve zero bin), becomes ikey
+                  pIndex[i] += (int64_t)partStart;
                }
             }
             else {
                pKey += partStart;
 
-               for (INT64 i = 0; i < partLength; i++) {
-                  pKey[i] += ((INT64)partStart + 1); // start at 1, becomes ikey
+               for (int64_t i = 0; i < partLength; i++) {
+                  pKey[i] += ((int64_t)partStart + 1); // start at 1, becomes ikey
                }
             }
 
-            INT64 uniqueLength = callbackArg->pUniqueCounts[t] - uniquesBefore;
+            int64_t uniqueLength = callbackArg->pUniqueCounts[t] - uniquesBefore;
             //printf("first reduced %d %lld\n", ubefore, uniqueLength);
             pFirst += partStart;
             pFirstReduced += ubefore;
@@ -3963,9 +3963,9 @@ static PyObject* GroupFromLexSortInternal(
             // very first [0] is for zero bin
             //pCount++;
 
-            for (INT64 i = 0; i < uniqueLength; i++) {
-               pFirstReduced[i] = pFirst[i] + (INT64)partStart;
-               //printf("setting %lld ", (INT64)pCount[i]);
+            for (int64_t i = 0; i < uniqueLength; i++) {
+               pFirstReduced[i] = pFirst[i] + (int64_t)partStart;
+               //printf("setting %lld ", (int64_t)pCount[i]);
                pCountReduced[i] = pCount[i];
             }
 
@@ -4007,7 +4007,7 @@ static PyObject* GroupFromLexSortInternal(
       // memcpy..
       // also count invalid bin
       PyArrayObject* firstReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
-      INT64 copySize = sizeof(UINDEX) * uniqueCount;
+      int64_t copySize = sizeof(UINDEX) * uniqueCount;
       memcpy(PyArray_BYTES(firstReduced), pFirstOut, copySize);
 
       uniqueCount++;
@@ -4033,7 +4033,7 @@ static PyObject* GroupFromLexSortInternal(
 //     Checks for cutoffs
 //     If no cutoffs
 //     
-//     Arg1: lex=INT32/INT64 result from lexsort
+//     Arg1: lex=int32_t/int64_t result from lexsort
 //     Arg2: value array that was sorted -- if it came from a list, convert it to a void type
 //
 // Returns 3 arrays
@@ -4071,11 +4071,11 @@ PyObject* GroupFromLexSort(PyObject *self, PyObject *args, PyObject *kwargs) {
 
    switch (dtype) {
    CASE_NPY_INT32:
-      return GroupFromLexSortInternal<INT32>(kwargs, (INT32*)pIndex, arrLength, arrLengthValues,  pValues, itemSize);
+      return GroupFromLexSortInternal<int32_t>(kwargs, (int32_t*)pIndex, arrLength, arrLengthValues,  pValues, itemSize);
       break;
 
    CASE_NPY_INT64:
-      return GroupFromLexSortInternal<INT64>(kwargs, (INT64*)pIndex, arrLength, arrLengthValues, pValues, itemSize);
+      return GroupFromLexSortInternal<int64_t>(kwargs, (int64_t*)pIndex, arrLength, arrLengthValues, pValues, itemSize);
       break;
 
    default:

--- a/src/Sort.cpp
+++ b/src/Sort.cpp
@@ -2667,7 +2667,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
       case NPY_INT16:
          SortInPlace<int16_t>(pDataIn1, arraySize1, mode);
          break;
-      CASE_NPY_INT32:
+      CASE_NPY_INT:
          SortInPlace<int32_t>(pDataIn1, arraySize1, mode);
          break;
       CASE_NPY_INT64:
@@ -2679,7 +2679,7 @@ aheapsort_float(T *vv, UINDEX *tosort, UINDEX n)
       case NPY_UINT16:
          SortInPlace<uint16_t>(pDataIn1, arraySize1, mode);
          break;
-      CASE_NPY_UINT32:
+      CASE_NPY_UINT:
          SortInPlace<uint32_t>(pDataIn1, arraySize1, mode);
          break;
       CASE_NPY_UINT64:
@@ -2753,7 +2753,7 @@ PyObject* SortInPlaceIndirect(PyObject *self, PyObject *args) {
    int64_t sortSize = ArrayLength(inSort);
 
 
-   if (arrayType1 == NPY_INT32 && sortType == NPY_INT32) {
+   if (arrayType1 == NPY_INT && sortType == NPY_INT) {
       int32_t* pDataIn = (int32_t*)PyArray_BYTES(inArr1);
       int32_t* pSort = (int32_t*)PyArray_BYTES(inSort);
 
@@ -2768,7 +2768,7 @@ PyObject* SortInPlaceIndirect(PyObject *self, PyObject *args) {
 
       WORKSPACE_FREE(inverseSort);
    }
-   else if (arrayType1 == NPY_INT32 && sortType == NPY_INT64) {
+   else if (arrayType1 == NPY_INT && sortType == NPY_INT64) {
       int32_t* pDataIn = (int32_t*)PyArray_BYTES(inArr1);
       int64_t* pSort = (int64_t*)PyArray_BYTES(inSort);
 
@@ -2876,7 +2876,7 @@ static void SortIndex(
    case NPY_INT16:
       SortIndex<int16_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
-   CASE_NPY_INT32:
+   CASE_NPY_INT:
       SortIndex<int32_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
    CASE_NPY_INT64:
@@ -2888,7 +2888,7 @@ static void SortIndex(
    case NPY_UINT16:
       SortIndex<uint16_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
-   CASE_NPY_UINT32:
+   CASE_NPY_UINT:
       SortIndex<uint32_t, UINDEX>(pCutOffs, cutOffLength, pDataIn1, pDataOut1, arraySize1, mode);
       break;
    CASE_NPY_UINT64:
@@ -3034,7 +3034,7 @@ PyObject* IsSorted(PyObject *self, PyObject *args) {
    case NPY_INT16:
       pSortedFunc = IsSorted<int16_t>;
       break;
-   CASE_NPY_INT32:
+   CASE_NPY_INT:
       pSortedFunc = IsSorted<int32_t>;
       break;
    CASE_NPY_INT64:
@@ -3046,7 +3046,7 @@ PyObject* IsSorted(PyObject *self, PyObject *args) {
    case NPY_UINT16:
       pSortedFunc = IsSorted<uint16_t>;
       break;
-   CASE_NPY_UINT32:
+   CASE_NPY_UINT:
       pSortedFunc = IsSorted<uint32_t>;
       break;
    CASE_NPY_UINT64:
@@ -3188,8 +3188,8 @@ static PyArrayObject* GetKwargIndex(PyObject *kwargs, int64_t& indexLength, int 
          CASE_NPY_INT64:
             dtype = NPY_INT64;
             return pStartIndex;
-         CASE_NPY_INT32:
-            dtype = NPY_INT32;
+         CASE_NPY_INT:
+            dtype = NPY_INT;
             return pStartIndex;
          default:
             printf("Bad index dtype... make sure int64_t or int32_t\n");
@@ -3265,7 +3265,7 @@ PyObject* LexSort(PyObject *self, PyObject *args, PyObject *kwargs) {
             return NULL;
          }
 
-         if (sizeof(UINDEX) == 4 && indexDType != NPY_INT32) {
+         if (sizeof(UINDEX) == 4 && indexDType != NPY_INT) {
             PyErr_Format(PyExc_ValueError, "LexSort 'index' is not int32_t");
             return NULL;
          }
@@ -3276,7 +3276,7 @@ PyObject* LexSort(PyObject *self, PyObject *args, PyObject *kwargs) {
          Py_IncRef((PyObject*)result);
       }
       else {
-         result = AllocateLikeNumpyArray(mlp.aInfo[0].pObject, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
+         result = AllocateLikeNumpyArray(mlp.aInfo[0].pObject, sizeof(UINDEX) == 4 ? NPY_INT : NPY_INT64);
       }
 
       if (result) {
@@ -3680,9 +3680,9 @@ static PyObject* GroupFromLexSortInternal(
    // TODO: Change this to use type npy_intp and check for overflow.
    int64_t worstCase = indexLength + 1 + cutOffLength;
 
-   PyArrayObject* const keys = AllocateNumpyArray(1, (npy_intp*)&indexLengthValues, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
-   PyArrayObject* const first = AllocateNumpyArray(1, (npy_intp*)&indexLength, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
-   PyArrayObject* const count = AllocateNumpyArray(1, (npy_intp*)&worstCase, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
+   PyArrayObject* const keys = AllocateNumpyArray(1, (npy_intp*)&indexLengthValues, sizeof(UINDEX) == 4 ? NPY_INT : NPY_INT64);
+   PyArrayObject* const first = AllocateNumpyArray(1, (npy_intp*)&indexLength, sizeof(UINDEX) == 4 ? NPY_INT : NPY_INT64);
+   PyArrayObject* const count = AllocateNumpyArray(1, (npy_intp*)&worstCase, sizeof(UINDEX) == 4 ? NPY_INT : NPY_INT64);
 
    // Make sure allocations succeeded
    if (!keys || !first || !count)
@@ -3797,10 +3797,10 @@ static PyObject* GroupFromLexSortInternal(
 
       // TODO: fix up keys
       //parallel add?
-      PyArrayObject* firstReduced = AllocateNumpyArray(1, (npy_intp*)&totalUniques, INDEX_SIZE == 4 ? NPY_INT32 : NPY_INT64);
+      PyArrayObject* firstReduced = AllocateNumpyArray(1, (npy_intp*)&totalUniques, INDEX_SIZE == 4 ? NPY_INT : NPY_INT64);
 
       totalUniques++;
-      PyArrayObject* countReduced = AllocateNumpyArray(1, (npy_intp*)&totalUniques, INDEX_SIZE == 4 ? NPY_INT32 : NPY_INT64);
+      PyArrayObject* countReduced = AllocateNumpyArray(1, (npy_intp*)&totalUniques, INDEX_SIZE == 4 ? NPY_INT : NPY_INT64);
 
       // ANOTHER PARALEL ROUTINE to copy
       struct stPGROUPADD {
@@ -4006,12 +4006,12 @@ static PyObject* GroupFromLexSortInternal(
       // now we know the actual unique counts
       // memcpy..
       // also count invalid bin
-      PyArrayObject* firstReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
+      PyArrayObject* firstReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, sizeof(UINDEX) == 4 ? NPY_INT : NPY_INT64);
       int64_t copySize = sizeof(UINDEX) * uniqueCount;
       memcpy(PyArray_BYTES(firstReduced), pFirstOut, copySize);
 
       uniqueCount++;
-      PyArrayObject* countReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, sizeof(UINDEX) == 4 ? NPY_INT32 : NPY_INT64);
+      PyArrayObject* countReduced = AllocateNumpyArray(1, (npy_intp*)&uniqueCount, sizeof(UINDEX) == 4 ? NPY_INT : NPY_INT64);
       copySize = sizeof(UINDEX) * uniqueCount;
       // reduced
       memcpy(PyArray_BYTES(countReduced), pCountOut, copySize);
@@ -4070,7 +4070,7 @@ PyObject* GroupFromLexSort(PyObject *self, PyObject *args, PyObject *kwargs) {
    void* pValues = PyArray_BYTES(inArrValues);
 
    switch (dtype) {
-   CASE_NPY_INT32:
+   CASE_NPY_INT:
       return GroupFromLexSortInternal<int32_t>(kwargs, (int32_t*)pIndex, arrLength, arrLengthValues,  pValues, itemSize);
       break;
 

--- a/src/Sort.h
+++ b/src/Sort.h
@@ -11,7 +11,7 @@ enum SORT_MODE {
 };
 
 
-INT64* GetCutOffs(PyObject* kwargs, INT64& cutoffLength);
+int64_t* GetCutOffs(PyObject* kwargs, int64_t& cutoffLength);
 PyObject* GroupFromLexSort(PyObject* self, PyObject* args, PyObject* kwargs);
 
 PyObject* IsSorted(PyObject* self, PyObject* args);
@@ -27,16 +27,16 @@ PyObject* SortInPlaceIndirect(PyObject *self, PyObject *args);
 
 //-----------------------------------------------------------------------------------------------
 template <typename T>
-int heapsort_(T *start, INT64 n);
+int heapsort_(T *start, int64_t n);
 
 template <typename T>
-int quicksort_(T *start, INT64 num);
+int quicksort_(T *start, int64_t num);
 
 template <typename T>
 void mergesort0_(T *pl, T *pr, T *pw);
 
 template <typename T>
-int mergesort_(T *start, INT64 num);
+int mergesort_(T *start, int64_t num);
 
 
 //===============================================================================
@@ -47,8 +47,8 @@ public:
 
    Py_ssize_t tupleSize;  // or number of arrays
    ArrayInfo* aInfo;
-   INT64 totalItemSize;
-   INT64 totalRows;
+   int64_t totalItemSize;
+   int64_t totalRows;
 
    CMultiListPrepare(PyObject* args) {
       aInfo = NULL;
@@ -69,14 +69,14 @@ public:
          }
       }
 
-      INT64 listSize = 0;
+      int64_t listSize = 0;
       aInfo = BuildArrayInfo(args, &listSize, &totalItemSize);
 
       if (aInfo) {
 
          totalRows = aInfo[0].ArrayLength;
 
-         for (INT64 i = 0; i < listSize; i++) {
+         for (int64_t i = 0; i < listSize; i++) {
             if (aInfo[i].ArrayLength != totalRows) {
                PyErr_Format(PyExc_ValueError, "MultiListPrepare all arrays must be same number of rows %llu", totalRows);
                totalRows = 0;

--- a/src/TileRepeat.cpp
+++ b/src/TileRepeat.cpp
@@ -85,7 +85,7 @@ void ConvertRecArray(char* pStartOffset, int64_t startRow, int64_t totalRows, st
             {
                int64_t endSubRow = endRow - 8;
                while (startRow < endSubRow) {
-                  __m256i m0 = _mm256_i32gather_epi32((int32_t*)(pRead + (startRow * itemSize)), vindex, 1);
+                  __m256i m0 = _mm256_i32gather_epi32(reinterpret_cast<int32_t*>(pRead + (startRow * itemSize)), vindex, 1);
                   _mm256_storeu_si256((__m256i*)(pWrite + (startRow * arrItemSize)), m0);
                   startRow += 8;
                }
@@ -100,7 +100,7 @@ void ConvertRecArray(char* pStartOffset, int64_t startRow, int64_t totalRows, st
             {
                int64_t endSubRow = endRow - 4;
                while (startRow < endSubRow) {
-                  __m256i m0 = _mm256_i32gather_epi64(reinterpret_cast<long long const *>(pRead + (startRow * itemSize)), vindex128, 1);
+                  __m256i m0 = _mm256_i32gather_epi64(reinterpret_cast<int64_t const *>(pRead + (startRow * itemSize)), vindex128, 1);
                   _mm256_storeu_si256((__m256i*)(pWrite + (startRow * arrItemSize)), m0);
                   startRow += 4;
                }

--- a/src/TileRepeat.cpp
+++ b/src/TileRepeat.cpp
@@ -100,7 +100,7 @@ void ConvertRecArray(char* pStartOffset, int64_t startRow, int64_t totalRows, st
             {
                int64_t endSubRow = endRow - 4;
                while (startRow < endSubRow) {
-                  __m256i m0 = _mm256_i32gather_epi64((int64_t*)(pRead + (startRow * itemSize)), vindex128, 1);
+                  __m256i m0 = _mm256_i32gather_epi64(reinterpret_cast<long long const *>(pRead + (startRow * itemSize)), vindex128, 1);
                   _mm256_storeu_si256((__m256i*)(pWrite + (startRow * arrItemSize)), m0);
                   startRow += 4;
                }

--- a/src/TimeWindow.cpp
+++ b/src/TimeWindow.cpp
@@ -4,7 +4,7 @@
 #include "TimeWindow.h"
 #define LOGGING(...)
 
-typedef void(*TIMEWINDOW_FUNC)(void* pDataIn, void* pTimeIn, void* pDataOut, INT64 start, INT64 length, INT64 windowSize);
+typedef void(*TIMEWINDOW_FUNC)(void* pDataIn, void* pTimeIn, void* pDataOut, int64_t start, int64_t length, int64_t windowSize);
 
 enum TIMEWINDOW_FUNCTIONS {
    TIMEWINDOW_SUM = 0,
@@ -22,7 +22,7 @@ public:
    TimeWindowBase() {};
    ~TimeWindowBase() {};
 
-   static void TimeWindowSum(void* pDataIn, void* pTimeIn, void* pDataOut, INT64 start, INT64 length, INT64 timeDelta) {
+   static void TimeWindowSum(void* pDataIn, void* pTimeIn, void* pDataOut, int64_t start, int64_t length, int64_t timeDelta) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -30,13 +30,13 @@ public:
 
       U currentSum = 0;
 
-      for (INT64 i = start; i < (start + length); i++) {
+      for (int64_t i = start; i < (start + length); i++) {
          currentSum = pIn[i];
-         INT64 timeIndex = i - 1;
+         int64_t timeIndex = i - 1;
          while (timeIndex >= 0) {
 
             // see if in time difference within range
-            INT64 deltaTime = pTime[i] - pTime[timeIndex];
+            int64_t deltaTime = pTime[i] - pTime[timeIndex];
             if (deltaTime <= timeDelta) {
 
                // keep tallying
@@ -52,7 +52,7 @@ public:
 
    }
 
-   static void TimeWindowProd(void* pDataIn, void* pTimeIn, void* pDataOut, INT64 start, INT64 length, INT64 timeDelta) {
+   static void TimeWindowProd(void* pDataIn, void* pTimeIn, void* pDataOut, int64_t start, int64_t length, int64_t timeDelta) {
 
       T* pIn = (T*)pDataIn;
       U* pOut = (U*)pDataOut;
@@ -60,13 +60,13 @@ public:
 
       U currentProd = 1;
 
-      for (INT64 i = start; i < (start + length); i++) {
+      for (int64_t i = start; i < (start + length); i++) {
          currentProd = pIn[i];
-         INT64 timeIndex = i - 1;
+         int64_t timeIndex = i - 1;
          while (timeIndex >= 0) {
 
             // see if in time difference within range
-            INT64 deltaTime = pTime[i] - pTime[timeIndex];
+            int64_t deltaTime = pTime[i] - pTime[timeIndex];
             if (deltaTime <= timeDelta) {
 
                // keep tallying
@@ -83,7 +83,7 @@ public:
 
 
 
-   static TIMEWINDOW_FUNC GeTimeWindowFunction(INT64 func) {
+   static TIMEWINDOW_FUNC GeTimeWindowFunction(int64_t func) {
       switch (func) {
       case TIMEWINDOW_SUM: return TimeWindowSum;
       case TIMEWINDOW_PROD: return TimeWindowProd;
@@ -95,20 +95,24 @@ public:
 
 
 
-TIMEWINDOW_FUNC GeTimeWindowFunction(INT64 func, INT32 inputType, INT32* outputType) {
+TIMEWINDOW_FUNC GeTimeWindowFunction(int64_t func, int32_t inputType, int32_t* outputType) {
    switch (inputType) {
-   case NPY_BOOL:   *outputType = NPY_INT64;  return TimeWindowBase<INT8, INT64, INT64>::GeTimeWindowFunction(func);
-   case NPY_FLOAT:  *outputType = NPY_FLOAT; return TimeWindowBase<float, float, INT64>::GeTimeWindowFunction(func);
-   case NPY_DOUBLE: *outputType = NPY_DOUBLE; return TimeWindowBase<double, double, INT64>::GeTimeWindowFunction(func);
-   case NPY_LONGDOUBLE: *outputType = NPY_LONGDOUBLE; return TimeWindowBase<long double, long double, INT64>::GeTimeWindowFunction(func);
-   case NPY_INT8:   *outputType = NPY_INT64; return TimeWindowBase<INT8, INT64, INT64>::GeTimeWindowFunction(func);
-   case NPY_INT16:  *outputType = NPY_INT64; return TimeWindowBase<INT16, INT64, INT64>::GeTimeWindowFunction(func);
-   CASE_NPY_INT32:  *outputType = NPY_INT64; return TimeWindowBase<INT32, INT64, INT64>::GeTimeWindowFunction(func);
-   CASE_NPY_INT64:  *outputType = NPY_INT64; return TimeWindowBase<INT64, INT64, INT64>::GeTimeWindowFunction(func);
-   case NPY_UINT8:  *outputType = NPY_UINT64; return TimeWindowBase<UINT8, UINT64, INT64>::GeTimeWindowFunction(func);
-   case NPY_UINT16: *outputType = NPY_UINT64; return TimeWindowBase<UINT16, UINT64, INT64>::GeTimeWindowFunction(func);
-   CASE_NPY_UINT32: *outputType = NPY_UINT64; return TimeWindowBase<UINT32, UINT64, INT64>::GeTimeWindowFunction(func);
-   CASE_NPY_UINT64: *outputType = NPY_UINT64; return TimeWindowBase<UINT64, UINT64, INT64>::GeTimeWindowFunction(func);
+   case NPY_BOOL:   *outputType = NPY_INT64;  return TimeWindowBase<int8_t, int64_t, int64_t>::GeTimeWindowFunction(func);
+   case NPY_FLOAT:  *outputType = NPY_FLOAT; return TimeWindowBase<float, float, int64_t>::GeTimeWindowFunction(func);
+   case NPY_DOUBLE: *outputType = NPY_DOUBLE; return TimeWindowBase<double, double, int64_t>::GeTimeWindowFunction(func);
+   case NPY_LONGDOUBLE: *outputType = NPY_LONGDOUBLE; return TimeWindowBase<long double, long double, int64_t>::GeTimeWindowFunction(func);
+   case NPY_INT8:   *outputType = NPY_INT64; return TimeWindowBase<int8_t, int64_t, int64_t>::GeTimeWindowFunction(func);
+   case NPY_INT16:  *outputType = NPY_INT64; return TimeWindowBase<int16_t, int64_t, int64_t>::GeTimeWindowFunction(func);
+   case NPY_INT32:  *outputType = NPY_INT64; return TimeWindowBase<int32_t, int64_t, int64_t>::GeTimeWindowFunction(func);
+   case NPY_INT64:
+   case NPY_LONGLONG:
+      *outputType = NPY_INT64; return TimeWindowBase<int64_t, int64_t, int64_t>::GeTimeWindowFunction(func);
+   case NPY_UINT8:  *outputType = NPY_UINT64; return TimeWindowBase<uint8_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
+   case NPY_UINT16: *outputType = NPY_UINT64; return TimeWindowBase<uint16_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
+   case NPY_UINT32: *outputType = NPY_UINT64; return TimeWindowBase<uint32_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
+   case NPY_UINT64:
+   case NPY_ULONGLONG:
+      *outputType = NPY_UINT64; return TimeWindowBase<uint64_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
    }
 
    return NULL;
@@ -128,8 +132,8 @@ TimeWindow(PyObject *self, PyObject *args)
 {
    PyArrayObject *inArr = NULL;
    PyArrayObject *timeArr = NULL;
-   INT64 func = 0;
-   INT64 param1 = 0;
+   int64_t func = 0;
+   int64_t param1 = 0;
 
    if (!PyArg_ParseTuple(
       args, "O!O!LL",
@@ -141,11 +145,11 @@ TimeWindow(PyObject *self, PyObject *args)
       return NULL;
    }
 
-   INT32 dType = PyArray_TYPE(inArr);
+   int32_t dType = PyArray_TYPE(inArr);
 
    PyArrayObject* outArray = NULL;
-   INT64 arrayLength = ArrayLength(inArr);
-   INT64 arrayLengthTime = ArrayLength(timeArr);
+   int64_t arrayLength = ArrayLength(inArr);
+   int64_t arrayLengthTime = ArrayLength(timeArr);
 
    // TODO: Check to make sure inArr and timeArr sizes are the same
    if (arrayLength != arrayLengthTime) {
@@ -154,17 +158,18 @@ TimeWindow(PyObject *self, PyObject *args)
    }
 
    switch (PyArray_TYPE(timeArr)) {
-      CASE_NPY_INT64:
-         break;
-      default:
-         PyErr_Format(PyExc_ValueError, "TimeWindow time array must be int64");
-         return NULL;
+   case NPY_INT64:
+   case NPY_LONGLONG:
+      break;
+   default:
+      PyErr_Format(PyExc_ValueError, "TimeWindow time array must be int64");
+      return NULL;
    }
 
    TIMEWINDOW_FUNC pTimeWindowFunc;
 
    // determine based on function
-   INT32 numpyOutType = NPY_FLOAT64;
+   int32_t numpyOutType = NPY_FLOAT64;
 
    pTimeWindowFunc = GeTimeWindowFunction(func, dType, &numpyOutType);
 
@@ -180,19 +185,19 @@ TimeWindow(PyObject *self, PyObject *args)
             void* pDataIn;
             void* pTimeIn;
             void* pDataOut;
-            INT64 timeDelta;
+            int64_t timeDelta;
          };
 
          TWCallbackStruct stTWCallback;
 
          // This is the routine that will be called back from multiple threads
-         auto lambdaTWCallback = [](void* callbackArgT, int core, INT64 start, INT64 length) -> BOOL {
+         auto lambdaTWCallback = [](void* callbackArgT, int core, int64_t start, int64_t length) -> bool {
             TWCallbackStruct* callbackArg = (TWCallbackStruct*)callbackArgT;
 
             //printf("[%d] TW %lld %lld\n", core, start, length);
 
             callbackArg->func(callbackArg->pDataIn, callbackArg->pTimeIn, callbackArg->pDataOut, start, length, callbackArg->timeDelta);
-            return TRUE;
+            return true;
          };
 
          stTWCallback.func = pTimeWindowFunc;

--- a/src/TimeWindow.cpp
+++ b/src/TimeWindow.cpp
@@ -103,15 +103,15 @@ TIMEWINDOW_FUNC GeTimeWindowFunction(int64_t func, int32_t inputType, int32_t* o
    case NPY_LONGDOUBLE: *outputType = NPY_LONGDOUBLE; return TimeWindowBase<long double, long double, int64_t>::GeTimeWindowFunction(func);
    case NPY_INT8:   *outputType = NPY_INT64; return TimeWindowBase<int8_t, int64_t, int64_t>::GeTimeWindowFunction(func);
    case NPY_INT16:  *outputType = NPY_INT64; return TimeWindowBase<int16_t, int64_t, int64_t>::GeTimeWindowFunction(func);
-   case NPY_INT32:  *outputType = NPY_INT64; return TimeWindowBase<int32_t, int64_t, int64_t>::GeTimeWindowFunction(func);
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT32:  *outputType = NPY_INT64; return TimeWindowBase<int32_t, int64_t, int64_t>::GeTimeWindowFunction(func);
+   CASE_NPY_INT64:
+   
       *outputType = NPY_INT64; return TimeWindowBase<int64_t, int64_t, int64_t>::GeTimeWindowFunction(func);
    case NPY_UINT8:  *outputType = NPY_UINT64; return TimeWindowBase<uint8_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
    case NPY_UINT16: *outputType = NPY_UINT64; return TimeWindowBase<uint16_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
-   case NPY_UINT32: *outputType = NPY_UINT64; return TimeWindowBase<uint32_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
-   case NPY_UINT64:
-   case NPY_ULONGLONG:
+   CASE_NPY_UINT32: *outputType = NPY_UINT64; return TimeWindowBase<uint32_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
+   CASE_NPY_UINT64:
+   
       *outputType = NPY_UINT64; return TimeWindowBase<uint64_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
    }
 
@@ -158,8 +158,8 @@ TimeWindow(PyObject *self, PyObject *args)
    }
 
    switch (PyArray_TYPE(timeArr)) {
-   case NPY_INT64:
-   case NPY_LONGLONG:
+   CASE_NPY_INT64:
+   
       break;
    default:
       PyErr_Format(PyExc_ValueError, "TimeWindow time array must be int64");

--- a/src/TimeWindow.cpp
+++ b/src/TimeWindow.cpp
@@ -103,13 +103,13 @@ TIMEWINDOW_FUNC GeTimeWindowFunction(int64_t func, int32_t inputType, int32_t* o
    case NPY_LONGDOUBLE: *outputType = NPY_LONGDOUBLE; return TimeWindowBase<long double, long double, int64_t>::GeTimeWindowFunction(func);
    case NPY_INT8:   *outputType = NPY_INT64; return TimeWindowBase<int8_t, int64_t, int64_t>::GeTimeWindowFunction(func);
    case NPY_INT16:  *outputType = NPY_INT64; return TimeWindowBase<int16_t, int64_t, int64_t>::GeTimeWindowFunction(func);
-   case NPY_INT:  *outputType = NPY_INT64; return TimeWindowBase<int32_t, int64_t, int64_t>::GeTimeWindowFunction(func);
+   case NPY_INT32:  *outputType = NPY_INT64; return TimeWindowBase<int32_t, int64_t, int64_t>::GeTimeWindowFunction(func);
    case NPY_INT64:
    case NPY_LONGLONG:
       *outputType = NPY_INT64; return TimeWindowBase<int64_t, int64_t, int64_t>::GeTimeWindowFunction(func);
    case NPY_UINT8:  *outputType = NPY_UINT64; return TimeWindowBase<uint8_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
    case NPY_UINT16: *outputType = NPY_UINT64; return TimeWindowBase<uint16_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
-   case NPY_UINT: *outputType = NPY_UINT64; return TimeWindowBase<uint32_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
+   case NPY_UINT32: *outputType = NPY_UINT64; return TimeWindowBase<uint32_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
    case NPY_UINT64:
    case NPY_ULONGLONG:
       *outputType = NPY_UINT64; return TimeWindowBase<uint64_t, uint64_t, int64_t>::GeTimeWindowFunction(func);

--- a/src/TimeWindow.cpp
+++ b/src/TimeWindow.cpp
@@ -103,13 +103,13 @@ TIMEWINDOW_FUNC GeTimeWindowFunction(int64_t func, int32_t inputType, int32_t* o
    case NPY_LONGDOUBLE: *outputType = NPY_LONGDOUBLE; return TimeWindowBase<long double, long double, int64_t>::GeTimeWindowFunction(func);
    case NPY_INT8:   *outputType = NPY_INT64; return TimeWindowBase<int8_t, int64_t, int64_t>::GeTimeWindowFunction(func);
    case NPY_INT16:  *outputType = NPY_INT64; return TimeWindowBase<int16_t, int64_t, int64_t>::GeTimeWindowFunction(func);
-   case NPY_INT32:  *outputType = NPY_INT64; return TimeWindowBase<int32_t, int64_t, int64_t>::GeTimeWindowFunction(func);
+   case NPY_INT:  *outputType = NPY_INT64; return TimeWindowBase<int32_t, int64_t, int64_t>::GeTimeWindowFunction(func);
    case NPY_INT64:
    case NPY_LONGLONG:
       *outputType = NPY_INT64; return TimeWindowBase<int64_t, int64_t, int64_t>::GeTimeWindowFunction(func);
    case NPY_UINT8:  *outputType = NPY_UINT64; return TimeWindowBase<uint8_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
    case NPY_UINT16: *outputType = NPY_UINT64; return TimeWindowBase<uint16_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
-   case NPY_UINT32: *outputType = NPY_UINT64; return TimeWindowBase<uint32_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
+   case NPY_UINT: *outputType = NPY_UINT64; return TimeWindowBase<uint32_t, uint64_t, int64_t>::GeTimeWindowFunction(func);
    case NPY_UINT64:
    case NPY_ULONGLONG:
       *outputType = NPY_UINT64; return TimeWindowBase<uint64_t, uint64_t, int64_t>::GeTimeWindowFunction(func);

--- a/src/UnaryOps.cpp
+++ b/src/UnaryOps.cpp
@@ -1130,7 +1130,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
    case MATH_OPERATION::FABS:
       //*wantedOutType = NPY_DOUBLE;
       //switch (numpyInType1) {
-      //case NPY_INT32:  return UnaryOpSlow_FABS<int32_t>;
+      //case NPY_INT:  return UnaryOpSlow_FABS<int32_t>;
       //CASE_NPY_INT64:  return UnaryOpSlow_FABS<int64_t>;
       //case NPY_INT8:   return UnaryOpSlow_FABS<int8_t>;
       //case NPY_INT16:  return UnaryOpSlow_FABS<int16_t>;
@@ -1144,7 +1144,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_ABS<float>;
       case NPY_DOUBLE: return UnaryOpSlow_ABS<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_ABS<long double>;
-      case NPY_INT32:  return UnaryOpSlow_ABS<int32_t>;
+      case NPY_INT:  return UnaryOpSlow_ABS<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return UnaryOpSlow_ABS<int64_t>;
@@ -1160,7 +1160,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_FLOATSIGN<float>;
       case NPY_DOUBLE: return UnaryOpSlow_FLOATSIGN<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_FLOATSIGN<long double>;
-      case NPY_INT32:  return UnaryOpSlow_SIGN<int32_t>;
+      case NPY_INT:  return UnaryOpSlow_SIGN<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return UnaryOpSlow_SIGN<int64_t>;
@@ -1177,7 +1177,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_NEG<float>;
       case NPY_DOUBLE: return UnaryOpSlow_NEG<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_NEG<long double>;
-      case NPY_INT32:  return UnaryOpSlow_NEG<int32_t>;
+      case NPY_INT:  return UnaryOpSlow_NEG<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlow_NEG<int64_t>;
@@ -1198,8 +1198,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_BOOL:   return UnaryOpSlow_NOT<int8_t>;
          case NPY_INT16:
          case NPY_UINT16:   return UnaryOpSlow_NOT<int16_t>;
-         case NPY_INT32:
-         case NPY_UINT32:   return UnaryOpSlow_NOT<int32_t>;
+         case NPY_INT:
+         case NPY_UINT:   return UnaryOpSlow_NOT<int32_t>;
          case NPY_INT64:
          case NPY_LONGLONG:
          case NPY_UINT64:
@@ -1216,8 +1216,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
    case MATH_OPERATION::INVERT:
       *wantedOutType = numpyInType1;
       switch (numpyInType1) {
-      case NPY_INT32:  return UnaryOpSlow_INVERT<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlow_INVERT<uint32_t>;
+      case NPY_INT:  return UnaryOpSlow_INVERT<int32_t>;
+      case NPY_UINT:  return UnaryOpSlow_INVERT<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlow_INVERT<int64_t>;
@@ -1240,8 +1240,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISFINITE<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISFINITE<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISFINITE<long double>;
-         case NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
-         case NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
+         case NPY_INT:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
+         case NPY_UINT:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
          case NPY_INT64:
          case NPY_LONGLONG:
                return UnaryOpSlow_ISNOTINVALID<int64_t>;
@@ -1267,8 +1267,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNOTFINITE<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNOTFINITE<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNOTFINITE<long double>;
-         case NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
-         case NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
+         case NPY_INT:      return UnaryOpSlow_ISINVALID<int32_t>;
+         case NPY_UINT:     return UnaryOpSlow_ISINVALID<uint32_t>;
          case NPY_INT64:
          case NPY_LONGLONG:
                return UnaryOpSlow_ISINVALID<int64_t>;
@@ -1294,8 +1294,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNAN<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNAN<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNAN<long double>;
-         case NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
-         case NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
+         case NPY_INT:      return UnaryOpSlow_ISINVALID<int32_t>;
+         case NPY_UINT:     return UnaryOpSlow_ISINVALID<uint32_t>;
          case NPY_INT64:
          case NPY_LONGLONG:
                return UnaryOpSlow_ISINVALID<int64_t>;
@@ -1322,8 +1322,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNANORZERO<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNANORZERO<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNANORZERO<long double>;
-         case NPY_INT32:      return UnaryOpSlow_ISINVALIDORZERO<int32_t>;
-         case NPY_UINT32:     return UnaryOpSlow_ISINVALIDORZERO<uint32_t>;
+         case NPY_INT:      return UnaryOpSlow_ISINVALIDORZERO<int32_t>;
+         case NPY_UINT:     return UnaryOpSlow_ISINVALIDORZERO<uint32_t>;
          case NPY_INT64:
          case NPY_LONGLONG:
                return UnaryOpSlow_ISINVALIDORZERO<int64_t>;
@@ -1349,8 +1349,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNOTNAN<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNOTNAN<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNOTNAN<long double>;
-         case NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
-         case NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
+         case NPY_INT:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
+         case NPY_UINT:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
          case NPY_INT64:
          case NPY_LONGLONG:
                return UnaryOpSlow_ISNOTINVALID<int64_t>;
@@ -1452,8 +1452,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          *wantedOutType = NPY_LONGDOUBLE;
       }
       switch (numpyInType1) {
-      case NPY_INT32:  return UnaryOpSlowDouble_SQRT<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlowDouble_SQRT<uint32_t>;
+      case NPY_INT:  return UnaryOpSlowDouble_SQRT<int32_t>;
+      case NPY_UINT:  return UnaryOpSlowDouble_SQRT<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlowDouble_SQRT<int64_t>;
@@ -1473,8 +1473,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          *wantedOutType = NPY_LONGDOUBLE;
       }
       switch (numpyInType1) {
-      case NPY_INT32:  return UnaryOpSlowDouble_CBRT<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlowDouble_CBRT<uint32_t>;
+      case NPY_INT:  return UnaryOpSlowDouble_CBRT<int32_t>;
+      case NPY_UINT:  return UnaryOpSlowDouble_CBRT<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlowDouble_CBRT<int64_t>;
@@ -1496,8 +1496,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_LOG<float>;
       case NPY_DOUBLE: return UnaryOpSlow_LOG<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_LOG<long double>;
-      case NPY_INT32:  return UnaryOpSlowDouble_LOG<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlowDouble_LOG<uint32_t>;
+      case NPY_INT:  return UnaryOpSlowDouble_LOG<int32_t>;
+      case NPY_UINT:  return UnaryOpSlowDouble_LOG<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlowDouble_LOG<int64_t>;
@@ -1519,8 +1519,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_LOG10<float>;
       case NPY_DOUBLE: return UnaryOpSlow_LOG10<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_LOG10<long double>;
-      case NPY_INT32:  return UnaryOpSlowDouble_LOG10<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlowDouble_LOG10<uint32_t>;
+      case NPY_INT:  return UnaryOpSlowDouble_LOG10<int32_t>;
+      case NPY_UINT:  return UnaryOpSlowDouble_LOG10<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlowDouble_LOG10<int64_t>;
@@ -1542,8 +1542,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_EXP<float>;
       case NPY_DOUBLE: return UnaryOpSlow_EXP<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_EXP<long double>;
-      case NPY_INT32:  return UnaryOpSlowDouble_EXP<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlowDouble_EXP<uint32_t>;
+      case NPY_INT:  return UnaryOpSlowDouble_EXP<int32_t>;
+      case NPY_UINT:  return UnaryOpSlowDouble_EXP<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlowDouble_EXP<int64_t>;
@@ -1565,8 +1565,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_EXP2<float>;
       case NPY_DOUBLE: return UnaryOpSlow_EXP2<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_EXP2<long double>;
-      case NPY_INT32:  return UnaryOpSlowDouble_EXP2<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlowDouble_EXP2<uint32_t>;
+      case NPY_INT:  return UnaryOpSlowDouble_EXP2<int32_t>;
+      case NPY_UINT:  return UnaryOpSlowDouble_EXP2<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlowDouble_EXP2<int64_t>;
@@ -1582,7 +1582,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_SIGNBIT<float>;
       case NPY_DOUBLE: return UnaryOpSlow_SIGNBIT<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_SIGNBIT<long double>;
-      //case NPY_INT32:  return UnaryOpSlowDouble_SIGNBIT<int32_t>;
+      //case NPY_INT:  return UnaryOpSlowDouble_SIGNBIT<int32_t>;
       }
       break;
 
@@ -1604,7 +1604,7 @@ UNARY_FUNC GetUnaryOpFast(int func, int numpyInType1, int numpyOutType, int* wan
       switch (numpyInType1) {
       case NPY_FLOAT:  return UnaryOpFast<float, __m256, ABS_OP<float>, ABS_OP_256<__m256>>;
       case NPY_DOUBLE: return UnaryOpFast<double, __m256d, ABS_OP<double>, ABS_OP_256<__m256d>>;
-      case NPY_INT32:  return UnaryOpFast<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
+      case NPY_INT:  return UnaryOpFast<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
       case NPY_INT16:  return UnaryOpFast<int16_t, __m256i, ABS_OP<int16_t>, ABS_OP_256i16>;
       case NPY_INT8:   return UnaryOpFast<int8_t, __m256i,  ABS_OP<int8_t>, ABS_OP_256i8>;
       }
@@ -1649,7 +1649,7 @@ UNARY_FUNC GetUnaryOpFast(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpFast<int64_t, __m256i, NEG_OP<int64_t>, NEG_OP_256i64>;
-      case NPY_INT32:  return UnaryOpFast<int32_t, __m256i, NEG_OP<int32_t>, NEG_OP_256i32>;
+      case NPY_INT:  return UnaryOpFast<int32_t, __m256i, NEG_OP<int32_t>, NEG_OP_256i32>;
       case NPY_INT16:  return UnaryOpFast<int16_t, __m256i, NEG_OP<int16_t>, NEG_OP_256i16>;
       case NPY_INT8:   return UnaryOpFast<int8_t, __m256i, NEG_OP<int8_t>, NEG_OP_256i8>;
       }
@@ -1714,7 +1714,7 @@ UNARY_FUNC_STRIDED GetUnaryOpFastStrided(int func, int numpyInType1, int numpyOu
       switch (numpyInType1) {
       case NPY_FLOAT:  return UnaryOpFastStrided<float, __m256, ABS_OP<float>, ABS_OP_256<__m256>>;
       //case NPY_DOUBLE: return UnaryOpFastStrided<double, __m256d, ABS_OP<double>, ABS_OP_256<__m256d>>;
-      //case NPY_INT32:  return UnaryOpFastStrided<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
+      //case NPY_INT:  return UnaryOpFastStrided<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
       //case NPY_INT16:  return UnaryOpFastStrided<int16_t, __m256i, ABS_OP<int16_t>, ABS_OP_256i16>;
       //case NPY_INT8:   return UnaryOpFastStrided<int8_t, __m256i, ABS_OP<int8_t>, ABS_OP_256i8>;
 

--- a/src/UnaryOps.cpp
+++ b/src/UnaryOps.cpp
@@ -1130,7 +1130,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
    case MATH_OPERATION::FABS:
       //*wantedOutType = NPY_DOUBLE;
       //switch (numpyInType1) {
-      //case NPY_INT32:  return UnaryOpSlow_FABS<int32_t>;
+      //CASE_NPY_INT32:  return UnaryOpSlow_FABS<int32_t>;
       //CASE_NPY_INT64:  return UnaryOpSlow_FABS<int64_t>;
       //case NPY_INT8:   return UnaryOpSlow_FABS<int8_t>;
       //case NPY_INT16:  return UnaryOpSlow_FABS<int16_t>;
@@ -1144,9 +1144,9 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_ABS<float>;
       case NPY_DOUBLE: return UnaryOpSlow_ABS<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_ABS<long double>;
-      case NPY_INT32:  return UnaryOpSlow_ABS<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return UnaryOpSlow_ABS<int32_t>;
+      CASE_NPY_INT64:
+      
          return UnaryOpSlow_ABS<int64_t>;
       case NPY_INT8:   return UnaryOpSlow_ABS<int8_t>;
       case NPY_INT16:  return UnaryOpSlow_ABS<int16_t>;
@@ -1160,9 +1160,9 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_FLOATSIGN<float>;
       case NPY_DOUBLE: return UnaryOpSlow_FLOATSIGN<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_FLOATSIGN<long double>;
-      case NPY_INT32:  return UnaryOpSlow_SIGN<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return UnaryOpSlow_SIGN<int32_t>;
+      CASE_NPY_INT64:
+      
          return UnaryOpSlow_SIGN<int64_t>;
       case NPY_INT8:   return UnaryOpSlow_SIGN<int8_t>;
       case NPY_INT16:  return UnaryOpSlow_SIGN<int16_t>;
@@ -1177,9 +1177,9 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_NEG<float>;
       case NPY_DOUBLE: return UnaryOpSlow_NEG<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_NEG<long double>;
-      case NPY_INT32:  return UnaryOpSlow_NEG<int32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return UnaryOpSlow_NEG<int32_t>;
+      CASE_NPY_INT64:
+      
            return UnaryOpSlow_NEG<int64_t>;
       case NPY_INT8:   return UnaryOpSlow_NEG<int8_t>;
       case NPY_INT16:  return UnaryOpSlow_NEG<int16_t>;
@@ -1198,12 +1198,12 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_BOOL:   return UnaryOpSlow_NOT<int8_t>;
          case NPY_INT16:
          case NPY_UINT16:   return UnaryOpSlow_NOT<int16_t>;
-         case NPY_INT32:
-         case NPY_UINT32:   return UnaryOpSlow_NOT<int32_t>;
-         case NPY_INT64:
-         case NPY_LONGLONG:
-         case NPY_UINT64:
-         case NPY_ULONGLONG:
+         CASE_NPY_INT32:
+         CASE_NPY_UINT32:   return UnaryOpSlow_NOT<int32_t>;
+         CASE_NPY_INT64:
+         
+         CASE_NPY_UINT64:
+         
             return UnaryOpSlow_NOT<int64_t>;
          case NPY_FLOAT:  return UnaryOpSlow_NOT<float>;
          case NPY_DOUBLE: return UnaryOpSlow_NOT<double>;
@@ -1216,13 +1216,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
    case MATH_OPERATION::INVERT:
       *wantedOutType = numpyInType1;
       switch (numpyInType1) {
-      case NPY_INT32:  return UnaryOpSlow_INVERT<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlow_INVERT<uint32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return UnaryOpSlow_INVERT<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlow_INVERT<uint32_t>;
+      CASE_NPY_INT64:
+      
            return UnaryOpSlow_INVERT<int64_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT64:
+      
            return UnaryOpSlow_INVERT<uint64_t>;
       case NPY_BOOL:   return UnaryOpSlow_INVERT_BOOL<int8_t>;
       case NPY_INT8:   return UnaryOpSlow_INVERT<int8_t>;
@@ -1240,13 +1240,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISFINITE<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISFINITE<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISFINITE<long double>;
-         case NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
-         case NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
-         case NPY_INT64:
-         case NPY_LONGLONG:
+         CASE_NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
+         CASE_NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
+         CASE_NPY_INT64:
+         
                return UnaryOpSlow_ISNOTINVALID<int64_t>;
-         case NPY_UINT64:
-         case NPY_ULONGLONG:
+         CASE_NPY_UINT64:
+         
               return UnaryOpSlow_ISNOTINVALID<uint64_t>;
          case NPY_BOOL:
          case NPY_INT8:       return UnaryOpSlow_ISNOTINVALID<int8_t>;
@@ -1267,13 +1267,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNOTFINITE<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNOTFINITE<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNOTFINITE<long double>;
-         case NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
-         case NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
-         case NPY_INT64:
-         case NPY_LONGLONG:
+         CASE_NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
+         CASE_NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
+         CASE_NPY_INT64:
+         
                return UnaryOpSlow_ISINVALID<int64_t>;
-         case NPY_UINT64:
-         case NPY_ULONGLONG:
+         CASE_NPY_UINT64:
+         
               return UnaryOpSlow_ISINVALID<uint64_t>;
          case NPY_BOOL:
          case NPY_INT8:       return UnaryOpSlow_ISINVALID<int8_t>;
@@ -1294,13 +1294,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNAN<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNAN<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNAN<long double>;
-         case NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
-         case NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
-         case NPY_INT64:
-         case NPY_LONGLONG:
+         CASE_NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
+         CASE_NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
+         CASE_NPY_INT64:
+         
                return UnaryOpSlow_ISINVALID<int64_t>;
-         case NPY_UINT64:
-         case NPY_ULONGLONG:
+         CASE_NPY_UINT64:
+         
               return UnaryOpSlow_ISINVALID<uint64_t>;
          case NPY_BOOL:
          case NPY_INT8:       return UnaryOpSlow_ISINVALID<int8_t>;
@@ -1322,13 +1322,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNANORZERO<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNANORZERO<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNANORZERO<long double>;
-         case NPY_INT32:      return UnaryOpSlow_ISINVALIDORZERO<int32_t>;
-         case NPY_UINT32:     return UnaryOpSlow_ISINVALIDORZERO<uint32_t>;
-         case NPY_INT64:
-         case NPY_LONGLONG:
+         CASE_NPY_INT32:      return UnaryOpSlow_ISINVALIDORZERO<int32_t>;
+         CASE_NPY_UINT32:     return UnaryOpSlow_ISINVALIDORZERO<uint32_t>;
+         CASE_NPY_INT64:
+         
                return UnaryOpSlow_ISINVALIDORZERO<int64_t>;
-         case NPY_UINT64:
-         case NPY_ULONGLONG:
+         CASE_NPY_UINT64:
+         
               return UnaryOpSlow_ISINVALIDORZERO<uint64_t>;
          case NPY_BOOL:
          case NPY_INT8:       return UnaryOpSlow_ISINVALIDORZERO<int8_t>;
@@ -1349,13 +1349,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNOTNAN<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNOTNAN<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNOTNAN<long double>;
-         case NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
-         case NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
-         case NPY_INT64:
-         case NPY_LONGLONG:
+         CASE_NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
+         CASE_NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
+         CASE_NPY_INT64:
+         
                return UnaryOpSlow_ISNOTINVALID<int64_t>;
-         case NPY_UINT64:
-         case NPY_ULONGLONG:
+         CASE_NPY_UINT64:
+         
               return UnaryOpSlow_ISNOTINVALID<uint64_t>;
          case NPY_BOOL:
          case NPY_INT8:       return UnaryOpSlow_ISNOTINVALID<int8_t>;
@@ -1452,13 +1452,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          *wantedOutType = NPY_LONGDOUBLE;
       }
       switch (numpyInType1) {
-      case NPY_INT32:  return UnaryOpSlowDouble_SQRT<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlowDouble_SQRT<uint32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return UnaryOpSlowDouble_SQRT<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlowDouble_SQRT<uint32_t>;
+      CASE_NPY_INT64:
+      
            return UnaryOpSlowDouble_SQRT<int64_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT64:
+      
            return UnaryOpSlowDouble_SQRT<int64_t>;
       case NPY_DOUBLE: return UnaryOpSlow_SQRT<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_SQRT<long double>;
@@ -1473,13 +1473,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          *wantedOutType = NPY_LONGDOUBLE;
       }
       switch (numpyInType1) {
-      case NPY_INT32:  return UnaryOpSlowDouble_CBRT<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlowDouble_CBRT<uint32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return UnaryOpSlowDouble_CBRT<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlowDouble_CBRT<uint32_t>;
+      CASE_NPY_INT64:
+      
            return UnaryOpSlowDouble_CBRT<int64_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT64:
+      
            return UnaryOpSlowDouble_CBRT<int64_t>;
       }
       break;
@@ -1496,13 +1496,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_LOG<float>;
       case NPY_DOUBLE: return UnaryOpSlow_LOG<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_LOG<long double>;
-      case NPY_INT32:  return UnaryOpSlowDouble_LOG<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlowDouble_LOG<uint32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return UnaryOpSlowDouble_LOG<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlowDouble_LOG<uint32_t>;
+      CASE_NPY_INT64:
+      
            return UnaryOpSlowDouble_LOG<int64_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT64:
+      
            return UnaryOpSlowDouble_LOG<int64_t>;
       }
       break;
@@ -1519,13 +1519,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_LOG10<float>;
       case NPY_DOUBLE: return UnaryOpSlow_LOG10<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_LOG10<long double>;
-      case NPY_INT32:  return UnaryOpSlowDouble_LOG10<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlowDouble_LOG10<uint32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return UnaryOpSlowDouble_LOG10<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlowDouble_LOG10<uint32_t>;
+      CASE_NPY_INT64:
+      
            return UnaryOpSlowDouble_LOG10<int64_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT64:
+      
            return UnaryOpSlowDouble_LOG10<int64_t>;
       }
       break;
@@ -1542,13 +1542,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_EXP<float>;
       case NPY_DOUBLE: return UnaryOpSlow_EXP<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_EXP<long double>;
-      case NPY_INT32:  return UnaryOpSlowDouble_EXP<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlowDouble_EXP<uint32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return UnaryOpSlowDouble_EXP<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlowDouble_EXP<uint32_t>;
+      CASE_NPY_INT64:
+      
            return UnaryOpSlowDouble_EXP<int64_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT64:
+      
            return UnaryOpSlowDouble_EXP<int64_t>;
       }
       break;
@@ -1565,13 +1565,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_EXP2<float>;
       case NPY_DOUBLE: return UnaryOpSlow_EXP2<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_EXP2<long double>;
-      case NPY_INT32:  return UnaryOpSlowDouble_EXP2<int32_t>;
-      case NPY_UINT32:  return UnaryOpSlowDouble_EXP2<uint32_t>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT32:  return UnaryOpSlowDouble_EXP2<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlowDouble_EXP2<uint32_t>;
+      CASE_NPY_INT64:
+      
            return UnaryOpSlowDouble_EXP2<int64_t>;
-      case NPY_UINT64:
-      case NPY_ULONGLONG:
+      CASE_NPY_UINT64:
+      
            return UnaryOpSlowDouble_EXP2<int64_t>;
       }
       break;
@@ -1582,7 +1582,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_SIGNBIT<float>;
       case NPY_DOUBLE: return UnaryOpSlow_SIGNBIT<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_SIGNBIT<long double>;
-      //case NPY_INT32:  return UnaryOpSlowDouble_SIGNBIT<int32_t>;
+      //CASE_NPY_INT32:  return UnaryOpSlowDouble_SIGNBIT<int32_t>;
       }
       break;
 
@@ -1604,7 +1604,7 @@ UNARY_FUNC GetUnaryOpFast(int func, int numpyInType1, int numpyOutType, int* wan
       switch (numpyInType1) {
       case NPY_FLOAT:  return UnaryOpFast<float, __m256, ABS_OP<float>, ABS_OP_256<__m256>>;
       case NPY_DOUBLE: return UnaryOpFast<double, __m256d, ABS_OP<double>, ABS_OP_256<__m256d>>;
-      case NPY_INT32:  return UnaryOpFast<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
+      CASE_NPY_INT32:  return UnaryOpFast<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
       case NPY_INT16:  return UnaryOpFast<int16_t, __m256i, ABS_OP<int16_t>, ABS_OP_256i16>;
       case NPY_INT8:   return UnaryOpFast<int8_t, __m256i,  ABS_OP<int8_t>, ABS_OP_256i8>;
       }
@@ -1646,10 +1646,10 @@ UNARY_FUNC GetUnaryOpFast(int func, int numpyInType1, int numpyOutType, int* wan
       switch (numpyInType1) {
       case NPY_FLOAT:  return UnaryOpFast<float, __m256, NEG_OP<float>, NEG_OP_256<__m256>>;
       case NPY_DOUBLE: return UnaryOpFast<double, __m256d, NEG_OP<double>, NEG_OP_256<__m256d>>;
-      case NPY_INT64:
-      case NPY_LONGLONG:
+      CASE_NPY_INT64:
+      
            return UnaryOpFast<int64_t, __m256i, NEG_OP<int64_t>, NEG_OP_256i64>;
-      case NPY_INT32:  return UnaryOpFast<int32_t, __m256i, NEG_OP<int32_t>, NEG_OP_256i32>;
+      CASE_NPY_INT32:  return UnaryOpFast<int32_t, __m256i, NEG_OP<int32_t>, NEG_OP_256i32>;
       case NPY_INT16:  return UnaryOpFast<int16_t, __m256i, NEG_OP<int16_t>, NEG_OP_256i16>;
       case NPY_INT8:   return UnaryOpFast<int8_t, __m256i, NEG_OP<int8_t>, NEG_OP_256i8>;
       }
@@ -1714,7 +1714,7 @@ UNARY_FUNC_STRIDED GetUnaryOpFastStrided(int func, int numpyInType1, int numpyOu
       switch (numpyInType1) {
       case NPY_FLOAT:  return UnaryOpFastStrided<float, __m256, ABS_OP<float>, ABS_OP_256<__m256>>;
       //case NPY_DOUBLE: return UnaryOpFastStrided<double, __m256d, ABS_OP<double>, ABS_OP_256<__m256d>>;
-      //case NPY_INT32:  return UnaryOpFastStrided<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
+      //CASE_NPY_INT32:  return UnaryOpFastStrided<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
       //case NPY_INT16:  return UnaryOpFastStrided<int16_t, __m256i, ABS_OP<int16_t>, ABS_OP_256i16>;
       //case NPY_INT8:   return UnaryOpFastStrided<int8_t, __m256i, ABS_OP<int8_t>, ABS_OP_256i8>;
 

--- a/src/UnaryOps.cpp
+++ b/src/UnaryOps.cpp
@@ -463,7 +463,7 @@ static inline void UnaryNanFastDouble(MathFunctionPtr MATH_OP, void* pDataIn, vo
          // Use 256 bit registers which hold 8 floats or 4 doubles
          U256 m0 = LOADU(pIn1_256++);
 
-         // A nan aware compare will return FALSE, since isnan(), invert 
+         // A nan aware compare will return false, since isnan(), invert 
          *pOut_i32++ = gBooleanLUT32Inverse[_mm256_movemask_pd(_mm256_cmp_pd(m0, m0, _CMP_EQ_OQ)) & 15];
       }
 
@@ -890,10 +890,10 @@ static void UnaryOpSlow_ISINVALID(void* pDataIn1, void* pDataOut, int64_t len, i
    // Slow loop, handle 1 at a time
    while (pOut != pLastOut) {
       if (*pIn == invalid) {
-         *pOut = TRUE;
+         *pOut = true;
       }
       else {
-         *pOut = FALSE;
+         *pOut = false;
       }
       pOut = STRIDE_NEXT(int8_t, pOut, strideOut);
       pIn = STRIDE_NEXT(T, pIn, strideIn);
@@ -910,10 +910,10 @@ static void UnaryOpSlow_ISINVALIDORZERO(void* pDataIn1, void* pDataOut, int64_t 
    // Slow loop, handle 1 at a time
    while (pOut != pLastOut) {
       if (*pIn == invalid || *pIn == 0) {
-         *pOut = TRUE;
+         *pOut = true;
       }
       else {
-         *pOut = FALSE;
+         *pOut = false;
       }
       pOut = STRIDE_NEXT(int8_t, pOut, strideOut);
       pIn = STRIDE_NEXT(T, pIn, strideIn);
@@ -930,10 +930,10 @@ static void UnaryOpSlow_ISNOTINVALID(void* pDataIn1, void* pDataOut, int64_t len
    // Slow loop, handle 1 at a time
    while (pOut != pLastOut) {
       if (*pIn == invalid) {
-         *pOut = FALSE;
+         *pOut = false;
       }
       else {
-         *pOut = TRUE;
+         *pOut = true;
       }
       pOut = STRIDE_NEXT(int8_t, pOut, strideOut);
       pIn = STRIDE_NEXT(T, pIn, strideIn);
@@ -1130,7 +1130,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
    case MATH_OPERATION::FABS:
       //*wantedOutType = NPY_DOUBLE;
       //switch (numpyInType1) {
-      //CASE_NPY_INT32:  return UnaryOpSlow_FABS<int32_t>;
+      //case NPY_INT32:  return UnaryOpSlow_FABS<int32_t>;
       //CASE_NPY_INT64:  return UnaryOpSlow_FABS<int64_t>;
       //case NPY_INT8:   return UnaryOpSlow_FABS<int8_t>;
       //case NPY_INT16:  return UnaryOpSlow_FABS<int16_t>;
@@ -1144,8 +1144,10 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_ABS<float>;
       case NPY_DOUBLE: return UnaryOpSlow_ABS<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_ABS<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlow_ABS<int32_t>;
-      CASE_NPY_INT64:  return UnaryOpSlow_ABS<int64_t>;
+      case NPY_INT32:  return UnaryOpSlow_ABS<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return UnaryOpSlow_ABS<int64_t>;
       case NPY_INT8:   return UnaryOpSlow_ABS<int8_t>;
       case NPY_INT16:  return UnaryOpSlow_ABS<int16_t>;
 
@@ -1158,8 +1160,10 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_FLOATSIGN<float>;
       case NPY_DOUBLE: return UnaryOpSlow_FLOATSIGN<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_FLOATSIGN<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlow_SIGN<int32_t>;
-      CASE_NPY_INT64:  return UnaryOpSlow_SIGN<int64_t>;
+      case NPY_INT32:  return UnaryOpSlow_SIGN<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+         return UnaryOpSlow_SIGN<int64_t>;
       case NPY_INT8:   return UnaryOpSlow_SIGN<int8_t>;
       case NPY_INT16:  return UnaryOpSlow_SIGN<int16_t>;
 
@@ -1173,8 +1177,10 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_NEG<float>;
       case NPY_DOUBLE: return UnaryOpSlow_NEG<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_NEG<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlow_NEG<int32_t>;
-      CASE_NPY_INT64:  return UnaryOpSlow_NEG<int64_t>;
+      case NPY_INT32:  return UnaryOpSlow_NEG<int32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return UnaryOpSlow_NEG<int64_t>;
       case NPY_INT8:   return UnaryOpSlow_NEG<int8_t>;
       case NPY_INT16:  return UnaryOpSlow_NEG<int16_t>;
 
@@ -1192,10 +1198,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_BOOL:   return UnaryOpSlow_NOT<int8_t>;
          case NPY_INT16:
          case NPY_UINT16:   return UnaryOpSlow_NOT<int16_t>;
-         CASE_NPY_INT32:
-         CASE_NPY_UINT32:   return UnaryOpSlow_NOT<int32_t>;
-         CASE_NPY_INT64:
-         CASE_NPY_UINT64:   return UnaryOpSlow_NOT<int64_t>;
+         case NPY_INT32:
+         case NPY_UINT32:   return UnaryOpSlow_NOT<int32_t>;
+         case NPY_INT64:
+         case NPY_LONGLONG:
+         case NPY_UINT64:
+         case NPY_ULONGLONG:
+            return UnaryOpSlow_NOT<int64_t>;
          case NPY_FLOAT:  return UnaryOpSlow_NOT<float>;
          case NPY_DOUBLE: return UnaryOpSlow_NOT<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_NOT<long double>;
@@ -1207,10 +1216,14 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
    case MATH_OPERATION::INVERT:
       *wantedOutType = numpyInType1;
       switch (numpyInType1) {
-      CASE_NPY_INT32:  return UnaryOpSlow_INVERT<int32_t>;
-      CASE_NPY_UINT32:  return UnaryOpSlow_INVERT<uint32_t>;
-      CASE_NPY_INT64:  return UnaryOpSlow_INVERT<int64_t>;
-      CASE_NPY_UINT64:  return UnaryOpSlow_INVERT<uint64_t>;
+      case NPY_INT32:  return UnaryOpSlow_INVERT<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlow_INVERT<uint32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return UnaryOpSlow_INVERT<int64_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+           return UnaryOpSlow_INVERT<uint64_t>;
       case NPY_BOOL:   return UnaryOpSlow_INVERT_BOOL<int8_t>;
       case NPY_INT8:   return UnaryOpSlow_INVERT<int8_t>;
       case NPY_UINT8:   return UnaryOpSlow_INVERT<uint8_t>;
@@ -1227,10 +1240,14 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISFINITE<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISFINITE<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISFINITE<long double>;
-         CASE_NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
-         CASE_NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
-         CASE_NPY_INT64:      return UnaryOpSlow_ISNOTINVALID<int64_t>;
-         CASE_NPY_UINT64:     return UnaryOpSlow_ISNOTINVALID<uint64_t>;
+         case NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
+         case NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
+         case NPY_INT64:
+         case NPY_LONGLONG:
+               return UnaryOpSlow_ISNOTINVALID<int64_t>;
+         case NPY_UINT64:
+         case NPY_ULONGLONG:
+              return UnaryOpSlow_ISNOTINVALID<uint64_t>;
          case NPY_BOOL:
          case NPY_INT8:       return UnaryOpSlow_ISNOTINVALID<int8_t>;
          case NPY_UINT8:      return UnaryOpSlow_ISNOTINVALID<uint8_t>;
@@ -1250,10 +1267,14 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNOTFINITE<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNOTFINITE<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNOTFINITE<long double>;
-         CASE_NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
-         CASE_NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
-         CASE_NPY_INT64:      return UnaryOpSlow_ISINVALID<int64_t>;
-         CASE_NPY_UINT64:     return UnaryOpSlow_ISINVALID<uint64_t>;
+         case NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
+         case NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
+         case NPY_INT64:
+         case NPY_LONGLONG:
+               return UnaryOpSlow_ISINVALID<int64_t>;
+         case NPY_UINT64:
+         case NPY_ULONGLONG:
+              return UnaryOpSlow_ISINVALID<uint64_t>;
          case NPY_BOOL:
          case NPY_INT8:       return UnaryOpSlow_ISINVALID<int8_t>;
          case NPY_UINT8:      return UnaryOpSlow_ISINVALID<uint8_t>;
@@ -1273,10 +1294,14 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNAN<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNAN<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNAN<long double>;
-         CASE_NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
-         CASE_NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
-         CASE_NPY_INT64:      return UnaryOpSlow_ISINVALID<int64_t>;
-         CASE_NPY_UINT64:     return UnaryOpSlow_ISINVALID<uint64_t>;
+         case NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
+         case NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
+         case NPY_INT64:
+         case NPY_LONGLONG:
+               return UnaryOpSlow_ISINVALID<int64_t>;
+         case NPY_UINT64:
+         case NPY_ULONGLONG:
+              return UnaryOpSlow_ISINVALID<uint64_t>;
          case NPY_BOOL:
          case NPY_INT8:       return UnaryOpSlow_ISINVALID<int8_t>;
          case NPY_UINT8:      return UnaryOpSlow_ISINVALID<uint8_t>;
@@ -1297,10 +1322,14 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNANORZERO<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNANORZERO<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNANORZERO<long double>;
-         CASE_NPY_INT32:      return UnaryOpSlow_ISINVALIDORZERO<int32_t>;
-         CASE_NPY_UINT32:     return UnaryOpSlow_ISINVALIDORZERO<uint32_t>;
-         CASE_NPY_INT64:      return UnaryOpSlow_ISINVALIDORZERO<int64_t>;
-         CASE_NPY_UINT64:     return UnaryOpSlow_ISINVALIDORZERO<uint64_t>;
+         case NPY_INT32:      return UnaryOpSlow_ISINVALIDORZERO<int32_t>;
+         case NPY_UINT32:     return UnaryOpSlow_ISINVALIDORZERO<uint32_t>;
+         case NPY_INT64:
+         case NPY_LONGLONG:
+               return UnaryOpSlow_ISINVALIDORZERO<int64_t>;
+         case NPY_UINT64:
+         case NPY_ULONGLONG:
+              return UnaryOpSlow_ISINVALIDORZERO<uint64_t>;
          case NPY_BOOL:
          case NPY_INT8:       return UnaryOpSlow_ISINVALIDORZERO<int8_t>;
          case NPY_UINT8:      return UnaryOpSlow_ISINVALIDORZERO<uint8_t>;
@@ -1320,10 +1349,14 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNOTNAN<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNOTNAN<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNOTNAN<long double>;
-         CASE_NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
-         CASE_NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
-         CASE_NPY_INT64:      return UnaryOpSlow_ISNOTINVALID<int64_t>;
-         CASE_NPY_UINT64:     return UnaryOpSlow_ISNOTINVALID<uint64_t>;
+         case NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
+         case NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
+         case NPY_INT64:
+         case NPY_LONGLONG:
+               return UnaryOpSlow_ISNOTINVALID<int64_t>;
+         case NPY_UINT64:
+         case NPY_ULONGLONG:
+              return UnaryOpSlow_ISNOTINVALID<uint64_t>;
          case NPY_BOOL:
          case NPY_INT8:       return UnaryOpSlow_ISNOTINVALID<int8_t>;
          case NPY_UINT8:      return UnaryOpSlow_ISNOTINVALID<uint8_t>;
@@ -1419,10 +1452,14 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          *wantedOutType = NPY_LONGDOUBLE;
       }
       switch (numpyInType1) {
-      CASE_NPY_INT32:  return UnaryOpSlowDouble_SQRT<int32_t>;
-      CASE_NPY_UINT32:  return UnaryOpSlowDouble_SQRT<uint32_t>;
-      CASE_NPY_INT64:  return UnaryOpSlowDouble_SQRT<int64_t>;
-      CASE_NPY_UINT64:  return UnaryOpSlowDouble_SQRT<int64_t>;
+      case NPY_INT32:  return UnaryOpSlowDouble_SQRT<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlowDouble_SQRT<uint32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return UnaryOpSlowDouble_SQRT<int64_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+           return UnaryOpSlowDouble_SQRT<int64_t>;
       case NPY_DOUBLE: return UnaryOpSlow_SQRT<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_SQRT<long double>;
       }
@@ -1436,10 +1473,14 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          *wantedOutType = NPY_LONGDOUBLE;
       }
       switch (numpyInType1) {
-      CASE_NPY_INT32:  return UnaryOpSlowDouble_CBRT<int32_t>;
-      CASE_NPY_UINT32:  return UnaryOpSlowDouble_CBRT<uint32_t>;
-      CASE_NPY_INT64:  return UnaryOpSlowDouble_CBRT<int64_t>;
-      CASE_NPY_UINT64:  return UnaryOpSlowDouble_CBRT<int64_t>;
+      case NPY_INT32:  return UnaryOpSlowDouble_CBRT<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlowDouble_CBRT<uint32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return UnaryOpSlowDouble_CBRT<int64_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+           return UnaryOpSlowDouble_CBRT<int64_t>;
       }
       break;
 
@@ -1455,10 +1496,14 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_LOG<float>;
       case NPY_DOUBLE: return UnaryOpSlow_LOG<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_LOG<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlowDouble_LOG<int32_t>;
-      CASE_NPY_UINT32:  return UnaryOpSlowDouble_LOG<uint32_t>;
-      CASE_NPY_INT64:  return UnaryOpSlowDouble_LOG<int64_t>;
-      CASE_NPY_UINT64:  return UnaryOpSlowDouble_LOG<int64_t>;
+      case NPY_INT32:  return UnaryOpSlowDouble_LOG<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlowDouble_LOG<uint32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return UnaryOpSlowDouble_LOG<int64_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+           return UnaryOpSlowDouble_LOG<int64_t>;
       }
       break;
    
@@ -1474,10 +1519,14 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_LOG10<float>;
       case NPY_DOUBLE: return UnaryOpSlow_LOG10<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_LOG10<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlowDouble_LOG10<int32_t>;
-      CASE_NPY_UINT32:  return UnaryOpSlowDouble_LOG10<uint32_t>;
-      CASE_NPY_INT64:  return UnaryOpSlowDouble_LOG10<int64_t>;
-      CASE_NPY_UINT64:  return UnaryOpSlowDouble_LOG10<int64_t>;
+      case NPY_INT32:  return UnaryOpSlowDouble_LOG10<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlowDouble_LOG10<uint32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return UnaryOpSlowDouble_LOG10<int64_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+           return UnaryOpSlowDouble_LOG10<int64_t>;
       }
       break;
 
@@ -1493,10 +1542,14 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_EXP<float>;
       case NPY_DOUBLE: return UnaryOpSlow_EXP<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_EXP<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlowDouble_EXP<int32_t>;
-      CASE_NPY_UINT32:  return UnaryOpSlowDouble_EXP<uint32_t>;
-      CASE_NPY_INT64:  return UnaryOpSlowDouble_EXP<int64_t>;
-      CASE_NPY_UINT64:  return UnaryOpSlowDouble_EXP<int64_t>;
+      case NPY_INT32:  return UnaryOpSlowDouble_EXP<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlowDouble_EXP<uint32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return UnaryOpSlowDouble_EXP<int64_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+           return UnaryOpSlowDouble_EXP<int64_t>;
       }
       break;
 
@@ -1512,10 +1565,14 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_EXP2<float>;
       case NPY_DOUBLE: return UnaryOpSlow_EXP2<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_EXP2<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlowDouble_EXP2<int32_t>;
-      CASE_NPY_UINT32:  return UnaryOpSlowDouble_EXP2<uint32_t>;
-      CASE_NPY_INT64:  return UnaryOpSlowDouble_EXP2<int64_t>;
-      CASE_NPY_UINT64:  return UnaryOpSlowDouble_EXP2<int64_t>;
+      case NPY_INT32:  return UnaryOpSlowDouble_EXP2<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlowDouble_EXP2<uint32_t>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return UnaryOpSlowDouble_EXP2<int64_t>;
+      case NPY_UINT64:
+      case NPY_ULONGLONG:
+           return UnaryOpSlowDouble_EXP2<int64_t>;
       }
       break;
 
@@ -1525,7 +1582,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_SIGNBIT<float>;
       case NPY_DOUBLE: return UnaryOpSlow_SIGNBIT<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_SIGNBIT<long double>;
-      //CASE_NPY_INT32:  return UnaryOpSlowDouble_SIGNBIT<int32_t>;
+      //case NPY_INT32:  return UnaryOpSlowDouble_SIGNBIT<int32_t>;
       }
       break;
 
@@ -1547,7 +1604,7 @@ UNARY_FUNC GetUnaryOpFast(int func, int numpyInType1, int numpyOutType, int* wan
       switch (numpyInType1) {
       case NPY_FLOAT:  return UnaryOpFast<float, __m256, ABS_OP<float>, ABS_OP_256<__m256>>;
       case NPY_DOUBLE: return UnaryOpFast<double, __m256d, ABS_OP<double>, ABS_OP_256<__m256d>>;
-      CASE_NPY_INT32:  return UnaryOpFast<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
+      case NPY_INT32:  return UnaryOpFast<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
       case NPY_INT16:  return UnaryOpFast<int16_t, __m256i, ABS_OP<int16_t>, ABS_OP_256i16>;
       case NPY_INT8:   return UnaryOpFast<int8_t, __m256i,  ABS_OP<int8_t>, ABS_OP_256i8>;
       }
@@ -1589,8 +1646,10 @@ UNARY_FUNC GetUnaryOpFast(int func, int numpyInType1, int numpyOutType, int* wan
       switch (numpyInType1) {
       case NPY_FLOAT:  return UnaryOpFast<float, __m256, NEG_OP<float>, NEG_OP_256<__m256>>;
       case NPY_DOUBLE: return UnaryOpFast<double, __m256d, NEG_OP<double>, NEG_OP_256<__m256d>>;
-      CASE_NPY_INT64:  return UnaryOpFast<int64_t, __m256i, NEG_OP<int64_t>, NEG_OP_256i64>;
-      CASE_NPY_INT32:  return UnaryOpFast<int32_t, __m256i, NEG_OP<int32_t>, NEG_OP_256i32>;
+      case NPY_INT64:
+      case NPY_LONGLONG:
+           return UnaryOpFast<int64_t, __m256i, NEG_OP<int64_t>, NEG_OP_256i64>;
+      case NPY_INT32:  return UnaryOpFast<int32_t, __m256i, NEG_OP<int32_t>, NEG_OP_256i32>;
       case NPY_INT16:  return UnaryOpFast<int16_t, __m256i, NEG_OP<int16_t>, NEG_OP_256i16>;
       case NPY_INT8:   return UnaryOpFast<int8_t, __m256i, NEG_OP<int8_t>, NEG_OP_256i8>;
       }
@@ -1655,7 +1714,7 @@ UNARY_FUNC_STRIDED GetUnaryOpFastStrided(int func, int numpyInType1, int numpyOu
       switch (numpyInType1) {
       case NPY_FLOAT:  return UnaryOpFastStrided<float, __m256, ABS_OP<float>, ABS_OP_256<__m256>>;
       //case NPY_DOUBLE: return UnaryOpFastStrided<double, __m256d, ABS_OP<double>, ABS_OP_256<__m256d>>;
-      //CASE_NPY_INT32:  return UnaryOpFastStrided<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
+      //case NPY_INT32:  return UnaryOpFastStrided<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
       //case NPY_INT16:  return UnaryOpFastStrided<int16_t, __m256i, ABS_OP<int16_t>, ABS_OP_256i16>;
       //case NPY_INT8:   return UnaryOpFastStrided<int8_t, __m256i, ABS_OP<int8_t>, ABS_OP_256i8>;
 
@@ -1699,7 +1758,7 @@ static UNARY_FUNC_STRIDED CheckMathOpOneInputStrided(int func, int numpyInType1,
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
 static bool UnaryThreadCallbackStrided(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
-   bool didSomeWork = FALSE;
+   bool didSomeWork = false;
    UNARY_CALLBACK* Callback = (UNARY_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    char* pDataIn = (char *)Callback->pDataIn;
@@ -1717,7 +1776,7 @@ static bool UnaryThreadCallbackStrided(struct stMATH_WORKER_ITEM* pstWorkerItem,
       Callback->pUnaryCallbackStrided(pDataIn + inputAdj, pDataOut + outputAdj, lenX, Callback->itemSizeIn, Callback->itemSizeOut);
 
       // Indicate we completed a block
-      didSomeWork = TRUE;
+      didSomeWork = true;
 
       // tell others we completed this work block
       pstWorkerItem->CompleteWorkBlock();

--- a/src/UnaryOps.cpp
+++ b/src/UnaryOps.cpp
@@ -46,7 +46,7 @@ static const inline void STOREA(__m256i* x, __m256i y) { _mm256_store_si256((__m
 SFW_ALIGN(64)
 const union
 {
-   INT32 i[8];
+   int32_t i[8];
    float f[8];
    __m256 m;
 } __f32vec8_abs_mask = { 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff, 0x7fffffff };
@@ -55,7 +55,7 @@ const union
 SFW_ALIGN(64)
 const union
 {
-   INT64  i[4];
+   int64_t  i[4];
    double d[4];
    __m256d m;
 } __f64vec4_abs_mask = { 0x7fffffffffffffff, 0x7fffffffffffffff, 0x7fffffffffffffff, 0x7fffffffffffffff };
@@ -64,7 +64,7 @@ const union
 SFW_ALIGN(64)
 const union
 {
-   INT32 i[8];
+   int32_t i[8];
    float f[8];
    __m256 m;
    // all 1 bits in exponent must be 1 (8 bits after sign)
@@ -75,7 +75,7 @@ const union
 SFW_ALIGN(64)
 const union
 {
-   INT32 i[8];
+   int32_t i[8];
    float f[8];
    __m256 m;
    // all 1 bits in exponent must be 1 (8 bits after sign)
@@ -85,7 +85,7 @@ const union
 SFW_ALIGN(64)
 const union
 {
-   INT32 i[8];
+   int32_t i[8];
    float f[8];
    __m256 m;
    // all 1 bits in exponent must be 1 (8 bits after sign)
@@ -96,7 +96,7 @@ const union
 SFW_ALIGN(64)
 const union
 {
-   INT64  i[4];
+   int64_t  i[4];
    double d[4];
    __m256d m;
    // all 1 bits in exponent must be 1 (11 bits after sign)
@@ -106,7 +106,7 @@ const union
 SFW_ALIGN(64)
 const union
 {
-   INT64  i[4];
+   int64_t  i[4];
    double d[4];
    __m256d m;
    // all 1 bits in exponent must be 1 (11 bits after sign)
@@ -116,7 +116,7 @@ const union
 SFW_ALIGN(64)
 const union
 {
-   INT64  i[4];
+   int64_t  i[4];
    double d[4];
    __m256d m;
    // all 1 bits in exponent must be 1 (11 bits after sign)
@@ -127,7 +127,7 @@ const union
 SFW_ALIGN(64)
 const union
 {
-   INT32 i[8];
+   int32_t i[8];
    __m256i m;
 } __vec8_strides = { 0, 1, 2, 3, 4, 5, 6, 7};
 
@@ -135,18 +135,18 @@ const union
 SFW_ALIGN(64)
 const union
 {
-   INT64 i[8];
+   int64_t i[8];
    __m256i m;
 } __vec4_strides = { 0, 1, 2, 3 };
 
 //// IEEE Mask
 //// NOTE: Check NAN mask -- if not then return number, else return 0.0 or +INF or -INF
 //// For IEEE 754, MSB is the sign bit, then next section is the exponent.  If the exponent is all 1111s, it is some kind of NAN
-//#define NAN_TO_NUM_F32(x) ((((*(UINT32*)&x)  & 0x7f800000) != 0x7f800000) ?  x :  (((*(UINT32*)&x)  & 0x007fffff) != 0) ?  0.0f : (((*(UINT32*)&x)  & 0x80000000) == 0) ?  FLT_MAX : -FLT_MAX)
-//#define NAN_TO_NUM_F64(x) ((((*(UINT64*)&x)  & 0x7ff0000000000000) != 0x7ff0000000000000) ?  x :  (((*(UINT64*)&x)  & 0x000fffffffffffff) != 0) ? 0.0 : (((*(UINT64*)&x)  & 0x8000000000000000) == 0) ?  DBL_MAX : -DBL_MAX )
+//#define NAN_TO_NUM_F32(x) ((((*(uint32_t*)&x)  & 0x7f800000) != 0x7f800000) ?  x :  (((*(uint32_t*)&x)  & 0x007fffff) != 0) ?  0.0f : (((*(uint32_t*)&x)  & 0x80000000) == 0) ?  FLT_MAX : -FLT_MAX)
+//#define NAN_TO_NUM_F64(x) ((((*(uint64_t*)&x)  & 0x7ff0000000000000) != 0x7ff0000000000000) ?  x :  (((*(uint64_t*)&x)  & 0x000fffffffffffff) != 0) ? 0.0 : (((*(uint64_t*)&x)  & 0x8000000000000000) == 0) ?  DBL_MAX : -DBL_MAX )
 //
-//#define NAN_TO_ZERO_F32(x) ((((*(UINT32*)&x)  & 0x7f800000) != 0x7f800000) ?  x :   0.0f )
-//#define NAN_TO_ZERO_F64(x) ((((*(UINT64*)&x)  & 0x7ff0000000000000) != 0x7ff0000000000000) ?  x : 0.0 )
+//#define NAN_TO_ZERO_F32(x) ((((*(uint32_t*)&x)  & 0x7f800000) != 0x7f800000) ?  x :   0.0f )
+//#define NAN_TO_ZERO_F64(x) ((((*(uint64_t*)&x)  & 0x7ff0000000000000) != 0x7ff0000000000000) ?  x : 0.0 )
 //
 
 
@@ -162,7 +162,7 @@ template<typename T> static const inline T FLOATSIGN_OP(T x) { return x > (T)(0.
 template<typename T> static const inline T NEG_OP(T x) { return -x; }
 template<typename T> static const inline T BITWISE_NOT_OP(T x) { return ~x; }
 template<typename T> static const inline T INVERT_OP(T x) { return ~x; }
-template<typename T> static const inline T INVERT_OP_BOOL(INT8 x) { return x ^ 1; }
+template<typename T> static const inline T INVERT_OP_BOOL(int8_t x) { return x ^ 1; }
 
 template<typename T> static const inline bool NOT_OP(T x) { return (bool)(x==(T)0); }
 
@@ -293,21 +293,21 @@ template<typename T> static const inline __m256d SQRT_OP_256(__m256d x) { return
 // T = data type as input
 // MathOp operation to perform
 template<typename T, typename U256, const T MATH_OP(T), const U256 MATH_OP256(U256)>
-static inline void UnaryOpFast(void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static inline void UnaryOpFast(void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    
    T* pIn = (T*)pDataIn;
    T* pOut = (T*)pDataOut;
    T* pLastOut = (T*)((char*)pOut + (strideOut*len));
 
-   INT64 chunkSize = sizeof(U256) / sizeof(T);
+   int64_t chunkSize = sizeof(U256) / sizeof(T);
    LOGGING("unary op fast strides %lld %lld   sizeof: %lld\n", strideIn, strideOut, sizeof(T));
    if (sizeof(T) == strideOut && sizeof(T) == strideIn && len >= chunkSize) {
 
       // possible to align 32 bit boundary?
-      //if (((INT64)pDataOut & 31) != 0) {
-      //   INT64 babylen = (32 - ((INT64)pDataOut & 31)) / sizeof(T);
+      //if (((int64_t)pDataOut & 31) != 0) {
+      //   int64_t babylen = (32 - ((int64_t)pDataOut & 31)) / sizeof(T);
       //   if (babylen > len) babylen = len;
-      //   for (INT64 i = 0; i < babylen; i++) {
+      //   for (int64_t i = 0; i < babylen; i++) {
       //      *pOut++ = MATH_OP(*pIn++);
       //   }
       //   len -= babylen;
@@ -347,25 +347,25 @@ static inline void UnaryOpFast(void* pDataIn, void* pDataOut, INT64 len, INT64 s
 // T = data type as input
 // MathOp operation to perform
 template<typename T, typename U256, const T MATH_OP(T), const U256 MATH_OP256(U256)>
-static inline void UnaryOpFastStrided(void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static inline void UnaryOpFastStrided(void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
    T* pIn = (T*)pDataIn;
    T* pOut = (T*)pDataOut;
    T* pLastOut = (T*)((char*)pOut + (strideOut*len));
 
-   INT64 chunkSize = (sizeof(U256)) / sizeof(T);
+   int64_t chunkSize = (sizeof(U256)) / sizeof(T);
 
    // TOOD: ensure stride*len < 2billion
    // assumes output not strided
    if (sizeof(T) == strideOut && sizeof(T) == strideIn && len >= chunkSize) {
-      const INT64 innerloopLen = chunkSize * (len / chunkSize);
+      const int64_t innerloopLen = chunkSize * (len / chunkSize);
       T* pEnd = &pOut[innerloopLen];
       U256* pEnd_256 = (U256*)pEnd;
 
       U256* pIn1_256 = (U256*)pIn;
       U256* pOut_256 = (U256*)pOut;
 
-      INT32 babyStride = (INT32)strideIn;
+      int32_t babyStride = (int32_t)strideIn;
       // add 8 strides everytime we process 8
       __m256i mindex = _mm256_mullo_epi32(_mm256_set1_epi32(babyStride), __vec8_strides.m );
 
@@ -400,20 +400,20 @@ static inline void UnaryOpFastStrided(void* pDataIn, void* pDataOut, INT64 len, 
 // T = data type as input
 // MathOp operation to perform
 template<typename T, typename U256, typename MathFunctionPtr>
-static inline void UnaryNanFastFloat(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static inline void UnaryNanFastFloat(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
    T* pIn = (T*)pDataIn;
    bool* pOut = (bool*)pDataOut;
    bool* pLastOut = (bool*)((char*)pOut + (strideOut*len));
 
-   INT64 chunkSize = sizeof(U256) / sizeof(T);
+   int64_t chunkSize = sizeof(U256) / sizeof(T);
 
    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize) {
       bool* pEnd = &pOut[chunkSize * (len / chunkSize)];
-      INT64* pEnd_i64 = (INT64*)pEnd;
+      int64_t* pEnd_i64 = (int64_t*)pEnd;
 
       U256* pIn1_256 = (U256*)pDataIn;
-      INT64* pOut_i64 = (INT64*)pDataOut;
+      int64_t* pOut_i64 = (int64_t*)pDataOut;
 
       while (pOut_i64 < pEnd_i64) {
          //// Use 256 bit registers which hold 8 floats or 4 doubles
@@ -445,19 +445,19 @@ static inline void UnaryNanFastFloat(MathFunctionPtr MATH_OP, void* pDataIn, voi
 // T = data type as input
 // MathOp operation to perform
 template<typename T, typename U256, typename MathFunctionPtr>
-static inline void UnaryNanFastDouble(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static inline void UnaryNanFastDouble(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
    T* pIn = (T*)pDataIn;
    bool* pOut = (bool*)pDataOut;
    bool* pLastOut = (bool*)((char*)pOut + (strideOut*len));
 
-   INT64 chunkSize = sizeof(U256) / sizeof(T);
+   int64_t chunkSize = sizeof(U256) / sizeof(T);
    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize) {
       bool* pEnd = &pOut[chunkSize * (len / chunkSize)];
-      INT32* pEnd_i32 = (INT32*)pEnd;
+      int32_t* pEnd_i32 = (int32_t*)pEnd;
 
       U256* pIn1_256 = (U256*)pDataIn;
-      INT32* pOut_i32 = (INT32*)pDataOut;
+      int32_t* pOut_i32 = (int32_t*)pDataOut;
 
       while (pOut_i32 < pEnd_i32) {
          // Use 256 bit registers which hold 8 floats or 4 doubles
@@ -485,20 +485,20 @@ static inline void UnaryNanFastDouble(MathFunctionPtr MATH_OP, void* pDataIn, vo
 // T = data type as input
 // MathOp operation to perform
 template<typename T, typename U256, typename MathFunctionPtr>
-static inline void UnaryNotNanFastFloat(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static inline void UnaryNotNanFastFloat(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
    T* pIn = (T*)pDataIn;
    bool* pOut = (bool*)pDataOut;
    bool* pLastOut = (bool*)((char*)pOut + (strideOut*len));
 
-   INT64 chunkSize = sizeof(U256) / sizeof(T);
+   int64_t chunkSize = sizeof(U256) / sizeof(T);
 
    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize) {
       bool* pEnd = &pOut[chunkSize * (len / chunkSize)];
-      INT64* pEnd_i64 = (INT64*)pEnd;
+      int64_t* pEnd_i64 = (int64_t*)pEnd;
 
       U256* pIn1_256 = (U256*)pDataIn;
-      INT64* pOut_i64 = (INT64*)pDataOut;
+      int64_t* pOut_i64 = (int64_t*)pDataOut;
 
       while (pOut_i64 < pEnd_i64) {
          U256 m0 = LOADU(pIn1_256);
@@ -527,20 +527,20 @@ static inline void UnaryNotNanFastFloat(MathFunctionPtr MATH_OP, void* pDataIn, 
 // T = data type as input
 // MathOp operation to perform
 template<typename T, typename U256, typename MathFunctionPtr>
-static inline void UnaryNotNanFastDouble(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static inline void UnaryNotNanFastDouble(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
    T* pIn = (T*)pDataIn;
    bool* pOut = (bool*)pDataOut;
    bool* pLastOut = (bool*)((char*)pOut + (strideOut*len));
 
-   INT64 chunkSize = sizeof(U256) / sizeof(T);
+   int64_t chunkSize = sizeof(U256) / sizeof(T);
 
    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize) {
       bool* pEnd = &pOut[chunkSize * (len / chunkSize)];
-      INT32* pEnd_i32 = (INT32*)pEnd;
+      int32_t* pEnd_i32 = (int32_t*)pEnd;
 
       U256* pIn1_256 = (U256*)pDataIn;
-      INT32* pOut_i32 = (INT32*)pDataOut;
+      int32_t* pOut_i32 = (int32_t*)pDataOut;
 
       while (pOut_i32 < pEnd_i32) {
          U256 m0 = LOADU(pIn1_256);
@@ -568,20 +568,20 @@ static inline void UnaryNotNanFastDouble(MathFunctionPtr MATH_OP, void* pDataIn,
 // T = data type as input
 // MathOp operation to perform
 template<typename T, typename U256, typename MathFunctionPtr>
-static inline void UnaryFiniteFastFloat(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static inline void UnaryFiniteFastFloat(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
    T* pIn = (T*)pDataIn;
    bool* pOut = (bool*)pDataOut;
    bool* pLastOut = (bool*)((char*)pOut + (strideOut*len));
 
-   INT64 chunkSize = sizeof(U256) / sizeof(T);
+   int64_t chunkSize = sizeof(U256) / sizeof(T);
 
    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize) {
       bool* pEnd = &pOut[chunkSize * (len / chunkSize)];
-      INT64* pEnd_i64 = (INT64*)pEnd;
+      int64_t* pEnd_i64 = (int64_t*)pEnd;
 
       U256* pIn1_256 = (U256*)pDataIn;
-      INT64* pOut_i64 = (INT64*)pDataOut;
+      int64_t* pOut_i64 = (int64_t*)pDataOut;
 
       // finite_comp 0x7f800000
       const __m256 m_finitecomp = _mm256_load_ps(__f32vec8_finite_compare.f);
@@ -590,7 +590,7 @@ static inline void UnaryFiniteFastFloat(MathFunctionPtr MATH_OP, void* pDataIn, 
          U256 m0 = LOADU(pIn1_256);
          pIn1_256++;
 
-         INT32 bitmask = _mm256_movemask_ps(
+         int32_t bitmask = _mm256_movemask_ps(
             _mm256_cmp_ps(m_finitecomp,
                _mm256_and_ps(m0, m_finitecomp), _CMP_NEQ_OQ));
 
@@ -615,19 +615,19 @@ static inline void UnaryFiniteFastFloat(MathFunctionPtr MATH_OP, void* pDataIn, 
 // T = data type as input
 // MathOp operation to perform
 template<typename T, typename U256, typename MathFunctionPtr>
-static inline void UnaryFiniteFastDouble(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static inline void UnaryFiniteFastDouble(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
    T* pIn = (T*)pDataIn;
    bool* pOut = (bool*)pDataOut;
    bool* pLastOut = (bool*)((char*)pOut + (strideOut*len));
 
-   INT64 chunkSize = sizeof(U256) / sizeof(T);
+   int64_t chunkSize = sizeof(U256) / sizeof(T);
    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize) {
       bool* pEnd = &pOut[chunkSize * (len / chunkSize)];
-      INT32* pEnd_i32 = (INT32*)pEnd;
+      int32_t* pEnd_i32 = (int32_t*)pEnd;
 
       U256* pIn1_256 = (U256*)pDataIn;
-      INT32* pOut_i32 = (INT32*)pDataOut;
+      int32_t* pOut_i32 = (int32_t*)pDataOut;
 
       const __m256d m_finitecomp = _mm256_load_pd(__f64vec4_finite_compare.d);
 
@@ -635,7 +635,7 @@ static inline void UnaryFiniteFastDouble(MathFunctionPtr MATH_OP, void* pDataIn,
          U256 m0 = LOADU(pIn1_256);
          pIn1_256++;
 
-         INT32 bitmask = _mm256_movemask_pd(
+         int32_t bitmask = _mm256_movemask_pd(
             _mm256_cmp_pd(m_finitecomp,
                _mm256_and_pd(m0, m_finitecomp), _CMP_NEQ_OQ));
 
@@ -660,20 +660,20 @@ static inline void UnaryFiniteFastDouble(MathFunctionPtr MATH_OP, void* pDataIn,
 // T = data type as input
 // MathOp operation to perform
 template<typename T, typename U256, typename MathFunctionPtr>
-static inline void UnaryNotFiniteFastFloat(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static inline void UnaryNotFiniteFastFloat(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
    T* pIn = (T*)pDataIn;
    bool* pOut = (bool*)pDataOut;
    bool* pLastOut = (bool*)((char*)pOut + (strideOut*len));
 
-   INT64 chunkSize = sizeof(U256) / sizeof(T);
+   int64_t chunkSize = sizeof(U256) / sizeof(T);
 
    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize) {
       bool* pEnd = &pOut[chunkSize * (len / chunkSize)];
-      INT64* pEnd_i64 = (INT64*)pEnd;
+      int64_t* pEnd_i64 = (int64_t*)pEnd;
 
       U256* pIn1_256 = (U256*)pDataIn;
-      INT64* pOut_i64 = (INT64*)pDataOut;
+      int64_t* pOut_i64 = (int64_t*)pDataOut;
 
       // finite_comp 0x7f800000
       const __m256 m_finitecomp = _mm256_load_ps(__f32vec8_finite_compare.f);
@@ -682,7 +682,7 @@ static inline void UnaryNotFiniteFastFloat(MathFunctionPtr MATH_OP, void* pDataI
          U256 m0 = LOADU(pIn1_256);
          pIn1_256++;
 
-         INT32 bitmask = _mm256_movemask_ps(
+         int32_t bitmask = _mm256_movemask_ps(
             _mm256_cmp_ps(m_finitecomp,
                _mm256_and_ps(m0, m_finitecomp), _CMP_EQ_OQ));
 
@@ -707,20 +707,20 @@ static inline void UnaryNotFiniteFastFloat(MathFunctionPtr MATH_OP, void* pDataI
 // T = data type as input
 // MathOp operation to perform
 template<typename T, typename U256, typename MathFunctionPtr>
-static inline void UnaryNotFiniteFastDouble(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static inline void UnaryNotFiniteFastDouble(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
    T* pIn = (T*)pDataIn;
    bool* pOut = (bool*)pDataOut;
    bool* pLastOut = (bool*)((char*)pOut + (strideOut*len));
 
-   INT64 chunkSize = sizeof(U256) / sizeof(T);
+   int64_t chunkSize = sizeof(U256) / sizeof(T);
 
    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize) {
       bool* pEnd = &pOut[chunkSize * (len / chunkSize)];
-      INT32* pEnd_i32 = (INT32*)pEnd;
+      int32_t* pEnd_i32 = (int32_t*)pEnd;
 
       U256* pIn1_256 = (U256*)pDataIn;
-      INT32* pOut_i32 = (INT32*)pDataOut;
+      int32_t* pOut_i32 = (int32_t*)pDataOut;
 
       const __m256d m_finitecomp = _mm256_load_pd(__f64vec4_finite_compare.d);
 
@@ -729,7 +729,7 @@ static inline void UnaryNotFiniteFastDouble(MathFunctionPtr MATH_OP, void* pData
          pIn1_256++;
 
          // After masking for all exponents == 1 check to see if same value
-         INT32 bitmask = _mm256_movemask_pd(
+         int32_t bitmask = _mm256_movemask_pd(
             _mm256_cmp_pd(m_finitecomp,
                _mm256_and_pd(m0, m_finitecomp), _CMP_EQ_OQ));
 
@@ -754,7 +754,7 @@ static inline void UnaryNotFiniteFastDouble(MathFunctionPtr MATH_OP, void* pData
 // Output same as input type
 // MathOp operation to perform
 template<typename T, typename MathFunctionPtr>
-static void UnaryOpSlow(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
    T* pIn = (T*)pDataIn;
    T* pOut = (T*)pDataOut;
@@ -773,7 +773,7 @@ static void UnaryOpSlow(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, 
 // Output always returns a double
 // MathOp operation to perform
 template<typename T, typename MathFunctionPtr>
-static void UnaryOpSlowDouble(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlowDouble(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
    T* pIn = (T*)pDataIn;
    double* pOut = (double*)pDataOut;
@@ -792,7 +792,7 @@ static void UnaryOpSlowDouble(MathFunctionPtr MATH_OP, void* pDataIn, void* pDat
 // Output always returns a double
 // MathOp operation to perform
 template<typename T, typename MathFunctionPtr>
-static void UnaryOpSlowBool(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlowBool(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
 
    T* pIn = (T*)pDataIn;
    bool* pOut = (bool*)pDataOut;
@@ -806,7 +806,7 @@ static void UnaryOpSlowBool(MathFunctionPtr MATH_OP, void* pDataIn, void* pDataO
    }
 }
 
-static void UnaryOpSlow_FillTrue(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_FillTrue(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    if (strideOut == sizeof(bool)) {
       memset(pDataOut, 1, len);
    }
@@ -820,7 +820,7 @@ static void UnaryOpSlow_FillTrue(void* pDataIn1, void* pDataOut, INT64 len, INT6
    }
 }
 
-static void UnaryOpSlow_FillFalse(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_FillFalse(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    if (strideOut == sizeof(bool)) {
       memset(pDataOut, 0, len);
    }
@@ -836,56 +836,56 @@ static void UnaryOpSlow_FillFalse(void* pDataIn1, void* pDataOut, INT64 len, INT
 
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_ABS(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ABS(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(ABS_OP<T>,pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_FABS(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_FABS(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const double(*)(T)>(FABS_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_SIGN(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_SIGN(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(SIGN_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_FLOATSIGN(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_FLOATSIGN(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(FLOATSIGN_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_NEG(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_NEG(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(NEG_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_ISNOTNAN(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ISNOTNAN(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowBool<T, const bool(*)(T)>(ISNOTNAN_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 template<typename T>
-static void UnaryOpSlow_ISNAN(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ISNAN(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowBool<T, const bool(*)(T)>(ISNAN_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 template<typename T>
-static void UnaryOpSlow_ISNANORZERO(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ISNANORZERO(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowBool<T, const bool(*)(T)>(ISNANORZERO_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 template<typename T>
-static void UnaryOpSlow_ISINVALID(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ISINVALID(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    T* pIn = (T*)pDataIn1;
    T invalid = *(T*)GetInvalid<T>(); 
-   INT8* pOut = (INT8*)pDataOut;
-   INT8* pLastOut = (INT8*)((char*)pOut + (strideOut*len));
+   int8_t* pOut = (int8_t*)pDataOut;
+   int8_t* pLastOut = (int8_t*)((char*)pOut + (strideOut*len));
 
    // Slow loop, handle 1 at a time
    while (pOut != pLastOut) {
@@ -895,17 +895,17 @@ static void UnaryOpSlow_ISINVALID(void* pDataIn1, void* pDataOut, INT64 len, INT
       else {
          *pOut = FALSE;
       }
-      pOut = STRIDE_NEXT(INT8, pOut, strideOut);
+      pOut = STRIDE_NEXT(int8_t, pOut, strideOut);
       pIn = STRIDE_NEXT(T, pIn, strideIn);
    }
 }
 
 template<typename T>
-static void UnaryOpSlow_ISINVALIDORZERO(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ISINVALIDORZERO(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    T* pIn = (T*)pDataIn1;
    T invalid = *(T*)GetInvalid<T>();
-   INT8* pOut = (INT8*)pDataOut;
-   INT8* pLastOut = (INT8*)((char*)pOut + (strideOut*len));
+   int8_t* pOut = (int8_t*)pDataOut;
+   int8_t* pLastOut = (int8_t*)((char*)pOut + (strideOut*len));
 
    // Slow loop, handle 1 at a time
    while (pOut != pLastOut) {
@@ -915,17 +915,17 @@ static void UnaryOpSlow_ISINVALIDORZERO(void* pDataIn1, void* pDataOut, INT64 le
       else {
          *pOut = FALSE;
       }
-      pOut = STRIDE_NEXT(INT8, pOut, strideOut);
+      pOut = STRIDE_NEXT(int8_t, pOut, strideOut);
       pIn = STRIDE_NEXT(T, pIn, strideIn);
    }
 }
 
 template<typename T>
-static void UnaryOpSlow_ISNOTINVALID(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ISNOTINVALID(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    T* pIn = (T*)pDataIn1;
    T invalid = *(T*)GetInvalid<T>();
-   INT8* pOut = (INT8*)pDataOut;
-   INT8* pLastOut = (INT8*)((char*)pOut + (strideOut*len));
+   int8_t* pOut = (int8_t*)pDataOut;
+   int8_t* pLastOut = (int8_t*)((char*)pOut + (strideOut*len));
 
    // Slow loop, handle 1 at a time
    while (pOut != pLastOut) {
@@ -935,154 +935,154 @@ static void UnaryOpSlow_ISNOTINVALID(void* pDataIn1, void* pDataOut, INT64 len, 
       else {
          *pOut = TRUE;
       }
-      pOut = STRIDE_NEXT(INT8, pOut, strideOut);
+      pOut = STRIDE_NEXT(int8_t, pOut, strideOut);
       pIn = STRIDE_NEXT(T, pIn, strideIn);
    }
 }
 
 template<typename T>
-static void UnaryOpSlow_ISFINITE(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ISFINITE(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowBool<T, const bool(*)(T)>(ISFINITE_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 template<typename T>
-static void UnaryOpSlow_ISNOTFINITE(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ISNOTFINITE(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowBool<T, const bool(*)(T)>(ISNOTFINITE_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 template<typename T>
-static void UnaryOpSlow_ISINF(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ISINF(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowBool<T, const bool(*)(T)>(ISINF_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 template<typename T>
-static void UnaryOpSlow_ISNOTINF(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ISNOTINF(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowBool<T, const bool(*)(T)>(ISNOTINF_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 template<typename T>
-static void UnaryOpSlow_ISNORMAL(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ISNORMAL(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowBool<T, const bool(*)(T)>(ISNORMAL_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 template<typename T>
-static void UnaryOpSlow_ISNOTNORMAL(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ISNOTNORMAL(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowBool<T, const bool(*)(T)>(ISNOTNORMAL_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 template<typename T>
-static void UnaryOpSlow_SIGNBIT(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_SIGNBIT(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowBool<T, const bool(*)(T)>(SIGNBIT_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_NOT(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_NOT(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowBool<T, const bool(*)(T)>(NOT_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_INVERT(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_INVERT(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(INVERT_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_INVERT_BOOL(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_INVERT_BOOL(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(INVERT_OP_BOOL<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_FLOOR(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_FLOOR(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(FLOOR_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_CEIL(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_CEIL(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(CEIL_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_TRUNC(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_TRUNC(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(TRUNC_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_ROUND(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_ROUND(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(ROUND_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_SQRT(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_SQRT(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(SQRT_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_CBRT(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_CBRT(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(CBRT_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_LOG(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_LOG(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(LOG_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_LOG2(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_LOG2(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(LOG2_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_LOG10(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_LOG10(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(LOG10_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_EXP(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_EXP(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(EXP_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlow_EXP2(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlow_EXP2(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlow<T, const T(*)(T)>(EXP2_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
 
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlowDouble_SQRT(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlowDouble_SQRT(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowDouble<T, const double(*)(double)>(SQRT_OP<double>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlowDouble_CBRT(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlowDouble_CBRT(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowDouble<T, const double(*)(double)>(CBRT_OP<double>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlowDouble_LOG(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlowDouble_LOG(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowDouble<T, const double(*)(double)>(LOG_OP<double>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlowDouble_LOG2(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlowDouble_LOG2(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowDouble<T, const double(*)(double)>(LOG2_OP<double>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlowDouble_LOG10(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlowDouble_LOG10(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowDouble<T, const double(*)(double)>(LOG10_OP<double>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlowDouble_EXP(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlowDouble_EXP(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowDouble<T, const double(*)(double)>(EXP_OP<double>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 //-------------------------------------------------------------------
 template<typename T>
-static void UnaryOpSlowDouble_EXP2(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+static void UnaryOpSlowDouble_EXP2(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryOpSlowDouble<T, const double(*)(double)>(EXP2_OP<double>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
@@ -1095,31 +1095,31 @@ static void UnaryOpSlowDouble_EXP2(void* pDataIn1, void* pDataOut, INT64 len, IN
 //------------------------------------------------------------------------------------
 // This routines will call the proper templated ABS function based on the type
 // It provides the standard signature
-template<typename T, typename U256> static inline void UnaryOpFast_NANF32(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+template<typename T, typename U256> static inline void UnaryOpFast_NANF32(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryNanFastFloat<T, U256, const bool(*)(T)>(ISNAN_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
-template<typename T, typename U256> static inline void UnaryOpFast_NANF64(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+template<typename T, typename U256> static inline void UnaryOpFast_NANF64(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryNanFastDouble<T, U256, const bool(*)(T)>(ISNAN_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
-template<typename T, typename U256> static inline void UnaryOpFast_NOTNANF32(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+template<typename T, typename U256> static inline void UnaryOpFast_NOTNANF32(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryNotNanFastFloat<T, U256, const bool(*)(T)>(ISNOTNAN_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
-template<typename T, typename U256> static inline void UnaryOpFast_NOTNANF64(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+template<typename T, typename U256> static inline void UnaryOpFast_NOTNANF64(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryNotNanFastDouble<T, U256, const bool(*)(T)>(ISNOTNAN_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
-template<typename T, typename U256> static inline void UnaryOpFast_FINITEF32(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+template<typename T, typename U256> static inline void UnaryOpFast_FINITEF32(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryFiniteFastFloat<T, U256, const bool(*)(T)>(ISFINITE_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
-template<typename T, typename U256> static inline void UnaryOpFast_FINITEF64(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+template<typename T, typename U256> static inline void UnaryOpFast_FINITEF64(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryFiniteFastDouble<T, U256, const bool(*)(T)>(ISFINITE_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
-template<typename T, typename U256> static inline void UnaryOpFast_NOTFINITEF32(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+template<typename T, typename U256> static inline void UnaryOpFast_NOTFINITEF32(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryNotFiniteFastFloat<T, U256, const bool(*)(T)>(ISNOTFINITE_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
-template<typename T, typename U256> static inline void UnaryOpFast_NOTFINITEF64(void* pDataIn1, void* pDataOut, INT64 len, INT64 strideIn, INT64 strideOut) {
+template<typename T, typename U256> static inline void UnaryOpFast_NOTFINITEF64(void* pDataIn1, void* pDataOut, int64_t len, int64_t strideIn, int64_t strideOut) {
    return UnaryNotFiniteFastDouble<T, U256, const bool(*)(T)>(ISNOTFINITE_OP<T>, pDataIn1, pDataOut, len, strideIn, strideOut);
 }
 
@@ -1130,10 +1130,10 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
    case MATH_OPERATION::FABS:
       //*wantedOutType = NPY_DOUBLE;
       //switch (numpyInType1) {
-      //CASE_NPY_INT32:  return UnaryOpSlow_FABS<INT32>;
-      //CASE_NPY_INT64:  return UnaryOpSlow_FABS<INT64>;
-      //case NPY_INT8:   return UnaryOpSlow_FABS<INT8>;
-      //case NPY_INT16:  return UnaryOpSlow_FABS<INT16>;
+      //CASE_NPY_INT32:  return UnaryOpSlow_FABS<int32_t>;
+      //CASE_NPY_INT64:  return UnaryOpSlow_FABS<int64_t>;
+      //case NPY_INT8:   return UnaryOpSlow_FABS<int8_t>;
+      //case NPY_INT16:  return UnaryOpSlow_FABS<int16_t>;
 
       //}
       break;
@@ -1144,10 +1144,10 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_ABS<float>;
       case NPY_DOUBLE: return UnaryOpSlow_ABS<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_ABS<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlow_ABS<INT32>;
-      CASE_NPY_INT64:  return UnaryOpSlow_ABS<INT64>;
-      case NPY_INT8:   return UnaryOpSlow_ABS<INT8>;
-      case NPY_INT16:  return UnaryOpSlow_ABS<INT16>;
+      CASE_NPY_INT32:  return UnaryOpSlow_ABS<int32_t>;
+      CASE_NPY_INT64:  return UnaryOpSlow_ABS<int64_t>;
+      case NPY_INT8:   return UnaryOpSlow_ABS<int8_t>;
+      case NPY_INT16:  return UnaryOpSlow_ABS<int16_t>;
 
       }
       break;
@@ -1158,10 +1158,10 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_FLOATSIGN<float>;
       case NPY_DOUBLE: return UnaryOpSlow_FLOATSIGN<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_FLOATSIGN<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlow_SIGN<INT32>;
-      CASE_NPY_INT64:  return UnaryOpSlow_SIGN<INT64>;
-      case NPY_INT8:   return UnaryOpSlow_SIGN<INT8>;
-      case NPY_INT16:  return UnaryOpSlow_SIGN<INT16>;
+      CASE_NPY_INT32:  return UnaryOpSlow_SIGN<int32_t>;
+      CASE_NPY_INT64:  return UnaryOpSlow_SIGN<int64_t>;
+      case NPY_INT8:   return UnaryOpSlow_SIGN<int8_t>;
+      case NPY_INT16:  return UnaryOpSlow_SIGN<int16_t>;
 
       }
       break;
@@ -1173,10 +1173,10 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_NEG<float>;
       case NPY_DOUBLE: return UnaryOpSlow_NEG<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_NEG<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlow_NEG<INT32>;
-      CASE_NPY_INT64:  return UnaryOpSlow_NEG<INT64>;
-      case NPY_INT8:   return UnaryOpSlow_NEG<INT8>;
-      case NPY_INT16:  return UnaryOpSlow_NEG<INT16>;
+      CASE_NPY_INT32:  return UnaryOpSlow_NEG<int32_t>;
+      CASE_NPY_INT64:  return UnaryOpSlow_NEG<int64_t>;
+      case NPY_INT8:   return UnaryOpSlow_NEG<int8_t>;
+      case NPY_INT16:  return UnaryOpSlow_NEG<int16_t>;
 
       }
       break;
@@ -1189,13 +1189,13 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          switch (numpyInType1) {
          case NPY_UINT8:
          case NPY_INT8:
-         case NPY_BOOL:   return UnaryOpSlow_NOT<INT8>;
+         case NPY_BOOL:   return UnaryOpSlow_NOT<int8_t>;
          case NPY_INT16:
-         case NPY_UINT16:   return UnaryOpSlow_NOT<INT16>;
+         case NPY_UINT16:   return UnaryOpSlow_NOT<int16_t>;
          CASE_NPY_INT32:
-         CASE_NPY_UINT32:   return UnaryOpSlow_NOT<INT32>;
+         CASE_NPY_UINT32:   return UnaryOpSlow_NOT<int32_t>;
          CASE_NPY_INT64:
-         CASE_NPY_UINT64:   return UnaryOpSlow_NOT<INT64>;
+         CASE_NPY_UINT64:   return UnaryOpSlow_NOT<int64_t>;
          case NPY_FLOAT:  return UnaryOpSlow_NOT<float>;
          case NPY_DOUBLE: return UnaryOpSlow_NOT<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_NOT<long double>;
@@ -1207,15 +1207,15 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
    case MATH_OPERATION::INVERT:
       *wantedOutType = numpyInType1;
       switch (numpyInType1) {
-      CASE_NPY_INT32:  return UnaryOpSlow_INVERT<INT32>;
-      CASE_NPY_UINT32:  return UnaryOpSlow_INVERT<UINT32>;
-      CASE_NPY_INT64:  return UnaryOpSlow_INVERT<INT64>;
-      CASE_NPY_UINT64:  return UnaryOpSlow_INVERT<UINT64>;
-      case NPY_BOOL:   return UnaryOpSlow_INVERT_BOOL<INT8>;
-      case NPY_INT8:   return UnaryOpSlow_INVERT<INT8>;
-      case NPY_UINT8:   return UnaryOpSlow_INVERT<UINT8>;
-      case NPY_INT16:  return UnaryOpSlow_INVERT<INT16>;
-      case NPY_UINT16:  return UnaryOpSlow_INVERT<UINT16>;
+      CASE_NPY_INT32:  return UnaryOpSlow_INVERT<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlow_INVERT<uint32_t>;
+      CASE_NPY_INT64:  return UnaryOpSlow_INVERT<int64_t>;
+      CASE_NPY_UINT64:  return UnaryOpSlow_INVERT<uint64_t>;
+      case NPY_BOOL:   return UnaryOpSlow_INVERT_BOOL<int8_t>;
+      case NPY_INT8:   return UnaryOpSlow_INVERT<int8_t>;
+      case NPY_UINT8:   return UnaryOpSlow_INVERT<uint8_t>;
+      case NPY_INT16:  return UnaryOpSlow_INVERT<int16_t>;
+      case NPY_UINT16:  return UnaryOpSlow_INVERT<uint16_t>;
       }
       break;
 
@@ -1227,15 +1227,15 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISFINITE<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISFINITE<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISFINITE<long double>;
-         CASE_NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<INT32>;
-         CASE_NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<UINT32>;
-         CASE_NPY_INT64:      return UnaryOpSlow_ISNOTINVALID<INT64>;
-         CASE_NPY_UINT64:     return UnaryOpSlow_ISNOTINVALID<UINT64>;
+         CASE_NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
+         CASE_NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
+         CASE_NPY_INT64:      return UnaryOpSlow_ISNOTINVALID<int64_t>;
+         CASE_NPY_UINT64:     return UnaryOpSlow_ISNOTINVALID<uint64_t>;
          case NPY_BOOL:
-         case NPY_INT8:       return UnaryOpSlow_ISNOTINVALID<INT8>;
-         case NPY_UINT8:      return UnaryOpSlow_ISNOTINVALID<UINT8>;
-         case NPY_INT16:      return UnaryOpSlow_ISNOTINVALID<INT16>;
-         case NPY_UINT16:     return UnaryOpSlow_ISNOTINVALID<UINT16>;
+         case NPY_INT8:       return UnaryOpSlow_ISNOTINVALID<int8_t>;
+         case NPY_UINT8:      return UnaryOpSlow_ISNOTINVALID<uint8_t>;
+         case NPY_INT16:      return UnaryOpSlow_ISNOTINVALID<int16_t>;
+         case NPY_UINT16:     return UnaryOpSlow_ISNOTINVALID<uint16_t>;
          default: return UnaryOpSlow_FillTrue;
          }
       }
@@ -1250,15 +1250,15 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNOTFINITE<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNOTFINITE<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNOTFINITE<long double>;
-         CASE_NPY_INT32:      return UnaryOpSlow_ISINVALID<INT32>;
-         CASE_NPY_UINT32:     return UnaryOpSlow_ISINVALID<UINT32>;
-         CASE_NPY_INT64:      return UnaryOpSlow_ISINVALID<INT64>;
-         CASE_NPY_UINT64:     return UnaryOpSlow_ISINVALID<UINT64>;
+         CASE_NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
+         CASE_NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
+         CASE_NPY_INT64:      return UnaryOpSlow_ISINVALID<int64_t>;
+         CASE_NPY_UINT64:     return UnaryOpSlow_ISINVALID<uint64_t>;
          case NPY_BOOL:
-         case NPY_INT8:       return UnaryOpSlow_ISINVALID<INT8>;
-         case NPY_UINT8:      return UnaryOpSlow_ISINVALID<UINT8>;
-         case NPY_INT16:      return UnaryOpSlow_ISINVALID<INT16>;
-         case NPY_UINT16:     return UnaryOpSlow_ISINVALID<UINT16>;
+         case NPY_INT8:       return UnaryOpSlow_ISINVALID<int8_t>;
+         case NPY_UINT8:      return UnaryOpSlow_ISINVALID<uint8_t>;
+         case NPY_INT16:      return UnaryOpSlow_ISINVALID<int16_t>;
+         case NPY_UINT16:     return UnaryOpSlow_ISINVALID<uint16_t>;
          default: return UnaryOpSlow_FillTrue;
          }
       }
@@ -1273,15 +1273,15 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNAN<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNAN<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNAN<long double>;
-         CASE_NPY_INT32:      return UnaryOpSlow_ISINVALID<INT32>;
-         CASE_NPY_UINT32:     return UnaryOpSlow_ISINVALID<UINT32>;
-         CASE_NPY_INT64:      return UnaryOpSlow_ISINVALID<INT64>;
-         CASE_NPY_UINT64:     return UnaryOpSlow_ISINVALID<UINT64>;
+         CASE_NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
+         CASE_NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
+         CASE_NPY_INT64:      return UnaryOpSlow_ISINVALID<int64_t>;
+         CASE_NPY_UINT64:     return UnaryOpSlow_ISINVALID<uint64_t>;
          case NPY_BOOL:
-         case NPY_INT8:       return UnaryOpSlow_ISINVALID<INT8>;
-         case NPY_UINT8:      return UnaryOpSlow_ISINVALID<UINT8>;
-         case NPY_INT16:      return UnaryOpSlow_ISINVALID<INT16>;
-         case NPY_UINT16:     return UnaryOpSlow_ISINVALID<UINT16>;
+         case NPY_INT8:       return UnaryOpSlow_ISINVALID<int8_t>;
+         case NPY_UINT8:      return UnaryOpSlow_ISINVALID<uint8_t>;
+         case NPY_INT16:      return UnaryOpSlow_ISINVALID<int16_t>;
+         case NPY_UINT16:     return UnaryOpSlow_ISINVALID<uint16_t>;
 
          default: return UnaryOpSlow_FillFalse;
          }
@@ -1297,15 +1297,15 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNANORZERO<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNANORZERO<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNANORZERO<long double>;
-         CASE_NPY_INT32:      return UnaryOpSlow_ISINVALIDORZERO<INT32>;
-         CASE_NPY_UINT32:     return UnaryOpSlow_ISINVALIDORZERO<UINT32>;
-         CASE_NPY_INT64:      return UnaryOpSlow_ISINVALIDORZERO<INT64>;
-         CASE_NPY_UINT64:     return UnaryOpSlow_ISINVALIDORZERO<UINT64>;
+         CASE_NPY_INT32:      return UnaryOpSlow_ISINVALIDORZERO<int32_t>;
+         CASE_NPY_UINT32:     return UnaryOpSlow_ISINVALIDORZERO<uint32_t>;
+         CASE_NPY_INT64:      return UnaryOpSlow_ISINVALIDORZERO<int64_t>;
+         CASE_NPY_UINT64:     return UnaryOpSlow_ISINVALIDORZERO<uint64_t>;
          case NPY_BOOL:
-         case NPY_INT8:       return UnaryOpSlow_ISINVALIDORZERO<INT8>;
-         case NPY_UINT8:      return UnaryOpSlow_ISINVALIDORZERO<UINT8>;
-         case NPY_INT16:      return UnaryOpSlow_ISINVALIDORZERO<INT16>;
-         case NPY_UINT16:     return UnaryOpSlow_ISINVALIDORZERO<UINT16>;
+         case NPY_INT8:       return UnaryOpSlow_ISINVALIDORZERO<int8_t>;
+         case NPY_UINT8:      return UnaryOpSlow_ISINVALIDORZERO<uint8_t>;
+         case NPY_INT16:      return UnaryOpSlow_ISINVALIDORZERO<int16_t>;
+         case NPY_UINT16:     return UnaryOpSlow_ISINVALIDORZERO<uint16_t>;
 
          default: return UnaryOpSlow_FillFalse;
          }
@@ -1320,15 +1320,15 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNOTNAN<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNOTNAN<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNOTNAN<long double>;
-         CASE_NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<INT32>;
-         CASE_NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<UINT32>;
-         CASE_NPY_INT64:      return UnaryOpSlow_ISNOTINVALID<INT64>;
-         CASE_NPY_UINT64:     return UnaryOpSlow_ISNOTINVALID<UINT64>;
+         CASE_NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
+         CASE_NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
+         CASE_NPY_INT64:      return UnaryOpSlow_ISNOTINVALID<int64_t>;
+         CASE_NPY_UINT64:     return UnaryOpSlow_ISNOTINVALID<uint64_t>;
          case NPY_BOOL:
-         case NPY_INT8:       return UnaryOpSlow_ISNOTINVALID<INT8>;
-         case NPY_UINT8:      return UnaryOpSlow_ISNOTINVALID<UINT8>;
-         case NPY_INT16:      return UnaryOpSlow_ISNOTINVALID<INT16>;
-         case NPY_UINT16:     return UnaryOpSlow_ISNOTINVALID<UINT16>;
+         case NPY_INT8:       return UnaryOpSlow_ISNOTINVALID<int8_t>;
+         case NPY_UINT8:      return UnaryOpSlow_ISNOTINVALID<uint8_t>;
+         case NPY_INT16:      return UnaryOpSlow_ISNOTINVALID<int16_t>;
+         case NPY_UINT16:     return UnaryOpSlow_ISNOTINVALID<uint16_t>;
          default: return UnaryOpSlow_FillTrue;
          }
       }
@@ -1419,10 +1419,10 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          *wantedOutType = NPY_LONGDOUBLE;
       }
       switch (numpyInType1) {
-      CASE_NPY_INT32:  return UnaryOpSlowDouble_SQRT<INT32>;
-      CASE_NPY_UINT32:  return UnaryOpSlowDouble_SQRT<UINT32>;
-      CASE_NPY_INT64:  return UnaryOpSlowDouble_SQRT<INT64>;
-      CASE_NPY_UINT64:  return UnaryOpSlowDouble_SQRT<INT64>;
+      CASE_NPY_INT32:  return UnaryOpSlowDouble_SQRT<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlowDouble_SQRT<uint32_t>;
+      CASE_NPY_INT64:  return UnaryOpSlowDouble_SQRT<int64_t>;
+      CASE_NPY_UINT64:  return UnaryOpSlowDouble_SQRT<int64_t>;
       case NPY_DOUBLE: return UnaryOpSlow_SQRT<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_SQRT<long double>;
       }
@@ -1436,10 +1436,10 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          *wantedOutType = NPY_LONGDOUBLE;
       }
       switch (numpyInType1) {
-      CASE_NPY_INT32:  return UnaryOpSlowDouble_CBRT<INT32>;
-      CASE_NPY_UINT32:  return UnaryOpSlowDouble_CBRT<UINT32>;
-      CASE_NPY_INT64:  return UnaryOpSlowDouble_CBRT<INT64>;
-      CASE_NPY_UINT64:  return UnaryOpSlowDouble_CBRT<INT64>;
+      CASE_NPY_INT32:  return UnaryOpSlowDouble_CBRT<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlowDouble_CBRT<uint32_t>;
+      CASE_NPY_INT64:  return UnaryOpSlowDouble_CBRT<int64_t>;
+      CASE_NPY_UINT64:  return UnaryOpSlowDouble_CBRT<int64_t>;
       }
       break;
 
@@ -1455,10 +1455,10 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_LOG<float>;
       case NPY_DOUBLE: return UnaryOpSlow_LOG<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_LOG<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlowDouble_LOG<INT32>;
-      CASE_NPY_UINT32:  return UnaryOpSlowDouble_LOG<UINT32>;
-      CASE_NPY_INT64:  return UnaryOpSlowDouble_LOG<INT64>;
-      CASE_NPY_UINT64:  return UnaryOpSlowDouble_LOG<INT64>;
+      CASE_NPY_INT32:  return UnaryOpSlowDouble_LOG<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlowDouble_LOG<uint32_t>;
+      CASE_NPY_INT64:  return UnaryOpSlowDouble_LOG<int64_t>;
+      CASE_NPY_UINT64:  return UnaryOpSlowDouble_LOG<int64_t>;
       }
       break;
    
@@ -1474,10 +1474,10 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_LOG10<float>;
       case NPY_DOUBLE: return UnaryOpSlow_LOG10<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_LOG10<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlowDouble_LOG10<INT32>;
-      CASE_NPY_UINT32:  return UnaryOpSlowDouble_LOG10<UINT32>;
-      CASE_NPY_INT64:  return UnaryOpSlowDouble_LOG10<INT64>;
-      CASE_NPY_UINT64:  return UnaryOpSlowDouble_LOG10<INT64>;
+      CASE_NPY_INT32:  return UnaryOpSlowDouble_LOG10<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlowDouble_LOG10<uint32_t>;
+      CASE_NPY_INT64:  return UnaryOpSlowDouble_LOG10<int64_t>;
+      CASE_NPY_UINT64:  return UnaryOpSlowDouble_LOG10<int64_t>;
       }
       break;
 
@@ -1493,10 +1493,10 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_EXP<float>;
       case NPY_DOUBLE: return UnaryOpSlow_EXP<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_EXP<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlowDouble_EXP<INT32>;
-      CASE_NPY_UINT32:  return UnaryOpSlowDouble_EXP<UINT32>;
-      CASE_NPY_INT64:  return UnaryOpSlowDouble_EXP<INT64>;
-      CASE_NPY_UINT64:  return UnaryOpSlowDouble_EXP<INT64>;
+      CASE_NPY_INT32:  return UnaryOpSlowDouble_EXP<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlowDouble_EXP<uint32_t>;
+      CASE_NPY_INT64:  return UnaryOpSlowDouble_EXP<int64_t>;
+      CASE_NPY_UINT64:  return UnaryOpSlowDouble_EXP<int64_t>;
       }
       break;
 
@@ -1512,10 +1512,10 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_EXP2<float>;
       case NPY_DOUBLE: return UnaryOpSlow_EXP2<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_EXP2<long double>;
-      CASE_NPY_INT32:  return UnaryOpSlowDouble_EXP2<INT32>;
-      CASE_NPY_UINT32:  return UnaryOpSlowDouble_EXP2<UINT32>;
-      CASE_NPY_INT64:  return UnaryOpSlowDouble_EXP2<INT64>;
-      CASE_NPY_UINT64:  return UnaryOpSlowDouble_EXP2<INT64>;
+      CASE_NPY_INT32:  return UnaryOpSlowDouble_EXP2<int32_t>;
+      CASE_NPY_UINT32:  return UnaryOpSlowDouble_EXP2<uint32_t>;
+      CASE_NPY_INT64:  return UnaryOpSlowDouble_EXP2<int64_t>;
+      CASE_NPY_UINT64:  return UnaryOpSlowDouble_EXP2<int64_t>;
       }
       break;
 
@@ -1525,7 +1525,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_SIGNBIT<float>;
       case NPY_DOUBLE: return UnaryOpSlow_SIGNBIT<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_SIGNBIT<long double>;
-      //CASE_NPY_INT32:  return UnaryOpSlowDouble_SIGNBIT<INT32>;
+      //CASE_NPY_INT32:  return UnaryOpSlowDouble_SIGNBIT<int32_t>;
       }
       break;
 
@@ -1547,9 +1547,9 @@ UNARY_FUNC GetUnaryOpFast(int func, int numpyInType1, int numpyOutType, int* wan
       switch (numpyInType1) {
       case NPY_FLOAT:  return UnaryOpFast<float, __m256, ABS_OP<float>, ABS_OP_256<__m256>>;
       case NPY_DOUBLE: return UnaryOpFast<double, __m256d, ABS_OP<double>, ABS_OP_256<__m256d>>;
-      CASE_NPY_INT32:  return UnaryOpFast<INT32, __m256i, ABS_OP<INT32>, ABS_OP_256i32>;
-      case NPY_INT16:  return UnaryOpFast<INT16, __m256i, ABS_OP<INT16>, ABS_OP_256i16>;
-      case NPY_INT8:   return UnaryOpFast<INT8, __m256i,  ABS_OP<INT8>, ABS_OP_256i8>;
+      CASE_NPY_INT32:  return UnaryOpFast<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
+      case NPY_INT16:  return UnaryOpFast<int16_t, __m256i, ABS_OP<int16_t>, ABS_OP_256i16>;
+      case NPY_INT8:   return UnaryOpFast<int8_t, __m256i,  ABS_OP<int8_t>, ABS_OP_256i8>;
       }
       break;
    case MATH_OPERATION::ISNAN:
@@ -1589,10 +1589,10 @@ UNARY_FUNC GetUnaryOpFast(int func, int numpyInType1, int numpyOutType, int* wan
       switch (numpyInType1) {
       case NPY_FLOAT:  return UnaryOpFast<float, __m256, NEG_OP<float>, NEG_OP_256<__m256>>;
       case NPY_DOUBLE: return UnaryOpFast<double, __m256d, NEG_OP<double>, NEG_OP_256<__m256d>>;
-      CASE_NPY_INT64:  return UnaryOpFast<INT64, __m256i, NEG_OP<INT64>, NEG_OP_256i64>;
-      CASE_NPY_INT32:  return UnaryOpFast<INT32, __m256i, NEG_OP<INT32>, NEG_OP_256i32>;
-      case NPY_INT16:  return UnaryOpFast<INT16, __m256i, NEG_OP<INT16>, NEG_OP_256i16>;
-      case NPY_INT8:   return UnaryOpFast<INT8, __m256i, NEG_OP<INT8>, NEG_OP_256i8>;
+      CASE_NPY_INT64:  return UnaryOpFast<int64_t, __m256i, NEG_OP<int64_t>, NEG_OP_256i64>;
+      CASE_NPY_INT32:  return UnaryOpFast<int32_t, __m256i, NEG_OP<int32_t>, NEG_OP_256i32>;
+      case NPY_INT16:  return UnaryOpFast<int16_t, __m256i, NEG_OP<int16_t>, NEG_OP_256i16>;
+      case NPY_INT8:   return UnaryOpFast<int8_t, __m256i, NEG_OP<int8_t>, NEG_OP_256i8>;
       }
       break;
    case MATH_OPERATION::INVERT:
@@ -1655,9 +1655,9 @@ UNARY_FUNC_STRIDED GetUnaryOpFastStrided(int func, int numpyInType1, int numpyOu
       switch (numpyInType1) {
       case NPY_FLOAT:  return UnaryOpFastStrided<float, __m256, ABS_OP<float>, ABS_OP_256<__m256>>;
       //case NPY_DOUBLE: return UnaryOpFastStrided<double, __m256d, ABS_OP<double>, ABS_OP_256<__m256d>>;
-      //CASE_NPY_INT32:  return UnaryOpFastStrided<INT32, __m256i, ABS_OP<INT32>, ABS_OP_256i32>;
-      //case NPY_INT16:  return UnaryOpFastStrided<INT16, __m256i, ABS_OP<INT16>, ABS_OP_256i16>;
-      //case NPY_INT8:   return UnaryOpFastStrided<INT8, __m256i, ABS_OP<INT8>, ABS_OP_256i8>;
+      //CASE_NPY_INT32:  return UnaryOpFastStrided<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
+      //case NPY_INT16:  return UnaryOpFastStrided<int16_t, __m256i, ABS_OP<int16_t>, ABS_OP_256i16>;
+      //case NPY_INT8:   return UnaryOpFastStrided<int8_t, __m256i, ABS_OP<int8_t>, ABS_OP_256i8>;
 
       }
    }
@@ -1698,20 +1698,20 @@ static UNARY_FUNC_STRIDED CheckMathOpOneInputStrided(int func, int numpyInType1,
 
 //------------------------------------------------------------------------------
 //  Concurrent callback from multiple threads
-static BOOL UnaryThreadCallbackStrided(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, INT64 workIndex) {
-   BOOL didSomeWork = FALSE;
+static bool UnaryThreadCallbackStrided(struct stMATH_WORKER_ITEM* pstWorkerItem, int core, int64_t workIndex) {
+   bool didSomeWork = FALSE;
    UNARY_CALLBACK* Callback = (UNARY_CALLBACK*)pstWorkerItem->WorkCallbackArg;
 
    char* pDataIn = (char *)Callback->pDataIn;
    char* pDataOut = (char*)Callback->pDataOut;
-   INT64 lenX;
-   INT64 workBlock;
+   int64_t lenX;
+   int64_t workBlock;
 
    // As long as there is work to do
    while ((lenX = pstWorkerItem->GetNextWorkBlock(&workBlock)) > 0) {
 
-      INT64 inputAdj = pstWorkerItem->BlockSize * workBlock * Callback->itemSizeIn;
-      INT64 outputAdj = pstWorkerItem->BlockSize * workBlock * Callback->itemSizeOut;
+      int64_t inputAdj = pstWorkerItem->BlockSize * workBlock * Callback->itemSizeIn;
+      int64_t outputAdj = pstWorkerItem->BlockSize * workBlock * Callback->itemSizeOut;
 
       LOGGING("[%d] working on %lld with len %lld   block: %lld\n", core, workIndex, lenX, workBlock);
       Callback->pUnaryCallbackStrided(pDataIn + inputAdj, pDataOut + outputAdj, lenX, Callback->itemSizeIn, Callback->itemSizeOut);
@@ -1742,10 +1742,10 @@ PyObject* ProcessOneInput(
 
    LOGGING("In process one input %d %d %d\n", funcNumber, numpyInType1, numpyOutType);
    int ndim ;
-   INT64 strideIn;
+   int64_t strideIn;
 
    int directionIn = GetStridesAndContig(inArray, ndim, strideIn);
-   INT64 len = CALC_ARRAY_LENGTH(ndim, PyArray_DIMS(inArray));
+   int64_t len = CALC_ARRAY_LENGTH(ndim, PyArray_DIMS(inArray));
 
    // Handle most common fast path up front
    if (directionIn == 0 && numpyOutType == -1) {
@@ -1819,7 +1819,7 @@ PyObject* ProcessOneInput(
          RETURN_NONE;
       }
 
-      INT64 lenOut = len;
+      int64_t lenOut = len;
 
       if (numpyOutType == -1) {
           LOGGING("Going to allocate   contig: %d  len: %lld\n", PyArray_FLAGS(inArray) & (NPY_ARRAY_F_CONTIGUOUS | NPY_ARRAY_C_CONTIGUOUS), len);
@@ -1833,7 +1833,7 @@ PyObject* ProcessOneInput(
       else {
          outputArray = outObject1;
          LOGGING("Output specified oref %llu\n", outObject1->ob_base.ob_refcnt);
-         INT64 lenOut = ArrayLength(outputArray);
+         int64_t lenOut = ArrayLength(outputArray);
 
          if (len != lenOut) {
             LOGGING("Wanted output length does not match %lld vs %lld or output is not contiguous\n", len, lenOut);
@@ -1848,7 +1848,7 @@ PyObject* ProcessOneInput(
       void* pDataOut = PyArray_BYTES(outputArray);
 
       int ndimOut;
-      INT64 strideOut;
+      int64_t strideOut;
       int directionOut = GetStridesAndContig(outputArray, ndimOut, strideOut);
 
       // F contig on 2 dim =>  dim0 * stride0 == stride1
@@ -1886,35 +1886,35 @@ PyObject* ProcessOneInput(
          // Check if we can process, else punt to numpy
          if (directionIn == 1 && directionOut == 0) {
             // Row Major 2dim like array with output being fully contiguous
-            INT64 innerLen=1;
+            int64_t innerLen=1;
             for (int i = directionIn; i < ndim; i++) {
                innerLen *= PyArray_DIM(inArray, i);
             }
             // TODO: consider dividing the work over multiple threads if innerLen is large enough
-            const INT64 outerLen = PyArray_DIM(inArray, 0);
-            const INT64 outerStride = PyArray_STRIDE(inArray, 0);
+            const int64_t outerLen = PyArray_DIM(inArray, 0);
+            const int64_t outerStride = PyArray_STRIDE(inArray, 0);
 
             LOGGING("Row Major  innerLen:%lld  outerLen:%lld  outerStride:%lld\n", innerLen, outerLen, outerStride);
 
-            for (INT64 j = 0; j < outerLen; j++) {
+            for (int64_t j = 0; j < outerLen; j++) {
                pUnaryFunc((char*)pDataIn + (j * outerStride), (char*)pDataOut + (j * innerLen * strideOut), innerLen, strideIn, strideOut);
             }
 
          }
          else if (directionIn == -1 && directionOut == 0) {
             // Col Major 2dim like array with output being fully contiguous
-            INT64 innerLen = 1;
+            int64_t innerLen = 1;
             directionIn = -directionIn;
             for (int i = 0; i < directionIn; i++) {
                innerLen *= PyArray_DIM(inArray, i);
             }
             // TODO: consider dividing the work over multiple threads if innerLen is large enough
-            const INT64 outerLen = PyArray_DIM(inArray, (ndim-1));
-            const INT64 outerStride = PyArray_STRIDE(inArray, (ndim - 1));
+            const int64_t outerLen = PyArray_DIM(inArray, (ndim-1));
+            const int64_t outerStride = PyArray_STRIDE(inArray, (ndim - 1));
 
             LOGGING("Col Major  innerLen:%lld  outerLen:%lld  outerStride:%lld\n", innerLen, outerLen, outerStride);
 
-            for (INT64 j = 0; j < outerLen; j++) {
+            for (int64_t j = 0; j < outerLen; j++) {
                pUnaryFunc((char*)pDataIn + (j * outerStride), (char*)pDataOut + (j * innerLen * strideOut), innerLen, strideIn, strideOut);
             }
          }
@@ -1940,8 +1940,8 @@ PyObject* ProcessOneInput(
 PyObject *
 BasicMathOneInput(PyObject *self, PyObject *args) {
    PyObject* tuple = NULL;
-   INT64 funcNumber;
-   INT64 numpyOutputType;
+   int64_t funcNumber;
+   int64_t numpyOutputType;
 
    if (!PyArg_ParseTuple(
       args, "OLL",
@@ -1952,7 +1952,7 @@ BasicMathOneInput(PyObject *self, PyObject *args) {
       return NULL;
    }
 
-   INT64 tupleSize = 1;
+   int64_t tupleSize = 1;
    // Assume no tuple and object passied in is array
    PyObject* inObject1 = tuple;
 
@@ -1998,7 +1998,7 @@ BasicMathOneInput(PyObject *self, PyObject *args) {
 //-----------------------------------------------------------------------------------
 // Called internally when python numbermethod called
 PyObject *
-BasicMathOneInputFromNumber(PyArrayObject* inObject1, INT64 funcNumber, BOOL inplace) {
+BasicMathOneInputFromNumber(PyArrayObject* inObject1, int64_t funcNumber, bool inplace) {
    UNARY_FUNC pOneFunc = NULL;
    int numpyInType1 = PyArray_TYPE(inObject1);
 
@@ -2050,7 +2050,7 @@ BasicMathUnaryOp(PyObject *self, PyObject *args, PyObject *kwargs) {
       PyArrayObject* inObject = (PyArrayObject*)PyTuple_GET_ITEM(args, 0);
       PyObject* funcNumber = PyTuple_GET_ITEM(args, 1);
       if (PyLong_CheckExact(funcNumber)) {
-         INT64 funcNum = PyLong_AsLongLong(funcNumber);
+         int64_t funcNum = PyLong_AsLongLong(funcNumber);
 
          if (IsFastArrayOrNumpy(inObject)) {
             PyObject* result =

--- a/src/UnaryOps.cpp
+++ b/src/UnaryOps.cpp
@@ -1130,7 +1130,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
    case MATH_OPERATION::FABS:
       //*wantedOutType = NPY_DOUBLE;
       //switch (numpyInType1) {
-      //case NPY_INT:  return UnaryOpSlow_FABS<int32_t>;
+      //case NPY_INT32:  return UnaryOpSlow_FABS<int32_t>;
       //CASE_NPY_INT64:  return UnaryOpSlow_FABS<int64_t>;
       //case NPY_INT8:   return UnaryOpSlow_FABS<int8_t>;
       //case NPY_INT16:  return UnaryOpSlow_FABS<int16_t>;
@@ -1144,7 +1144,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_ABS<float>;
       case NPY_DOUBLE: return UnaryOpSlow_ABS<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_ABS<long double>;
-      case NPY_INT:  return UnaryOpSlow_ABS<int32_t>;
+      case NPY_INT32:  return UnaryOpSlow_ABS<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return UnaryOpSlow_ABS<int64_t>;
@@ -1160,7 +1160,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_FLOATSIGN<float>;
       case NPY_DOUBLE: return UnaryOpSlow_FLOATSIGN<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_FLOATSIGN<long double>;
-      case NPY_INT:  return UnaryOpSlow_SIGN<int32_t>;
+      case NPY_INT32:  return UnaryOpSlow_SIGN<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
          return UnaryOpSlow_SIGN<int64_t>;
@@ -1177,7 +1177,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT:  return UnaryOpSlow_NEG<float>;
       case NPY_DOUBLE: return UnaryOpSlow_NEG<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_NEG<long double>;
-      case NPY_INT:  return UnaryOpSlow_NEG<int32_t>;
+      case NPY_INT32:  return UnaryOpSlow_NEG<int32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlow_NEG<int64_t>;
@@ -1198,8 +1198,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_BOOL:   return UnaryOpSlow_NOT<int8_t>;
          case NPY_INT16:
          case NPY_UINT16:   return UnaryOpSlow_NOT<int16_t>;
-         case NPY_INT:
-         case NPY_UINT:   return UnaryOpSlow_NOT<int32_t>;
+         case NPY_INT32:
+         case NPY_UINT32:   return UnaryOpSlow_NOT<int32_t>;
          case NPY_INT64:
          case NPY_LONGLONG:
          case NPY_UINT64:
@@ -1216,8 +1216,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
    case MATH_OPERATION::INVERT:
       *wantedOutType = numpyInType1;
       switch (numpyInType1) {
-      case NPY_INT:  return UnaryOpSlow_INVERT<int32_t>;
-      case NPY_UINT:  return UnaryOpSlow_INVERT<uint32_t>;
+      case NPY_INT32:  return UnaryOpSlow_INVERT<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlow_INVERT<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlow_INVERT<int64_t>;
@@ -1240,8 +1240,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISFINITE<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISFINITE<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISFINITE<long double>;
-         case NPY_INT:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
-         case NPY_UINT:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
+         case NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
+         case NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
          case NPY_INT64:
          case NPY_LONGLONG:
                return UnaryOpSlow_ISNOTINVALID<int64_t>;
@@ -1267,8 +1267,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNOTFINITE<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNOTFINITE<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNOTFINITE<long double>;
-         case NPY_INT:      return UnaryOpSlow_ISINVALID<int32_t>;
-         case NPY_UINT:     return UnaryOpSlow_ISINVALID<uint32_t>;
+         case NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
+         case NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
          case NPY_INT64:
          case NPY_LONGLONG:
                return UnaryOpSlow_ISINVALID<int64_t>;
@@ -1294,8 +1294,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNAN<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNAN<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNAN<long double>;
-         case NPY_INT:      return UnaryOpSlow_ISINVALID<int32_t>;
-         case NPY_UINT:     return UnaryOpSlow_ISINVALID<uint32_t>;
+         case NPY_INT32:      return UnaryOpSlow_ISINVALID<int32_t>;
+         case NPY_UINT32:     return UnaryOpSlow_ISINVALID<uint32_t>;
          case NPY_INT64:
          case NPY_LONGLONG:
                return UnaryOpSlow_ISINVALID<int64_t>;
@@ -1322,8 +1322,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNANORZERO<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNANORZERO<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNANORZERO<long double>;
-         case NPY_INT:      return UnaryOpSlow_ISINVALIDORZERO<int32_t>;
-         case NPY_UINT:     return UnaryOpSlow_ISINVALIDORZERO<uint32_t>;
+         case NPY_INT32:      return UnaryOpSlow_ISINVALIDORZERO<int32_t>;
+         case NPY_UINT32:     return UnaryOpSlow_ISINVALIDORZERO<uint32_t>;
          case NPY_INT64:
          case NPY_LONGLONG:
                return UnaryOpSlow_ISINVALIDORZERO<int64_t>;
@@ -1349,8 +1349,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          case NPY_FLOAT:  return UnaryOpSlow_ISNOTNAN<float>;
          case NPY_DOUBLE: return UnaryOpSlow_ISNOTNAN<double>;
          case NPY_LONGDOUBLE: return UnaryOpSlow_ISNOTNAN<long double>;
-         case NPY_INT:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
-         case NPY_UINT:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
+         case NPY_INT32:      return UnaryOpSlow_ISNOTINVALID<int32_t>;
+         case NPY_UINT32:     return UnaryOpSlow_ISNOTINVALID<uint32_t>;
          case NPY_INT64:
          case NPY_LONGLONG:
                return UnaryOpSlow_ISNOTINVALID<int64_t>;
@@ -1452,8 +1452,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          *wantedOutType = NPY_LONGDOUBLE;
       }
       switch (numpyInType1) {
-      case NPY_INT:  return UnaryOpSlowDouble_SQRT<int32_t>;
-      case NPY_UINT:  return UnaryOpSlowDouble_SQRT<uint32_t>;
+      case NPY_INT32:  return UnaryOpSlowDouble_SQRT<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlowDouble_SQRT<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlowDouble_SQRT<int64_t>;
@@ -1473,8 +1473,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
          *wantedOutType = NPY_LONGDOUBLE;
       }
       switch (numpyInType1) {
-      case NPY_INT:  return UnaryOpSlowDouble_CBRT<int32_t>;
-      case NPY_UINT:  return UnaryOpSlowDouble_CBRT<uint32_t>;
+      case NPY_INT32:  return UnaryOpSlowDouble_CBRT<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlowDouble_CBRT<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlowDouble_CBRT<int64_t>;
@@ -1496,8 +1496,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_LOG<float>;
       case NPY_DOUBLE: return UnaryOpSlow_LOG<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_LOG<long double>;
-      case NPY_INT:  return UnaryOpSlowDouble_LOG<int32_t>;
-      case NPY_UINT:  return UnaryOpSlowDouble_LOG<uint32_t>;
+      case NPY_INT32:  return UnaryOpSlowDouble_LOG<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlowDouble_LOG<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlowDouble_LOG<int64_t>;
@@ -1519,8 +1519,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_LOG10<float>;
       case NPY_DOUBLE: return UnaryOpSlow_LOG10<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_LOG10<long double>;
-      case NPY_INT:  return UnaryOpSlowDouble_LOG10<int32_t>;
-      case NPY_UINT:  return UnaryOpSlowDouble_LOG10<uint32_t>;
+      case NPY_INT32:  return UnaryOpSlowDouble_LOG10<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlowDouble_LOG10<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlowDouble_LOG10<int64_t>;
@@ -1542,8 +1542,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_EXP<float>;
       case NPY_DOUBLE: return UnaryOpSlow_EXP<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_EXP<long double>;
-      case NPY_INT:  return UnaryOpSlowDouble_EXP<int32_t>;
-      case NPY_UINT:  return UnaryOpSlowDouble_EXP<uint32_t>;
+      case NPY_INT32:  return UnaryOpSlowDouble_EXP<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlowDouble_EXP<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlowDouble_EXP<int64_t>;
@@ -1565,8 +1565,8 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_EXP2<float>;
       case NPY_DOUBLE: return UnaryOpSlow_EXP2<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_EXP2<long double>;
-      case NPY_INT:  return UnaryOpSlowDouble_EXP2<int32_t>;
-      case NPY_UINT:  return UnaryOpSlowDouble_EXP2<uint32_t>;
+      case NPY_INT32:  return UnaryOpSlowDouble_EXP2<int32_t>;
+      case NPY_UINT32:  return UnaryOpSlowDouble_EXP2<uint32_t>;
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpSlowDouble_EXP2<int64_t>;
@@ -1582,7 +1582,7 @@ UNARY_FUNC GetUnaryOpSlow(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_FLOAT: return UnaryOpSlow_SIGNBIT<float>;
       case NPY_DOUBLE: return UnaryOpSlow_SIGNBIT<double>;
       case NPY_LONGDOUBLE: return UnaryOpSlow_SIGNBIT<long double>;
-      //case NPY_INT:  return UnaryOpSlowDouble_SIGNBIT<int32_t>;
+      //case NPY_INT32:  return UnaryOpSlowDouble_SIGNBIT<int32_t>;
       }
       break;
 
@@ -1604,7 +1604,7 @@ UNARY_FUNC GetUnaryOpFast(int func, int numpyInType1, int numpyOutType, int* wan
       switch (numpyInType1) {
       case NPY_FLOAT:  return UnaryOpFast<float, __m256, ABS_OP<float>, ABS_OP_256<__m256>>;
       case NPY_DOUBLE: return UnaryOpFast<double, __m256d, ABS_OP<double>, ABS_OP_256<__m256d>>;
-      case NPY_INT:  return UnaryOpFast<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
+      case NPY_INT32:  return UnaryOpFast<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
       case NPY_INT16:  return UnaryOpFast<int16_t, __m256i, ABS_OP<int16_t>, ABS_OP_256i16>;
       case NPY_INT8:   return UnaryOpFast<int8_t, __m256i,  ABS_OP<int8_t>, ABS_OP_256i8>;
       }
@@ -1649,7 +1649,7 @@ UNARY_FUNC GetUnaryOpFast(int func, int numpyInType1, int numpyOutType, int* wan
       case NPY_INT64:
       case NPY_LONGLONG:
            return UnaryOpFast<int64_t, __m256i, NEG_OP<int64_t>, NEG_OP_256i64>;
-      case NPY_INT:  return UnaryOpFast<int32_t, __m256i, NEG_OP<int32_t>, NEG_OP_256i32>;
+      case NPY_INT32:  return UnaryOpFast<int32_t, __m256i, NEG_OP<int32_t>, NEG_OP_256i32>;
       case NPY_INT16:  return UnaryOpFast<int16_t, __m256i, NEG_OP<int16_t>, NEG_OP_256i16>;
       case NPY_INT8:   return UnaryOpFast<int8_t, __m256i, NEG_OP<int8_t>, NEG_OP_256i8>;
       }
@@ -1714,7 +1714,7 @@ UNARY_FUNC_STRIDED GetUnaryOpFastStrided(int func, int numpyInType1, int numpyOu
       switch (numpyInType1) {
       case NPY_FLOAT:  return UnaryOpFastStrided<float, __m256, ABS_OP<float>, ABS_OP_256<__m256>>;
       //case NPY_DOUBLE: return UnaryOpFastStrided<double, __m256d, ABS_OP<double>, ABS_OP_256<__m256d>>;
-      //case NPY_INT:  return UnaryOpFastStrided<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
+      //case NPY_INT32:  return UnaryOpFastStrided<int32_t, __m256i, ABS_OP<int32_t>, ABS_OP_256i32>;
       //case NPY_INT16:  return UnaryOpFastStrided<int16_t, __m256i, ABS_OP<int16_t>, ABS_OP_256i16>;
       //case NPY_INT8:   return UnaryOpFastStrided<int8_t, __m256i, ABS_OP<int8_t>, ABS_OP_256i8>;
 

--- a/src/UnaryOps.h
+++ b/src/UnaryOps.h
@@ -1,10 +1,11 @@
-
+#ifndef RIPTIDECPP_UNARYOPS_H
+#define RIPTIDECPP_UNARYOPS_H
 
 PyObject *
 BasicMathOneInput(PyObject *self, PyObject *args);
 
 PyObject *
-BasicMathOneInputFromNumber(PyArrayObject* inObject1, INT64 funcNumber, BOOL inplace);
+BasicMathOneInputFromNumber(PyArrayObject* inObject1, int64_t funcNumber, bool inplace);
 
 PyObject *
 BasicMathUnaryOp(PyObject *self, PyObject *args, PyObject *kwargs);
@@ -20,6 +21,8 @@ struct UNARY_CALLBACK {
    char* pDataIn;
    char* pDataOut;
 
-   INT64 itemSizeIn;
-   INT64 itemSizeOut;
+   int64_t itemSizeIn;
+   int64_t itemSizeOut;
 };
+
+#endif

--- a/src/ndarray.h
+++ b/src/ndarray.h
@@ -4,8 +4,8 @@
 extern Py_ssize_t
 GetNdArrayLen(PyObject *self);
 
-extern INT64
-CopyNdArrayToBuffer(PyObject *self, char* destBuffer, INT64 len);
+extern int64_t
+CopyNdArrayToBuffer(PyObject *self, char* destBuffer, int64_t len);
 
 
 


### PR DESCRIPTION
Retype the main sources to the cstdint types.
Also cleans up the use of #defines on switch cases.
Removes a couple of instances of the bad-indentation bug where we had different behaviour between release and debug builds.