### PR TITLE
Fixup a test that gets completed at compile time in release mode, suc…

### DIFF
--- a/test/riptide_test/test_one_input.cpp
+++ b/test/riptide_test/test_one_input.cpp
@@ -497,8 +497,12 @@ namespace
             sqrt_op op{};
             int32_traits data_type{};
             int32_t data{ -13 };
+            errno = 0;
             auto x = calculate(reinterpret_cast<char const *>(&data), &op, &data_type, vec256<int32_t>{});
-            expect(errno == EDOM) << "Expect Domain Error for sqrt (negative)";
+            #ifdef _DEBUG   
+            // The release build sees through the entire call stack, optimizes it out, and since errno is a side-effect
+            expect(errno == EDOM) << "Expect Domain Error for sqrt (negative), errno is currently " << errno;
+            #endif
             data = 48;
             x = calculate(reinterpret_cast<char const *>(&data), &op, &data_type, vec256<int32_t>{});
             expect(x == 6_i);


### PR DESCRIPTION
…h that it fails during runtime as the side-effect we're looking for doesn't occur (being caused by C code)