### PR TITLE
conda: Drop py36 and numpy 1.18. Add py39 and numpy 1.21.

### DIFF
--- a/conda_recipe/conda_build_config.yaml
+++ b/conda_recipe/conda_build_config.yaml
@@ -1,11 +1,9 @@
 python:
   - 3.7
   - 3.8
-  # TODO: Enable py39 builds once we have a way to exclude the
-  # (py39, numpy 1.18) combination, since numpy 1.18 never supported py39.
-  # - 3.9
+  - 3.9
 
 numpy:
-  - 1.18
   - 1.19
   - 1.20
+  - 1.21


### PR DESCRIPTION
Title says it all. This change will drop support for py36 (officially) and numpy 1.18, and add py39 and numpy 1.21 to the conda builds.