### PR TITLE
Compile with /W3 on Windows

### DIFF
--- a/src/SDSFilePython.cpp
+++ b/src/SDSFilePython.cpp
@@ -425,7 +425,7 @@ StringListToVector(PyObject* listFilenames) {
 
 //----------------------------------------------------
 // Input: Python List of Tuples(asciiz string,int)
-// Output: Write to pListNames.  
+// Output: Write to pListNames.
 //         ASCIIZ strings follow by UINT8 enum (string1, 0, enum1, string2, 0, enum2, etc.)
 // Returns: Length of data in pListNames
 //
@@ -724,7 +724,7 @@ const char* FindBang(const char *pString) {
 //----------------------------------------------------
 // Returns true if included
 bool IsIncluded(PyObject* pInclusionList, const char* pArrayName) {
-  
+
    // If there is no inclusion list, assume all are included
     if (pInclusionList) {
 
@@ -794,7 +794,7 @@ void* ReadFromSharedMemory(SDS_SHARED_MEMORY_CALLBACK* pSMCB) {
 
    PyObject* pystring = NULL;
    PyObject* pListName = NULL;
-   LOGGING("Reading from shared memory\n");    
+   LOGGING("Reading from shared memory\n");
 
    //----------- LOAD ARRAY NAMES -------------------------
    int64_t nameSize = pFileHeader->NameBlockSize;
@@ -1033,7 +1033,7 @@ PyObject* ReadFinalWrap(SDS_FINAL_CALLBACK* pSDSFinalCallback) {
 // CALLBACK2 - can wrap more than one file
 // finalCount is how many info sections to return
 // if there are sections inside a single file, the finalCount > 1
-void* ReadFinal(SDS_FINAL_CALLBACK* pSDSFinalCallback, int64_t finalCount) {     
+void* ReadFinal(SDS_FINAL_CALLBACK* pSDSFinalCallback, int64_t finalCount) {
 
    PyObject* returnItem = NULL;
 
@@ -1065,9 +1065,9 @@ void* ReadFinal(SDS_FINAL_CALLBACK* pSDSFinalCallback, int64_t finalCount) {
 //----------------------------------------
 // CALLBACK2 - all files were stacked into one column
 void* ReadFinalStack(
-   SDS_STACK_CALLBACK* pSDSFinalCallback, 
-   int64_t finalCount, 
-   SDS_STACK_CALLBACK_FILES *pSDSFileInfo, 
+   SDS_STACK_CALLBACK* pSDSFinalCallback,
+   int64_t finalCount,
+   SDS_STACK_CALLBACK_FILES *pSDSFileInfo,
    SDS_FILTER*    pSDSFilter,
    int64_t fileCount) {
 
@@ -1396,7 +1396,7 @@ PyObject *CompressFile(PyObject* self, PyObject *args, PyObject *kwargs)
          SDSWriteFile(
             fileName,
             shareName,  // can be NULL
-            folderName, 
+            folderName,
             &SDSWriteInfo,
             &SDSWriteCallbacks );
 
@@ -1526,7 +1526,7 @@ GetFilters(PyObject* kwargs, SDS_READ_CALLBACKS* pRCB) {
       PyObject* maskItem = PyDict_GetItemString(kwargs, "mask");
 
       if (maskItem && PyArray_Check(maskItem)) {
-         if (PyArray_TYPE((PyArrayObject*)maskItem) == NPY_BOOL) {         
+         if (PyArray_TYPE((PyArrayObject*)maskItem) == NPY_BOOL) {
             pRCB->Filter.BoolMaskLength = ArrayLength((PyArrayObject*)maskItem);
             pRCB->Filter.pBoolMask = (bool*)PyArray_GETPTR1((PyArrayObject*)maskItem, 0);
             // Needed
@@ -1662,7 +1662,7 @@ PyObject *DecompressFile(PyObject* self, PyObject *args, PyObject *kwargs) {
 //
 PyObject*
 InternalDecompressFiles(
-   PyObject*   self, 
+   PyObject*   self,
    PyObject*   args,
    PyObject*   kwargs,
    int         multiMode) {
@@ -1880,7 +1880,7 @@ PyObject *SetLustreGateway(PyObject* self, PyObject *args) {
 
    //printf("hint: %s\n", fileName);
 
-   g_gatewaylist.empty();
+   g_gatewaylist.clear();
    int64_t tupleLength = PyTuple_GET_SIZE(tuple);
    g_gatewaylist.reserve(tupleLength);
 

--- a/src/SharedMemory.cpp
+++ b/src/SharedMemory.cpp
@@ -30,7 +30,7 @@ void LogWarningLE(HRESULT error) {
 //------------------------------------------------------------------------------------------
 // Checks Windows policy settings if the current process has
 // the privilege enabled.
-// 
+//
 bool
 CheckWindowsPrivilege(const char* pPrivilegeName)
 {
@@ -92,7 +92,7 @@ bool SetPrivilege(
 
    if (!LookupPrivilegeValue(
       NULL,            // lookup privilege on local system
-      lpszPrivilege,   // privilege to lookup 
+      lpszPrivilege,   // privilege to lookup
       &luid))        // receives LUID of privilege
    {
       printf("LookupPrivilegeValue error: %u\n", GetLastError());
@@ -369,7 +369,7 @@ UtilSharedNumaMemoryBegin(
 // The pReturnStruct will be valid if the call succeeded
 // if bTest = true, it will not complain if it cannot find shared memory
 // if returns S_OK you are mapped
-// returns S_FALSE if it does not exist yet 
+// returns S_FALSE if it does not exist yet
 HRESULT
 UtilSharedMemoryCopy(
    const char*              pMappingName,
@@ -488,17 +488,17 @@ UtilMappedViewReadBegin(
 
    PULONG               pulFile;
    PMAPPED_VIEW_STRUCT  pMappedViewStruct;
-   const char*              pMappingName;
+   //UNUSED? const char*              pMappingName;
 
    //
    // NULL indicates failure - default to that.
    //
    *pReturnStruct = NULL;
 
-   if (!CheckWindowsSharedMemoryPrerequisites(pMappingName)) 
-   {
-      return -(S_FALSE);
-   }
+   //UNUSED? if (!CheckWindowsSharedMemoryPrerequisites(pMappingName))
+   //UNUSED? {
+   //UNUSED?    return -(S_FALSE);
+   //UNUSED? }
 
    //
    // Allocate fixed, zero inited memory
@@ -543,27 +543,27 @@ UtilMappedViewReadBegin(
       return(HRESULT_FROM_WIN32(GetLastError()));
    }
 
-   //
-   // Break off any \ or : or / in the file
-   //
-   // Search for the last one
-   //
-   {
-      const char* pTemp = pszFilename;
-      pMappingName = pTemp;
-
-      while (*pTemp != 0) {
-
-         if (*pTemp == '\\' ||
-            *pTemp == ':' ||
-            *pTemp == '/') {
-
-            pMappingName = pTemp + 1;
-         }
-
-         pTemp++;
-      }
-   }
+   //UNUSED?   //
+   //UNUSED?   // Break off any \ or : or / in the file
+   //UNUSED?   //
+   //UNUSED?   // Search for the last one
+   //UNUSED?   //
+   //UNUSED?   {
+   //UNUSED?      const char* pTemp = pszFilename;
+   //UNUSED?      pMappingName = pTemp;
+   //UNUSED?
+   //UNUSED?      while (*pTemp != 0) {
+   //UNUSED?
+   //UNUSED?         if (*pTemp == '\\' ||
+   //UNUSED?            *pTemp == ':' ||
+   //UNUSED?            *pTemp == '/') {
+   //UNUSED?
+   //UNUSED?            pMappingName = pTemp + 1;
+   //UNUSED?         }
+   //UNUSED?
+   //UNUSED?         pTemp++;
+   //UNUSED?      }
+   //UNUSED?   }
 
    //
    // We create a file mapping in order to map the file
@@ -674,17 +674,17 @@ UtilMappedViewWriteBegin(
 
    PULONG               pulFile;
    PMAPPED_VIEW_STRUCT  pMappedViewStruct;
-   const char*              pMappingName;
+   //UNUSED? const char*              pMappingName;
 
    //
    // NULL indicates failure - default to that.
    //
    *pReturnStruct = NULL;
 
-   if (!CheckWindowsSharedMemoryPrerequisites(pMappingName))
-   {
-      return -(S_FALSE);
-   }
+   //UNUSED? if (!CheckWindowsSharedMemoryPrerequisites(pMappingName))
+   //UNUSED? {
+   //UNUSED?    return -(S_FALSE);
+   //UNUSED? }
 
    //
    // Allocate fixed, zero inited memory
@@ -729,27 +729,27 @@ UtilMappedViewWriteBegin(
       return (HRESULT_FROM_WIN32(GetLastError()));
    }
 
-   //
-   // Break off any \ or : or / in the file
-   //
-   // Search for the last one
-   //
-   {
-      const char* pTemp = pszFilename;
-      pMappingName = pTemp;
-
-      while (*pTemp != 0) {
-
-         if (*pTemp == '\\' ||
-            *pTemp == ':' ||
-            *pTemp == '/') {
-
-            pMappingName = pTemp + 1;
-         }
-
-         pTemp++;
-      }
-   }
+   //UNUSED?   //
+   //UNUSED?   // Break off any \ or : or / in the file
+   //UNUSED?   //
+   //UNUSED?   // Search for the last one
+   //UNUSED?   //
+   //UNUSED?   {
+   //UNUSED?      const char* pTemp = pszFilename;
+   //UNUSED?      pMappingName = pTemp;
+   //UNUSED?
+   //UNUSED?      while (*pTemp != 0) {
+   //UNUSED?
+   //UNUSED?         if (*pTemp == '\\' ||
+   //UNUSED?            *pTemp == ':' ||
+   //UNUSED?            *pTemp == '/') {
+   //UNUSED?
+   //UNUSED?            pMappingName = pTemp + 1;
+   //UNUSED?         }
+   //UNUSED?
+   //UNUSED?         pTemp++;
+   //UNUSED?      }
+   //UNUSED?   }
 
    //
    // We create a file mapping inorder to map the file
@@ -853,7 +853,7 @@ UtilSharedMemoryBegin(
 
    // Our memory buffer will be readable and writable:
    int protection = PROT_READ | PROT_WRITE;
-   
+
    //MAP_HUGETLB(since Linux 2.6.32)
    //   Allocate the mapping using "huge pages."  See the Linux kernel
    //   source file Documentation / vm / hugetlbpage.txt for further
@@ -941,7 +941,7 @@ UtilSharedMemoryCopy(
 
    // Our memory buffer will be readable and writable:
    int protection = PROT_READ;
-   
+
    if (!bCanOnlyRead) {
       protection |= PROT_WRITE;
    }
@@ -969,7 +969,7 @@ UtilSharedMemoryCopy(
    // Allocate memory
    //
    PMAPPED_VIEW_STRUCT pMappedViewStruct;
-   
+
    pMappedViewStruct=
       static_cast<PMAPPED_VIEW_STRUCT>(WORKSPACE_ALLOC(sizeof(MAPPED_VIEW_STRUCT)));
 

--- a/src/setup.py
+++ b/src/setup.py
@@ -75,7 +75,9 @@ if sys.platform == 'win32':
         #extra_compile_args = ['/MT /Ox /Ob2 /Oi /Ot'],
         # For MSVC windows compiler 2019 it has the new __CxxFrameHandler4 which is found in vcrntime140_1.dll which is not on all systems
         # We use /dsFH4- to disable this frame handler
-        extra_compile_args = ['/Ox','/Ob2','/Oi','/Ot','/d2FH4-'],
+        extra_compile_args = ['/Ox','/Ob2','/Oi','/Ot','/d2FH4-','/W3','/WX','/FC'],
+        #extra_compile_args = ['/Od','/Z7','/d2FH4-','/W3','/WX','/FC'],
+        #extra_link_args = ['/debug']
         )
 
 setuptools.setup(


### PR DESCRIPTION
Enable /WX (treat warnings as errors).
Fix some basic errors that were found.
Enable /FC (emit full path on diagnostics) to make it easier for IDE.
Add (commented out) entries for enabling debug builds for dev.