### PR TITLE
Add __version__ attribute

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -105,7 +105,7 @@ setup(
         'root': '.',
         'version_scheme': 'post-release',
         'write_to': 'src/_version.d',
-        'write_to_template': 'char const * const __version__ = "{version}";',
+        'write_to_template': '"{version}"',
     },
     setup_requires=['setuptools_scm'],
     description = 'Python Package with fast math util functions',

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,8 @@ setup(
     use_scm_version = {
         'root': '.',
         'version_scheme': 'post-release',
+        'write_to': 'src/_version.d',
+        'write_to_template': 'char const * const __version__ = "{version}";',
     },
     setup_requires=['setuptools_scm'],
     description = 'Python Package with fast math util functions',

--- a/src/RipTide.cpp
+++ b/src/RipTide.cpp
@@ -25,7 +25,9 @@
 #include "DateTime.h"
 #include "Hook.h"
 #include "Array.h"
-#include "_version.d"
+#if __has_include("_version.d")
+# include "_version.d"
+#endif
 
 #undef LOGGING
 //#define LOGGING printf

--- a/src/RipTide.cpp
+++ b/src/RipTide.cpp
@@ -25,6 +25,7 @@
 #include "DateTime.h"
 #include "Hook.h"
 #include "Array.h"
+#include "_version.d"
 
 #undef LOGGING
 //#define LOGGING printf
@@ -1828,6 +1829,9 @@ PyMODINIT_FUNC PyInit_riptide_cpp()
         return m;
 
     g_FastArrayModule = m;
+
+    // Set the version
+    PyObject_SetAttrString(m, "__version__", Py_BuildValue("s", __version__));
 
     // Load numpy
     import_array();

--- a/src/RipTide.cpp
+++ b/src/RipTide.cpp
@@ -25,9 +25,16 @@
 #include "DateTime.h"
 #include "Hook.h"
 #include "Array.h"
+
+namespace {
+char const * const __version__{
 #if __has_include("_version.d")
 # include "_version.d"
+#else
+  "DEV"
 #endif
+};
+}
 
 #undef LOGGING
 //#define LOGGING printf


### PR DESCRIPTION
This makes it possible to obtain the version via the riptide_cpp.__version__ attribute, just like for riptable.