### PR TITLE
Refactor AccumSumFloat/AccumNanSumFloat temp work

### DIFF
--- a/src/CommonInc.h
+++ b/src/CommonInc.h
@@ -362,7 +362,7 @@ typedef void (*ANY_TWO_FUNC)(void * pDataIn, void * pDataIn2, void * pDataOut, i
 
 // Used for Groupby Sum/Mean/Min/Max/etc
 typedef void (*GROUPBY_TWO_FUNC)(void * pDataIn, void * pIndex, int32_t * pCountOut, void * pDataOut, int64_t len, int64_t binLow,
-                                 int64_t binHigh, int64_t pass);
+                                 int64_t binHigh, int64_t pass, bool isFinalPass, void * pDataTmp);
 
 // Used for Groupby Mode/Median/etc
 typedef void (*GROUPBY_X_FUNC32)(void * pColumn, void * pGroup, int32_t * pFirst, int32_t * pCount, void * pAccumBin,

--- a/src/CommonInc.h
+++ b/src/CommonInc.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <iostream>
 #include <limits>
+#include <memory>
 
 // TODO: Remove these includes, they don't seem to be used anymore (at least directly within this file).
 #include <cstdio>

--- a/src/CommonInc.h
+++ b/src/CommonInc.h
@@ -176,11 +176,26 @@ FORCEINLINE void * aligned_alloc(size_t alignment, size_t size)
 void * FmAlloc(size_t _Size);
 void FmFree(void * _Block);
 
+namespace internal
+{
+    struct fm_mem_deleter
+    {
+        void operator()(void * const block)
+        {
+            FmFree(block);
+        }
+    };
+}
+
+// Smart pointer managing FmAlloc'ed memory.
+using fm_mem_ptr = std::unique_ptr<void, internal::fm_mem_deleter>;
+
 #define ARRAY_ALLOC malloc
 #define ARRAY_FREE free
 
 #define WORKSPACE_ALLOC FmAlloc
 #define WORKSPACE_FREE FmFree
+using workspace_mem_ptr = fm_mem_ptr;
 
 #define COMPRESS_ALLOC FmAlloc
 #define COMPRESS_FREE FmFree

--- a/src/GroupBy.cpp
+++ b/src/GroupBy.cpp
@@ -248,14 +248,12 @@ public:
                               int64_t binHigh, int64_t pass, bool isFinalPass, void * pDataTmp)
     {
         float * pIn = (float *)pDataIn;
-        float * pOut = (float *)pDataOut;
         V * pIndex = (V *)pIndexT;
         double * pOutAccum = static_cast<double *>(pDataTmp);
 
         if (pass <= 0)
         {
             // Clear out memory for our range
-            memset(pOut + binLow, 0, sizeof(float) * (binHigh - binLow));
             memset(pOutAccum, 0, sizeof(double) * (binHigh - binLow));
         }
 
@@ -273,6 +271,7 @@ public:
         if (isFinalPass)
         {
             // Downcast from double to single
+            float * pOut = (float *)pDataOut;
             for (int64_t i = binLow; i < binHigh; i++)
             {
                 pOut[i] = (float)pOutAccum[i - binLow];
@@ -342,14 +341,12 @@ public:
                                  int64_t binHigh, int64_t pass, bool isFinalPass, void * pDataTmp)
     {
         float * pIn = (float *)pDataIn;
-        float * pOut = (float *)pDataOut;
         V * pIndex = (V *)pIndexT;
         double * pOutAccum = static_cast<double *>(pDataTmp);
 
         if (pass <= 0)
         {
             // Clear out memory for our range
-            memset(pOut + binLow, 0, sizeof(float) * (binHigh - binLow));
             memset(pOutAccum, 0, sizeof(double) * (binHigh - binLow));
         }
 
@@ -371,6 +368,7 @@ public:
         if (isFinalPass)
         {
             // Downcast from double to single
+            float * pOut = (float *)pDataOut;
             for (int64_t i = binLow; i < binHigh; i++)
             {
                 pOut[i] = (float)pOutAccum[i - binLow];

--- a/src/GroupBy.h
+++ b/src/GroupBy.h
@@ -24,6 +24,7 @@ struct stGroupByReturn
 
     // for multithreaded sum this is set
     void * pOutArray;
+    void * pTmpArray;
 
     int32_t * pCountOut;
 


### PR DESCRIPTION
Add support for GroupBy methods to accept shared temp buffer and final pass indication.
Allocate shared temp buffer for multithreaded and non-multithreaded cases.
Have AccumSumFloat/AccumNanSumFloat use shared temp buffer and final pass downsample.
Add smart pointers for managing FmAlloc'ed (and WORKSPACE_ALLOC'ed) memory.
Restores performance to original (unsafe) version.
Fixes rtosholdings/riptable#258
Fixes #64