### PR TITLE
Stop infinite loops

### DIFF
--- a/bench/riptide_bench/riptide_bench/CMakeLists.txt
+++ b/bench/riptide_bench/riptide_bench/CMakeLists.txt
@@ -34,6 +34,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 set(SOURCES main.cpp
 			bench_one_input.cpp
+			hash_linear_bench.cpp
 			memcmp_bench.cpp)
 
 add_executable(${TARGET_NAME} ${HEADERS} ${SOURCES})
@@ -45,3 +46,14 @@ target_include_directories(${TARGET_NAME} PRIVATE ${RT_SOURCE_DIR} ${Python3_INC
 target_link_directories(${TARGET_NAME} PRIVATE ${Python3_LIBRARY_DIRS})
 
 target_link_libraries(${TARGET_NAME} PRIVATE riptide_cpp ${Python3_Libraries} benchmark::benchmark $<$<PLATFORM_ID:Linux>:pthread> $<$<PLATFORM_ID:Linux>:rt>)
+
+if(WIN32)
+    set(_TARGET_DIR $<TARGET_FILE_DIR:${TARGET_NAME}>)
+
+    add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
+        COMMENT "Copying runtime dependencies from riptide_cpp to ${_TARGET_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:riptide_cpp> ${_TARGET_DIR}
+
+        COMMENT "Copying Python dependencies to ${_TARGET_DIR}"
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different ${Python3_RUNTIME_LIBRARY_DIRS}/python${Python3_VERSION_MAJOR}${Python3_VERSION_MINOR}.dll ${_TARGET_DIR})
+endif()

--- a/bench/riptide_bench/riptide_bench/hash_linear_bench.cpp
+++ b/bench/riptide_bench/riptide_bench/hash_linear_bench.cpp
@@ -1,0 +1,30 @@
+#include "RipTide.h"
+#include "HashLinear.h"
+
+#include "benchmark/benchmark.h"
+
+#include <vector>
+#include <numeric>
+#include <algorithm>
+#include <random>
+
+namespace
+{
+    std::vector<uint64_t> test_data(1024ULL * 1024ULL * 1024ULL);
+    std::random_device dev{};
+    CHashLinear<uint64_t, int64_t> hasher{};
+
+    void bench_MakeHashLocation(benchmark::State & state)
+    {
+        std::iota(std::begin(test_data), std::end(test_data), 3002954500);
+        std::shuffle(std::begin(test_data), std::end(test_data), std::mt19937{ dev() });
+        for (auto _ : state)
+        {
+            hasher.MakeHashLocation(test_data.size(), test_data.data(), 0);
+            benchmark::DoNotOptimize(test_data.data());
+            benchmark::ClobberMemory();
+        }
+    }
+
+    BENCHMARK(bench_MakeHashLocation);
+}

--- a/bench/riptide_bench/riptide_bench/hash_linear_bench.cpp
+++ b/bench/riptide_bench/riptide_bench/hash_linear_bench.cpp
@@ -10,6 +10,7 @@
 
 namespace
 {
+#if 0
     std::vector<uint64_t> test_data(1024ULL * 1024ULL * 1024ULL);
     std::random_device dev{};
     CHashLinear<uint64_t, int64_t> hasher{};
@@ -26,5 +27,6 @@ namespace
         }
     }
 
-//    BENCHMARK(bench_MakeHashLocation);
+    BENCHMARK(bench_MakeHashLocation);
+#endif
 }

--- a/bench/riptide_bench/riptide_bench/hash_linear_bench.cpp
+++ b/bench/riptide_bench/riptide_bench/hash_linear_bench.cpp
@@ -26,5 +26,5 @@ namespace
         }
     }
 
-    BENCHMARK(bench_MakeHashLocation);
+//    BENCHMARK(bench_MakeHashLocation);
 }

--- a/bench/riptide_bench/riptide_bench/memcmp_bench.cpp
+++ b/bench/riptide_bench/riptide_bench/memcmp_bench.cpp
@@ -33,55 +33,54 @@ namespace
 
     BENCHMARK(bench_memcmp)->RangeMultiplier(64)->Range(1,4096ull*1024*1024)->Setup(init)->Teardown(teardown)->Repetitions(30)->ReportAggregatesOnly(true);
 
-
-#define MEMCMP_NEW(ARG1, ARG2, ARG3, ARG4)      \
-    { \
-        ARG1 = 0; \
-        const char * pSrc1 = ARG2; \
-        const char * pSrc2 = ARG3; \
-        int64_t length = ARG4; \
-        while (length >= 8) \
+    #define MEMCMP_NEW(ARG1, ARG2, ARG3, ARG4) \
         { \
-            uint64_t * p1 = (uint64_t *)pSrc1; \
-            uint64_t * p2 = (uint64_t *)pSrc2; \
-            if (*p1 != *p2) \
+            ARG1 = 0; \
+            const char * pSrc1 = ARG2; \
+            const char * pSrc2 = ARG3; \
+            int64_t length = ARG4; \
+            while (length >= 8) \
             { \
-                ARG1 = 1; \
-                length = 0; \
-                break; \
+                uint64_t * p1 = (uint64_t *)pSrc1; \
+                uint64_t * p2 = (uint64_t *)pSrc2; \
+                if (*p1 != *p2) \
+                { \
+                    ARG1 = 1; \
+                    length = 0; \
+                    break; \
+                } \
+                length -= 8; \
+                pSrc1 += 8; \
+                pSrc2 += 8; \
             } \
-            length -= 8; \
-            pSrc1 += 8; \
-            pSrc2 += 8; \
-        } \
-        if (length >= 4) \
-        { \
-            uint32_t * p1 = (uint32_t *)pSrc1; \
-            uint32_t * p2 = (uint32_t *)pSrc2; \
-            if (*p1 != *p2) \
+            if (length >= 4) \
             { \
-                ARG1 = 1; \
-                length = 0; \
+                uint32_t * p1 = (uint32_t *)pSrc1; \
+                uint32_t * p2 = (uint32_t *)pSrc2; \
+                if (*p1 != *p2) \
+                { \
+                    ARG1 = 1; \
+                    length = 0; \
+                } \
+                else \
+                { \
+                    length -= 4; \
+                    pSrc1 += 4; \
+                    pSrc2 += 4; \
+                } \
             } \
-            else \
+            while (length > 0) \
             { \
-                length -= 4; \
-                pSrc1 += 4; \
-                pSrc2 += 4; \
+                if (*pSrc1 != *pSrc2) \
+                { \
+                    ARG1 = 1; \
+                    break; \
+                } \
+                length -= 1; \
+                pSrc1 += 1; \
+                pSrc2 += 1; \
             } \
-        } \
-        while (length > 0) \
-        { \
-            if (*pSrc1 != *pSrc2) \
-            { \
-                ARG1 = 1; \
-                break; \
-            } \
-            length -= 1; \
-            pSrc1 += 1; \
-            pSrc2 += 1; \
-        } \
-    }
+        }
 
     void bench_memcmp_new(benchmark::State & state)
     {

--- a/src/BasicMath.cpp
+++ b/src/BasicMath.cpp
@@ -2194,10 +2194,10 @@ public:
                     LOGGING("overflow dtype %d\n", dtype);
                     switch (dtype)
                     {
-                        CASE_NPY_UINT64:
-                            break;
-                        default:
-                            return NPY_FLOAT64;
+                    CASE_NPY_UINT64:
+                        break;
+                    default:
+                        return NPY_FLOAT64;
                     }
                 }
             }

--- a/src/Convert.cpp
+++ b/src/Convert.cpp
@@ -3797,7 +3797,7 @@ PyObject * SetItem(PyObject * self, PyObject * args)
 
     // Try to convert value if we have to
     PyObject * value = PyTuple_GetItem(args, 2);
-    bool newValue{false};
+    bool newValue{ false };
     if (! PyArray_Check(value))
     {
         value = PyArray_FromAny(value, NULL, 0, 0, NPY_ARRAY_ENSUREARRAY, NULL);
@@ -3826,18 +3826,18 @@ PyObject * SetItem(PyObject * self, PyObject * args)
 
                     if (arrayLength == ArrayLength(mask))
                     {
-                        PyObject * returnValue{nullptr};
-                        
+                        PyObject * returnValue{ nullptr };
+
                         if (arrayLength <= SETITEM_PARTITION_SIZE)
                         {
-                            returnValue =  SetItemBooleanMask(arr, mask, inValues, arrayLength);
+                            returnValue = SetItemBooleanMask(arr, mask, inValues, arrayLength);
                         }
                         else
                         {
                             // special count
                             returnValue = SetItemBooleanMaskLarge(arr, mask, inValues, arrayLength);
                         }
-                        
+
                         if (newValue)
                         {
                             Py_DECREF(value);
@@ -3850,7 +3850,7 @@ PyObject * SetItem(PyObject * self, PyObject * args)
         }
         LOGGING("SetItem Could not convert value to array %d  %lld  %d  %lld\n", PyArray_NDIM(arr), PyArray_ITEMSIZE(arr),
                 PyArray_NDIM((PyArrayObject *)value), PyArray_ITEMSIZE((PyArrayObject *)value));
-        
+
         if (newValue)
         {
             Py_DECREF(value);

--- a/src/GroupBy.cpp
+++ b/src/GroupBy.cpp
@@ -2465,7 +2465,8 @@ static GROUPBY_GATHER_FUNC GetGroupByGatherFunction(int outputType, GB_FUNCTIONS
 // U is the output type
 // V is the index type, like int32_t or int8_t
 template <typename V>
-static GROUPBY_TWO_FUNC GetGroupByFunction(bool * hasCounts, int32_t * wantedOutputType, int32_t * wantedTempType, int inputType, GB_FUNCTIONS func)
+static GROUPBY_TWO_FUNC GetGroupByFunction(bool * hasCounts, int32_t * wantedOutputType, int32_t * wantedTempType, int inputType,
+                                           GB_FUNCTIONS func)
 {
     *hasCounts = false;
     *wantedTempType = -1;
@@ -3366,7 +3367,8 @@ void GroupByCall(void * pGroupBy, int64_t i)
             // Accum the calculation
             // Sum/NanSum
             // Make the range from 1 to uniqueRows to skip over bin 0
-            pFunction(pDataIn, pDataIn2 /* USE IKEY which can be int8/16/32/64*/, pCountOut, pDataOut, len, binLow, binHigh, -1, pDataTmp);
+            pFunction(pDataIn, pDataIn2 /* USE IKEY which can be int8/16/32/64*/, pCountOut, pDataOut, len, binLow, binHigh, -1,
+                      pDataTmp);
         }
         else
 
@@ -3439,8 +3441,8 @@ PyObject * GroupByAll64(PyObject * self, PyObject * args)
 }
 
 //---------------------------------------------------------------
-GROUPBY_TWO_FUNC GetGroupByFunctionStep1(int32_t iKeyType, bool * hasCounts, int32_t * numpyOutType, int32_t * numpyTmpType, int32_t numpyInType,
-                                         GB_FUNCTIONS funcNum)
+GROUPBY_TWO_FUNC GetGroupByFunctionStep1(int32_t iKeyType, bool * hasCounts, int32_t * numpyOutType, int32_t * numpyTmpType,
+                                         int32_t numpyInType, GB_FUNCTIONS funcNum)
 {
     GROUPBY_TWO_FUNC pFunction = NULL;
 
@@ -3657,8 +3659,8 @@ PyObject * GroupBySingleOpMultithreaded(ArrayInfo * aInfo, PyArrayObject * iKey,
     int32_t numpyTmpType = -1;
     bool hasCounts = false;
 
-    GROUPBY_TWO_FUNC pFunction =
-        GetGroupByFunctionStep1(iKeyType, &hasCounts, &numpyOutType, &numpyTmpType, aInfo[0].NumpyDType, (GB_FUNCTIONS)firstFuncNum);
+    GROUPBY_TWO_FUNC pFunction = GetGroupByFunctionStep1(iKeyType, &hasCounts, &numpyOutType, &numpyTmpType, aInfo[0].NumpyDType,
+                                                         (GB_FUNCTIONS)firstFuncNum);
 
     // printf("Taking the divide path  %lld \n", unique_rows);
 
@@ -3715,8 +3717,8 @@ PyObject * GroupBySingleOpMultithreaded(ArrayInfo * aInfo, PyArrayObject * iKey,
                 LOGGING("***pCountOut %p   unique:%lld  allocsize:%lld   cores:%d\n", pCountOut, unique_rows, allocSize, numCores);
             }
 
-            void * pTmpWorkspace{nullptr};
-            int32_t tempItemSize{0};
+            void * pTmpWorkspace{ nullptr };
+            int32_t tempItemSize{ 0 };
 
             if (numpyTmpType >= 0)
             {
@@ -3724,7 +3726,7 @@ PyObject * GroupBySingleOpMultithreaded(ArrayInfo * aInfo, PyArrayObject * iKey,
                 int64_t tempSize = tempItemSize * (binHigh - binLow) * numCores;
                 workspaceMemList.emplace_back(WORKSPACE_ALLOC(tempSize));
                 pTmpWorkspace = workspaceMemList.back().get();
-                if (!pTmpWorkspace)
+                if (! pTmpWorkspace)
                 {
                     return NULL;
                 }
@@ -3761,9 +3763,8 @@ PyObject * GroupBySingleOpMultithreaded(ArrayInfo * aInfo, PyArrayObject * iKey,
 
                 // Assign working memory per call
                 pstGroupBy32->returnObjects[i].pOutArray = &pWorkspace[unique_rows * i * itemSize];
-                pstGroupBy32->returnObjects[i].pTmpArray = pTmpWorkspace
-                    ? &(static_cast<char *>(pTmpWorkspace)[(binHigh - binLow) * i * tempItemSize])
-                    : nullptr;
+                pstGroupBy32->returnObjects[i].pTmpArray =
+                    pTmpWorkspace ? &(static_cast<char *>(pTmpWorkspace)[(binHigh - binLow) * i * tempItemSize]) : nullptr;
                 pstGroupBy32->returnObjects[i].pCountOut = &pCountOut[unique_rows * i];
                 pstGroupBy32->returnObjects[i].pFunction = pFunction;
                 pstGroupBy32->returnObjects[i].returnObject = Py_None;
@@ -3958,8 +3959,8 @@ PyObject * GroupByAll32(PyObject * self, PyObject * args)
             int64_t binHigh = PyLong_AsLongLongAndOverflow(PyList_GET_ITEM(listBinHigh, i), &overflow);
             pstGroupBy32->returnObjects[i].binHigh = binHigh;
 
-            GROUPBY_TWO_FUNC pFunction =
-                GetGroupByFunctionStep1(iKeyType, &hasCounts, &numpyOutType, &numpyTmpType, aInfo[i].NumpyDType, (GB_FUNCTIONS)funcNum);
+            GROUPBY_TWO_FUNC pFunction = GetGroupByFunctionStep1(iKeyType, &hasCounts, &numpyOutType, &numpyTmpType,
+                                                                 aInfo[i].NumpyDType, (GB_FUNCTIONS)funcNum);
 
             PyArrayObject * outArray = NULL;
             int32_t * pCountOut = NULL;
@@ -3997,7 +3998,7 @@ PyObject * GroupByAll32(PyObject * self, PyObject * args)
                     int32_t tempItemSize = NpyToSize(numpyTmpType);
                     workspaceMemList.emplace_back(WORKSPACE_ALLOC(tempItemSize * (binHigh - binLow)));
                     pTmpArray = workspaceMemList.back().get();
-                    if (!pTmpArray)
+                    if (! pTmpArray)
                     {
                         return NULL;
                     }

--- a/src/HashFunctions.cpp
+++ b/src/HashFunctions.cpp
@@ -92,40 +92,40 @@ PyObject * IsMember64(PyObject * self, PyObject * args)
     {
         try
         {
-        void * pDataIn1 = PyArray_BYTES(inArr1);
-        void * pDataIn2 = PyArray_BYTES(inArr2);
-        int8_t * pDataOut1 = (int8_t *)PyArray_BYTES(boolArray);
-        int64_t * pDataOut2 = (int64_t *)PyArray_BYTES(indexArray);
+            void * pDataIn1 = PyArray_BYTES(inArr1);
+            void * pDataIn2 = PyArray_BYTES(inArr2);
+            int8_t * pDataOut1 = (int8_t *)PyArray_BYTES(boolArray);
+            int64_t * pDataOut2 = (int64_t *)PyArray_BYTES(indexArray);
 
-        // printf("Size array1: %llu   array2: %llu\n", arraySize1, arraySize2);
+            // printf("Size array1: %llu   array2: %llu\n", arraySize1, arraySize2);
 
-        if (arrayType1 >= NPY_STRING)
-        {
-            LOGGING("Calling string!\n");
-            IsMemberHashString64(arraySize1, sizeType1, (const char *)pDataIn1, arraySize2, sizeType2, (const char *)pDataIn2,
-                                 pDataOut2, pDataOut1, HASH_MODE(hashMode), hintSize, arrayType1 == NPY_UNICODE);
-        }
-        else
-        {
-            if (arrayType1 == NPY_FLOAT32 || arrayType1 == NPY_FLOAT64)
+            if (arrayType1 >= NPY_STRING)
             {
-                IsMemberHash64(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, pDataOut1, sizeType1 + 100,
-                               HASH_MODE(hashMode), hintSize);
+                LOGGING("Calling string!\n");
+                IsMemberHashString64(arraySize1, sizeType1, (const char *)pDataIn1, arraySize2, sizeType2, (const char *)pDataIn2,
+                                     pDataOut2, pDataOut1, HASH_MODE(hashMode), hintSize, arrayType1 == NPY_UNICODE);
             }
             else
             {
-                IsMemberHash64(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, pDataOut1, sizeType1, HASH_MODE(hashMode),
-                               hintSize);
+                if (arrayType1 == NPY_FLOAT32 || arrayType1 == NPY_FLOAT64)
+                {
+                    IsMemberHash64(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, pDataOut1, sizeType1 + 100,
+                                   HASH_MODE(hashMode), hintSize);
+                }
+                else
+                {
+                    IsMemberHash64(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, pDataOut1, sizeType1,
+                                   HASH_MODE(hashMode), hintSize);
+                }
+
+                PyObject * retObject = Py_BuildValue("(OO)", boolArray, indexArray);
+                Py_DECREF((PyObject *)boolArray);
+                Py_DECREF((PyObject *)indexArray);
+
+                return (PyObject *)retObject;
             }
-
-            PyObject * retObject = Py_BuildValue("(OO)", boolArray, indexArray);
-            Py_DECREF((PyObject *)boolArray);
-            Py_DECREF((PyObject *)indexArray);
-
-            return (PyObject *)retObject;
         }
-        }
-        catch ( std::runtime_error const & e )
+        catch (std::runtime_error const & e)
         {
             PyErr_Format(PyExc_RuntimeError, e.what());
         }
@@ -244,53 +244,53 @@ PyObject * IsMemberCategorical(PyObject * self, PyObject * args)
 
     try
     {
-    if (arrayType1 >= NPY_STRING)
-    {
-        LOGGING("Calling string/uni/void!\n");
-        missed = IsMemberCategoricalHashStringPre(&indexArray, inArr1, arraySize1, sizeType1, (const char *)pDataIn1, arraySize2,
-                                                  sizeType2, (const char *)pDataIn2, HASH_MODE(hashMode), hintSize,
-                                                  arrayType1 == NPY_UNICODE);
-    }
-    else if (arrayType1 == NPY_FLOAT32 || arrayType1 == NPY_FLOAT64 || arrayType1 == NPY_LONGDOUBLE)
-    {
-        LOGGING("Calling float!\n");
-        if (arraySize1 < 2100000000)
+        if (arrayType1 >= NPY_STRING)
         {
-            indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
-            int32_t * pDataOut2 = (int32_t *)PyArray_BYTES(indexArray);
-            missed = IsMemberHashCategorical(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1 + 100,
-                                             HASH_MODE(hashMode), hintSize);
+            LOGGING("Calling string/uni/void!\n");
+            missed = IsMemberCategoricalHashStringPre(&indexArray, inArr1, arraySize1, sizeType1, (const char *)pDataIn1,
+                                                      arraySize2, sizeType2, (const char *)pDataIn2, HASH_MODE(hashMode), hintSize,
+                                                      arrayType1 == NPY_UNICODE);
+        }
+        else if (arrayType1 == NPY_FLOAT32 || arrayType1 == NPY_FLOAT64 || arrayType1 == NPY_LONGDOUBLE)
+        {
+            LOGGING("Calling float!\n");
+            if (arraySize1 < 2100000000)
+            {
+                indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
+                int32_t * pDataOut2 = (int32_t *)PyArray_BYTES(indexArray);
+                missed = IsMemberHashCategorical(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1 + 100,
+                                                 HASH_MODE(hashMode), hintSize);
+            }
+            else
+            {
+                indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT64);
+                int64_t * pDataOut2 = (int64_t *)PyArray_BYTES(indexArray);
+                missed = IsMemberHashCategorical64(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1 + 100,
+                                                   HASH_MODE(hashMode), hintSize);
+            }
         }
         else
         {
-            indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT64);
-            int64_t * pDataOut2 = (int64_t *)PyArray_BYTES(indexArray);
-            missed = IsMemberHashCategorical64(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1 + 100,
-                                               HASH_MODE(hashMode), hintSize);
+            LOGGING("Calling hash!\n");
+            if (arraySize1 < 2100000000)
+            {
+                indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
+                int32_t * pDataOut2 = (int32_t *)PyArray_BYTES(indexArray);
+                missed = IsMemberHashCategorical(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1,
+                                                 HASH_MODE(hashMode), hintSize);
+            }
+            else
+            {
+                indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT64);
+                int64_t * pDataOut2 = (int64_t *)PyArray_BYTES(indexArray);
+                missed = IsMemberHashCategorical64(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1,
+                                                   HASH_MODE(hashMode), hintSize);
+            }
         }
     }
-    else
+    catch (std::runtime_error const & e)
     {
-        LOGGING("Calling hash!\n");
-        if (arraySize1 < 2100000000)
-        {
-            indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT32);
-            int32_t * pDataOut2 = (int32_t *)PyArray_BYTES(indexArray);
-            missed = IsMemberHashCategorical(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1, HASH_MODE(hashMode),
-                                             hintSize);
-        }
-        else
-        {
-            indexArray = AllocateLikeNumpyArray(inArr1, NPY_INT64);
-            int64_t * pDataOut2 = (int64_t *)PyArray_BYTES(indexArray);
-            missed = IsMemberHashCategorical64(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1,
-                                               HASH_MODE(hashMode), hintSize);
-        }
-    }
-    }
-    catch( std::runtime_error const & e )
-    {
-        PyErr_Format(PyExc_RuntimeError, e.what() );
+        PyErr_Format(PyExc_RuntimeError, e.what());
         return NULL;
     }
 

--- a/src/HashFunctions.cpp
+++ b/src/HashFunctions.cpp
@@ -47,12 +47,12 @@ PyObject * IsMember64(PyObject * self, PyObject * args)
     int sizeType1 = (int)NpyItemSize((PyObject *)inArr1);
     int sizeType2 = (int)NpyItemSize((PyObject *)inArr2);
 
-    LOGGING("IsMember32 %s vs %s   size: %d  %d\n", NpyToString(arrayType1), NpyToString(arrayType2), sizeType1, sizeType2);
+    LOGGING("IsMember64 %s vs %s   size: %d  %d\n", NpyToString(arrayType1), NpyToString(arrayType2), sizeType1, sizeType2);
 
     if (arrayType1 != arrayType2)
     {
         // Arguments do not match
-        PyErr_Format(PyExc_ValueError, "IsMember32 needs first arg to match %s vs %s", NpyToString(arrayType1),
+        PyErr_Format(PyExc_ValueError, "IsMember64 needs first arg to match %s vs %s", NpyToString(arrayType1),
                      NpyToString(arrayType2));
         return NULL;
     }
@@ -60,7 +60,7 @@ PyObject * IsMember64(PyObject * self, PyObject * args)
     if (sizeType1 == 0)
     {
         // Weird type
-        PyErr_Format(PyExc_ValueError, "IsMember32 needs a type it understands %s vs %s", NpyToString(arrayType1),
+        PyErr_Format(PyExc_ValueError, "IsMember64 needs a type it understands %s vs %s", NpyToString(arrayType1),
                      NpyToString(arrayType2));
         return NULL;
     }
@@ -68,7 +68,7 @@ PyObject * IsMember64(PyObject * self, PyObject * args)
     if (arrayType1 == NPY_OBJECT)
     {
         PyErr_Format(PyExc_ValueError,
-                     "IsMember32 cannot handle unicode strings, "
+                     "IsMember64 cannot handle unicode strings, "
                      "please convert to np.chararray");
         return NULL;
     }

--- a/src/HashFunctions.cpp
+++ b/src/HashFunctions.cpp
@@ -90,6 +90,8 @@ PyObject * IsMember64(PyObject * self, PyObject * args)
 
     if (boolArray && indexArray)
     {
+        try
+        {
         void * pDataIn1 = PyArray_BYTES(inArr1);
         void * pDataIn2 = PyArray_BYTES(inArr2);
         int8_t * pDataOut1 = (int8_t *)PyArray_BYTES(boolArray);
@@ -121,6 +123,11 @@ PyObject * IsMember64(PyObject * self, PyObject * args)
             Py_DECREF((PyObject *)indexArray);
 
             return (PyObject *)retObject;
+        }
+        }
+        catch ( std::runtime_error const & e )
+        {
+            PyErr_Format(PyExc_RuntimeError, e.what());
         }
     }
     // out of memory
@@ -235,6 +242,8 @@ PyObject * IsMemberCategorical(PyObject * self, PyObject * args)
 
     int64_t missed = 0;
 
+    try
+    {
     if (arrayType1 >= NPY_STRING)
     {
         LOGGING("Calling string/uni/void!\n");
@@ -277,6 +286,12 @@ PyObject * IsMemberCategorical(PyObject * self, PyObject * args)
             missed = IsMemberHashCategorical64(arraySize1, pDataIn1, arraySize2, pDataIn2, pDataOut2, sizeType1,
                                                HASH_MODE(hashMode), hintSize);
         }
+    }
+    }
+    catch( std::runtime_error const & e )
+    {
+        PyErr_Format(PyExc_RuntimeError, e.what() );
+        return NULL;
     }
 
     PyObject * retObject = Py_BuildValue("(LO)", missed, indexArray);

--- a/src/HashLinear.cpp
+++ b/src/HashLinear.cpp
@@ -6175,4 +6175,6 @@ PyObject * MergeBinnedAndSorted(PyObject * self, PyObject * args)
     return (PyObject *)indexArray;
 }
 
+#ifdef RT_COMPILER_MSVC
 template CHashLinear<uint64_t, int64_t>;
+#endif

--- a/src/HashLinear.cpp
+++ b/src/HashLinear.cpp
@@ -387,12 +387,12 @@ int64_t CHashLinear<T, U>::GetHashSize(int64_t numberOfEntries)
     else
     {
         // Power of 2 search
-        int64_t i = 0;
+        int32_t i = 0;
         while ((1LL << i) < numberOfEntries)
             i++;
 
         int64_t result = (1LL << i);
-        int64_t maxhashsize = (1LL << 63);
+        int64_t maxhashsize = (1LL << 31);
 
         // TODO: really need to change strategies if high unique count and high row
         // count

--- a/src/HashLinear.cpp
+++ b/src/HashLinear.cpp
@@ -1489,7 +1489,7 @@ void CHashLinear<T, U>::MakeHashLocation(int64_t arraySize, T * pHashList, int64
                                 hash = 0;
                             }
 
-                            if (hash == h)
+                            if (hash == static_cast<uint64_t>(h))
                             {
                                 throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
                             }

--- a/src/HashLinear.cpp
+++ b/src/HashLinear.cpp
@@ -370,15 +370,6 @@ bool STRING_MATCH2(const char * str1, const char * str2, int64_t strWidth1, int6
 template <typename T, typename U>
 int64_t CHashLinear<T, U>::GetHashSize(int64_t numberOfEntries)
 {
-    // Check for perfect hashes first when type size is small
-    // if (sizeof(T) == 1) {
-    //   return 256;
-    //}
-
-    // if (sizeof(T) == 2) {
-    //   return 65536;
-    //}
-
     if (HashMode == HASH_MODE_PRIME)
     {
         int i = 0;
@@ -386,14 +377,7 @@ int64_t CHashLinear<T, U>::GetHashSize(int64_t numberOfEntries)
         {
             if (PRIME_NUMBERS[i] > numberOfEntries)
             {
-                if (i == 0)
-                {
-                    return PRIME_NUMBERS[i];
-                }
-                else
-                {
-                    return PRIME_NUMBERS[i];
-                }
+                return PRIME_NUMBERS[i];
             }
             i++;
         }
@@ -403,12 +387,12 @@ int64_t CHashLinear<T, U>::GetHashSize(int64_t numberOfEntries)
     else
     {
         // Power of 2 search
-        int i = 0;
+        int64_t i = 0;
         while ((1LL << i) < numberOfEntries)
             i++;
 
         int64_t result = (1LL << i);
-        int64_t maxhashsize = (1LL << 31);
+        int64_t maxhashsize = (1LL << 63);
 
         // TODO: really need to change strategies if high unique count and high row
         // count
@@ -669,8 +653,6 @@ FORCE_INLINE void CHashLinear<T, U>::InternalSetLocation(U i, HashLocation * pLo
     pLocation[hash].Location = i;
     pLocation[hash].value = item;
 }
-
-#define INTERNAL_SET_LOCATION
 
 //-----------------------------------------------
 // stores the index of the first location
@@ -1670,8 +1652,6 @@ int64_t CHashLinear<T, U>::IsMemberCategorical(int64_t arraySize, T * pHashList,
         pLocationOutput[i] = BAD_INDEX; \
         pBoolOutput[i] = 0; \
     }
-
-#define INNER_GET_LOCATION
 
 //-----------------------------------------------
 // T is the input type byte/float32/float64/int8/uint8/int16/uint16/int32/...

--- a/src/HashLinear.cpp
+++ b/src/HashLinear.cpp
@@ -6175,6 +6175,4 @@ PyObject * MergeBinnedAndSorted(PyObject * self, PyObject * args)
     return (PyObject *)indexArray;
 }
 
-#ifdef RT_COMPILER_MSVC
-template CHashLinear<uint64_t, int64_t>;
-#endif
+template class CHashLinear<uint64_t, int64_t>;

--- a/src/HashLinear.cpp
+++ b/src/HashLinear.cpp
@@ -1403,7 +1403,7 @@ void CHashLinear<T, U>::MakeHashLocation(int64_t arraySize, T * pHashList, int64
                                 hash = 0;
                             }
 
-                            if (hash == h)
+                            if (hash == static_cast<uint64_t>(h))
                             {
                                 throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
                             }
@@ -1483,12 +1483,10 @@ void CHashLinear<T, U>::MakeHashLocation(int64_t arraySize, T * pHashList, int64
                                 /* Duplicate */
                                 break;
                             }
-                            /* This entry is not us so we must ha;
-                            }
-
-                            if (hash == h)
+                            /* This entry is not us so we must have collided */
+                            if (++hash >= HashSize)
                             {
-                                throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
+                                hash = 0;
                             }
 
                             if (hash == h)
@@ -1733,7 +1731,7 @@ void IsMember(void * pHashLinearVoid, int64_t arraySize, void * pHashListT, int8
                             {
                                 hash = 0;
                             }
-                            if (hash == h)
+                            if (hash == static_cast<uint64_t>(h))
                             {
                                 throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
                             }
@@ -1819,7 +1817,7 @@ void IsMember(void * pHashLinearVoid, int64_t arraySize, void * pHashListT, int8
                             {
                                 hash = 0;
                             }
-                            if (hash == h)
+                            if (hash == static_cast<uint64_t>(h))
                             {
                                 throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
                             }

--- a/src/HashLinear.cpp
+++ b/src/HashLinear.cpp
@@ -552,7 +552,7 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocation(U i, HashLocation * pLo
     const U BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
 
     uint64_t const h{ hash };
-    
+
     while (IsBitSet(hash))
     {
         // Check if we have a match from before
@@ -570,10 +570,10 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocation(U i, HashLocation * pLo
             hash = 0;
         }
 
-                            if (hash == h)
-                            {
-                                throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
-                            }
+        if (hash == h)
+        {
+            throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
+        }
     }
     // Not found
     pLocationOutput[i] = BAD_INDEX;
@@ -589,8 +589,8 @@ template <typename T, typename U>
 FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationCategorical(U i, HashLocation * pLocation, U * pLocationOutput, T item,
                                                                     uint64_t hash, int64_t * missed)
 {
-    uint64_t const h{hash};
-    
+    uint64_t const h{ hash };
+
     while (IsBitSet(hash))
     {
         // Check if we have a match from before
@@ -607,10 +607,10 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationCategorical(U i, HashLoc
             hash = 0;
         }
 
-                            if (hash == h)
-                            {
-                                throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
-                            }
+        if (hash == h)
+        {
+            throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
+        }
     }
     // Not found
     pLocationOutput[i] = 0;
@@ -623,8 +623,8 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationCategorical(U i, HashLoc
 template <typename T, typename U>
 FORCE_INLINE void CHashLinear<T, U>::InternalSetLocation(U i, HashLocation * pLocation, T item, uint64_t hash)
 {
-    uint64_t const h{hash};
-    
+    uint64_t const h{ hash };
+
     while (IsBitSet(hash))
     {
         // Check if we have a match from before
@@ -642,10 +642,10 @@ FORCE_INLINE void CHashLinear<T, U>::InternalSetLocation(U i, HashLocation * pLo
         {
             hash = 0;
         }
-                            if (hash == h)
-                            {
-                                throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
-                            }
+        if (hash == h)
+        {
+            throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
+        }
     }
     // Failed to find hash
     SetBit(hash);
@@ -688,7 +688,7 @@ void CHashLinear<T, U>::MakeHashLocationMK(int64_t arraySize, T * pInput, int64_
         const char * pMatch = reinterpret_cast<char const *>(pInput) + (totalItemSize * i);
         uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
         hash = hash & (HashSize - 1);
-        uint64_t const h{hash};
+        uint64_t const h{ hash };
 
         while (1)
         {
@@ -752,10 +752,10 @@ void CHashLinear<T, U>::MakeHashLocationMK(int64_t arraySize, T * pInput, int64_
                     hash = 0;
                 }
 
-                            if (hash == h)
-                            {
-                                throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
-                            }
+                if (hash == h)
+                {
+                    throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
+                }
                 continue;
             }
 
@@ -867,7 +867,7 @@ void CHashLinear<T, U>::FindLastMatchMK(int64_t arraySize1, int64_t arraySize2, 
             const char * pMatch1 = pKey1 + (totalItemSize * i);
             uint64_t hash = DEFAULT_HASH64(pMatch1, totalItemSize);
             hash = hash & (HashSize - 1);
-            uint64_t const h{hash};
+            uint64_t const h{ hash };
 
             // TODO: should maybe put begin .. end into function implementing lookup
             // for hashmap begin
@@ -892,10 +892,10 @@ void CHashLinear<T, U>::FindLastMatchMK(int64_t arraySize1, int64_t arraySize2, 
                         hash = 0;
                     }
 
-                            if (hash == h)
-                            {
-                                throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
-                            }
+                    if (hash == h)
+                    {
+                        throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
+                    }
                     continue;
                 }
                 // Not found
@@ -910,7 +910,7 @@ void CHashLinear<T, U>::FindLastMatchMK(int64_t arraySize1, int64_t arraySize2, 
             const char * pMatch1 = pKey2 + (totalItemSize * j);
             uint64_t hash = DEFAULT_HASH64(pMatch1, totalItemSize);
             hash = hash & (HashSize - 1);
-            uint64_t const h{hash};
+            uint64_t const h{ hash };
 
             // TODO: should maybe start .. end into a function implementing insertion
             // for hashmap begin
@@ -935,10 +935,10 @@ void CHashLinear<T, U>::FindLastMatchMK(int64_t arraySize1, int64_t arraySize2, 
                         hash = 0;
                     }
 
-                            if (hash == h)
-                            {
-                                throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
-                            }
+                    if (hash == h)
+                    {
+                        throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
+                    }
                     continue;
                 }
                 // Failed to find hash
@@ -956,7 +956,7 @@ void CHashLinear<T, U>::FindLastMatchMK(int64_t arraySize1, int64_t arraySize2, 
         const char * pMatch1 = pKey1 + (totalItemSize * i);
         uint64_t hash = DEFAULT_HASH64(pMatch1, totalItemSize);
         hash = hash & (HashSize - 1);
-        uint64_t const h{hash};
+        uint64_t const h{ hash };
 
         // TODO: should maybe put begin .. end into function implementing lookup for
         // hashmap begin
@@ -982,10 +982,10 @@ void CHashLinear<T, U>::FindLastMatchMK(int64_t arraySize1, int64_t arraySize2, 
                     hash = 0;
                 }
 
-                            if (hash == h)
-                            {
-                                throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
-                            }
+                if (hash == h)
+                {
+                    throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
+                }
                 continue;
             }
             // Not found
@@ -1025,7 +1025,7 @@ void CHashLinear<T, U>::FindNextMatchMK(int64_t arraySize1, int64_t arraySize2, 
             const char * pMatch1 = pKey1 + (totalItemSize * i);
             uint64_t hash = DEFAULT_HASH64(pMatch1, totalItemSize);
             hash = hash & (HashSize - 1);
-            uint64_t const h{hash};
+            uint64_t const h{ hash };
 
             // TODO: should maybe put begin .. end into function implementing lookup
             // for hashmap begin
@@ -1050,10 +1050,10 @@ void CHashLinear<T, U>::FindNextMatchMK(int64_t arraySize1, int64_t arraySize2, 
                         hash = 0;
                     }
 
-                            if (hash == h)
-                            {
-                                throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
-                            }
+                    if (hash == h)
+                    {
+                        throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
+                    }
                     continue;
                 }
                 // Not found
@@ -1071,8 +1071,8 @@ void CHashLinear<T, U>::FindNextMatchMK(int64_t arraySize1, int64_t arraySize2, 
 
             // TODO: should maybe start .. end into a function implementing insertion
             // for hashmap begin
-            uint64_t const h{hash};
-            
+            uint64_t const h{ hash };
+
             while (1)
             {
                 if (IsBitSet(hash))
@@ -1094,10 +1094,10 @@ void CHashLinear<T, U>::FindNextMatchMK(int64_t arraySize1, int64_t arraySize2, 
                         hash = 0;
                     }
 
-                            if (hash == h)
-                            {
-                                throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
-                            }
+                    if (hash == h)
+                    {
+                        throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
+                    }
                     continue;
                 }
                 // Failed to find hash
@@ -1118,8 +1118,8 @@ void CHashLinear<T, U>::FindNextMatchMK(int64_t arraySize1, int64_t arraySize2, 
 
         // TODO: should maybe put begin .. end into function implementing lookup for
         // hashmap begin
-        uint64_t const h{hash};
-        
+        uint64_t const h{ hash };
+
         while (1)
         {
             if (IsBitSet(hash))
@@ -1142,10 +1142,10 @@ void CHashLinear<T, U>::FindNextMatchMK(int64_t arraySize1, int64_t arraySize2, 
                     hash = 0;
                 }
 
-                            if (hash == h)
-                            {
-                                throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
-                            }
+                if (hash == h)
+                {
+                    throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
+                }
                 continue;
             }
             // Not found
@@ -1197,7 +1197,7 @@ static void IsMemberMK(void * pHashLinearVoid, int64_t arraySize, void * pInputT
         uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
         hash = hash & (HashSize - 1);
 
-        uint64_t const h{hash};
+        uint64_t const h{ hash };
 
         while (1)
         {
@@ -1223,10 +1223,10 @@ static void IsMemberMK(void * pHashLinearVoid, int64_t arraySize, void * pInputT
                     hash = 0;
                 }
 
-                            if (hash == h)
-                            {
-                                throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
-                            }
+                if (hash == h)
+                {
+                    throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
+                }
                 // printf("[%d] continue\n", (int)i);
                 continue;
             }
@@ -1357,10 +1357,10 @@ void CHashLinear<T, U>::MakeHashLocation(int64_t arraySize, T * pHashList, int64
                         hash = 0;
                     }
 
-                            if (hash == item)
-                            {
-                                throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
-                            }
+                    if (hash == item)
+                    {
+                        throw(std::runtime_error("About to go into infinite loop, need a smaller dataset"));
+                    }
                 }
                 else
                 {
@@ -1770,7 +1770,7 @@ void IsMember(void * pHashLinearVoid, int64_t arraySize, void * pHashListT, int8
                                 pBoolOutput[i] = 1;
                                 break;
                             }
-                               
+
                             if (hash >= HashSize)
                             {
                                 hash = 0;
@@ -2294,7 +2294,7 @@ void IsMemberFloat(void * pHashLinearVoid, int64_t arraySize, void * pHashListT,
                                 pBoolOutput[i] = 1;
                                 break;
                             }
-                            
+
                             if (hash >= HashSize)
                             {
                                 hash = 0;
@@ -2355,9 +2355,9 @@ void IsMemberFloat(void * pHashLinearVoid, int64_t arraySize, void * pHashListT,
                             {
                                 hash = 0;
                             }
-                            if ( hash == h)
+                            if (hash == h)
                             {
-                                                                throw(std::runtime_error(
+                                throw(std::runtime_error(
                                     "We are about to enter an infinite loop, we need a smaller set of uniques"));
                             }
                         }
@@ -2948,7 +2948,7 @@ uint64_t CHashLinear<T, U>::GroupBy(int64_t totalRows, int64_t totalItemSize, co
 
             // Use and mask to strip off high bits
             hash = hash & (HashSize - 1);
-            uint64_t const h{hash};
+            uint64_t const h{ hash };
             while (1)
             {
                 if (pBitFieldsX[hash >> 6] & (1LL << (hash & 63)))
@@ -3004,7 +3004,7 @@ uint64_t CHashLinear<T, U>::GroupBy(int64_t totalRows, int64_t totalItemSize, co
                 uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
                 // Use and mask to strip off high bits
                 hash = hash & (HashSize - 1);
-                uint64_t h{hash};
+                uint64_t h{ hash };
                 while (1)
                 {
                     if (pBitFieldsX[hash >> 6] & (1LL << (hash & 63)))
@@ -3115,7 +3115,7 @@ uint64_t CHashLinear<T, U>::GroupBySuper(int64_t totalRows, int64_t totalItemSiz
             // printf("%d", hash);
             // Use and mask to strip off high bits
             hash = hash & (HashSize - 1);
-            uint64_t const h{hash};
+            uint64_t const h{ hash };
             while (1)
             {
                 if (pBitFieldsX[hash >> 6] & (1LL << (hash & 63)))
@@ -3195,7 +3195,7 @@ uint64_t CHashLinear<T, U>::GroupBySuper(int64_t totalRows, int64_t totalItemSiz
                 // printf("%d", hash);
                 // Use and mask to strip off high bits
                 hash = hash & (HashSize - 1);
-                uint64_t const h{hash};
+                uint64_t const h{ hash };
                 while (1)
                 {
                     if (pBitFieldsX[hash >> 6] & (1LL << (hash & 63)))
@@ -3223,7 +3223,7 @@ uint64_t CHashLinear<T, U>::GroupBySuper(int64_t totalRows, int64_t totalItemSiz
                             pUniqueCountArray[pLocation[hash].UniqueKey]++;
                             break;
                         }
-                        
+
                         // Linear goes to next position
                         ++hash;
                         if (hash >= HashSize)
@@ -3332,7 +3332,7 @@ uint64_t CHashLinear<T, U>::Unique(int64_t totalRows, int64_t totalItemSize, con
                 uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
                 // Use and mask to strip off high bits
                 hash = hash & (HashSize - 1);
-                uint64_t const h{hash};
+                uint64_t const h{ hash };
                 while (1)
                 {
                     if (IsBitSet(hash))
@@ -3389,7 +3389,7 @@ uint64_t CHashLinear<T, U>::Unique(int64_t totalRows, int64_t totalItemSize, con
             uint64_t hash = DEFAULT_HASH64(pMatch, totalItemSize);
             // Use and mask to strip off high bits
             hash = hash & (HashSize - 1);
-            uint64_t h{hash};
+            uint64_t h{ hash };
             while (1)
             {
                 if (IsBitSet(hash))
@@ -3485,7 +3485,7 @@ void CHashLinear<T, U>::MultiKeyRolling(int64_t totalRows, int64_t totalItemSize
 
         // Use and mask to strip off high bits
         hash = hash & (HashSize - 1);
-        uint64_t const h{hash};
+        uint64_t const h{ hash };
         while (1)
         {
             if (IsBitSet(hash))
@@ -3570,7 +3570,7 @@ void CHashLinear<T, U>::MakeHashLocationMultiKey(int64_t totalRows, int64_t tota
         // printf("%d", hash);
         // Use and mask to strip off high bits
         hash = hash & (HashSize - 1);
-        uint64_t h{hash};
+        uint64_t h{ hash };
         while (1)
         {
             if (IsBitSet(hash))
@@ -3681,8 +3681,8 @@ template <typename T, typename U>
 FORCE_INLINE void CHashLinear<T, U>::InternalSetLocationString(U i, HashLocation * pLocation, const char * strValue,
                                                                int64_t strWidth, uint64_t hash)
 {
-    uint64_t const h{hash};
-    
+    uint64_t const h{ hash };
+
     while (IsBitSet(hash))
     {
         // Check if we have a match from before
@@ -3700,7 +3700,7 @@ FORCE_INLINE void CHashLinear<T, U>::InternalSetLocationString(U i, HashLocation
         }
         if (hash == h)
         {
-                    throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
+            throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
         }
     }
     // Failed to find hash
@@ -3717,8 +3717,8 @@ template <typename T, typename U>
 FORCE_INLINE void CHashLinear<T, U>::InternalSetLocationUnicode(U i, HashLocation * pLocation, const char * strValue,
                                                                 int64_t strWidth, uint64_t hash)
 {
-    uint64_t const h{hash};
-    
+    uint64_t const h{ hash };
+
     while (IsBitSet(hash))
     {
         // Check if we have a match from before
@@ -3739,7 +3739,7 @@ FORCE_INLINE void CHashLinear<T, U>::InternalSetLocationUnicode(U i, HashLocatio
         }
         if (hash == h)
         {
-                    throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
+            throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
         }
     }
     // Failed to find hash
@@ -3761,7 +3761,7 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationString(int64_t i, HashLo
                                                                uint64_t hash)
 {
     const U BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
-    uint64_t const h{hash};
+    uint64_t const h{ hash };
 
     while (IsBitSet(hash))
     {
@@ -3782,7 +3782,7 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationString(int64_t i, HashLo
         }
         if (hash == h)
         {
-                    throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
+            throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
         }
     }
     // Not found
@@ -3802,7 +3802,7 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationUnicode(int64_t i, HashL
                                                                 uint64_t hash)
 {
     const U BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
-    uint64_t const h{hash};
+    uint64_t const h{ hash };
 
     while (IsBitSet(hash))
     {
@@ -3821,9 +3821,9 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationUnicode(int64_t i, HashL
         {
             hash = 0;
         }
-        if( hash == h)
+        if (hash == h)
         {
-                    throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
+            throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
         }
     }
     // Not found
@@ -3843,7 +3843,7 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationString2(int64_t i, HashL
                                                                 int64_t strWidth2, uint64_t hash)
 {
     const U BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
-    uint64_t const h{hash};
+    uint64_t const h{ hash };
 
     while (IsBitSet(hash))
     {
@@ -3868,7 +3868,7 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationString2(int64_t i, HashL
         }
         if (hash == h)
         {
-                    throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
+            throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
         }
     }
     // Not found
@@ -3888,7 +3888,7 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationUnicode2(int64_t i, Hash
                                                                  int64_t strWidth2, uint64_t hash)
 {
     const U BAD_INDEX = (U)(1LL << (sizeof(U) * 8 - 1));
-    uint64_t const h{hash};
+    uint64_t const h{ hash };
 
     while (IsBitSet(hash))
     {
@@ -3913,7 +3913,7 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationUnicode2(int64_t i, Hash
         }
         if (hash == h)
         {
-                    throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
+            throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
         }
     }
     // Not found
@@ -3932,7 +3932,7 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationStringCategorical(int64_
                                                                           const char * strValue, int64_t strWidth, uint64_t hash,
                                                                           int64_t * missed)
 {
-    uint64_t const h{hash};
+    uint64_t const h{ hash };
     while (IsBitSet(hash))
     {
         // Check if we have a match from before
@@ -3949,9 +3949,9 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationStringCategorical(int64_
         {
             hash = 0;
         }
-        if(hash == h)
+        if (hash == h)
         {
-                    throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
+            throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
         }
     }
     // Not found
@@ -3971,7 +3971,7 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationString2Categorical(int64
                                                                            int64_t strWidth, int64_t strWidth2, uint64_t hash,
                                                                            int64_t * missed)
 {
-    uint64_t const h{hash};
+    uint64_t const h{ hash };
     while (IsBitSet(hash))
     {
         // Check if we have a match from before
@@ -3994,7 +3994,7 @@ FORCE_INLINE void CHashLinear<T, U>::InternalGetLocationString2Categorical(int64
         }
         if (hash == h)
         {
-                    throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
+            throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
         }
     }
     // Not found
@@ -4042,8 +4042,8 @@ static int64_t IsMemberStringCategorical(void * pHashLinearVoid, int64_t arraySi
 
                 // Use and mask to strip off high bits
                 hash = hash & (HashSize - 1);
-                uint64_t const h{hash};
-                
+                uint64_t const h{ hash };
+
                 while (1)
                 {
                     uint64_t index = hash >> 6;
@@ -4087,7 +4087,7 @@ static int64_t IsMemberStringCategorical(void * pHashLinearVoid, int64_t arraySi
 
                 // Use and mask to strip off high bits
                 hash = hash & (HashSize - 1);
-                uint64_t const h{hash};
+                uint64_t const h{ hash };
                 while (1)
                 {
                     uint64_t index = hash >> 6;
@@ -4135,7 +4135,7 @@ static int64_t IsMemberStringCategorical(void * pHashLinearVoid, int64_t arraySi
 
                 // Use and mask to strip off high bits
                 hash = hash & (pHashLinear->HashSize - 1);
-                uint64_t const h{hash};
+                uint64_t const h{ hash };
 
                 while (1)
                 {
@@ -4156,7 +4156,7 @@ static int64_t IsMemberStringCategorical(void * pHashLinearVoid, int64_t arraySi
                         {
                             hash = 0;
                         }
-                        if ( hash == h )
+                        if (hash == h)
                         {
                             throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
                         }
@@ -4180,7 +4180,7 @@ static int64_t IsMemberStringCategorical(void * pHashLinearVoid, int64_t arraySi
 
                 // Use and mask to strip off high bits
                 hash = hash & (pHashLinear->HashSize - 1);
-                uint64_t const h{hash};
+                uint64_t const h{ hash };
 
                 while (1)
                 {
@@ -4200,7 +4200,7 @@ static int64_t IsMemberStringCategorical(void * pHashLinearVoid, int64_t arraySi
                         {
                             hash = 0;
                         }
-                        if ( hash == h )
+                        if (hash == h)
                         {
                             throw(std::runtime_error("We are about to enter an infinite loop. We need a smaller set of uniques"));
                         }
@@ -5748,86 +5748,95 @@ PyObject * IsMember32(PyObject * self, PyObject * args)
 
     if (boolArray)
     {
-        void * pDataIn1 = PyArray_BYTES(inArr1);
-        void * pDataIn2 = PyArray_BYTES(inArr2);
-
-        int8_t * pDataOut1 = (int8_t *)PyArray_BYTES(boolArray);
-
-        PyArrayObject * indexArray = NULL;
-
-        LOGGING("Size array1: %llu   array2: %llu\n", arraySize1, arraySize2);
-
-        if (arrayType1 >= NPY_STRING)
+        try
         {
-            LOGGING("Calling string!\n");
+            void * pDataIn1 = PyArray_BYTES(inArr1);
+            void * pDataIn2 = PyArray_BYTES(inArr2);
 
-            // Performance gain: if STRING and itemsize matches and itemsize is 1 or 2
-            // --> Send to IsMemberHash32
-            IsMemberHashString32Pre(&indexArray, inArr1, arraySize1, sizeType1, (const char *)pDataIn1, arraySize2, sizeType2,
-                                    (const char *)pDataIn2, pDataOut1, HASH_MODE(hashMode), hintSize, arrayType1 == NPY_UNICODE);
-        }
-        else
-        {
-            if (arrayType1 == NPY_FLOAT32 || arrayType1 == NPY_FLOAT64)
-            {
-                LOGGING("Calling float!\n");
-                sizeType1 += 100;
-            }
+            int8_t * pDataOut1 = (int8_t *)PyArray_BYTES(boolArray);
 
-            int dtype = NPY_INT8;
+            PyArrayObject * indexArray = NULL;
 
-            if (arraySize2 < 100)
+            LOGGING("Size array1: %llu   array2: %llu\n", arraySize1, arraySize2);
+
+            if (arrayType1 >= NPY_STRING)
             {
-                dtype = NPY_INT8;
-            }
-            else if (arraySize2 < 30000)
-            {
-                dtype = NPY_INT16;
-            }
-            else if (arraySize2 < 2000000000)
-            {
-                dtype = NPY_INT32;
+                LOGGING("Calling string!\n");
+
+                // Performance gain: if STRING and itemsize matches and itemsize is 1 or 2
+                // --> Send to IsMemberHash32
+                IsMemberHashString32Pre(&indexArray, inArr1, arraySize1, sizeType1, (const char *)pDataIn1, arraySize2, sizeType2,
+                                        (const char *)pDataIn2, pDataOut1, HASH_MODE(hashMode), hintSize,
+                                        arrayType1 == NPY_UNICODE);
             }
             else
             {
-                dtype = NPY_INT64;
-            }
-
-            indexArray = AllocateLikeNumpyArray(inArr1, dtype);
-
-            // make sure allocation succeeded
-            if (indexArray)
-            {
-                void * pDataOut2 = PyArray_BYTES(indexArray);
-                switch (dtype)
+                if (arrayType1 == NPY_FLOAT32 || arrayType1 == NPY_FLOAT64)
                 {
-                case NPY_INT8:
-                    IsMemberHash32<int8_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int8_t *)pDataOut2, pDataOut1, sizeType1,
-                                           HASH_MODE(hashMode), hintSize);
-                    break;
-                case NPY_INT16:
-                    IsMemberHash32<int16_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int16_t *)pDataOut2, pDataOut1, sizeType1,
-                                            HASH_MODE(hashMode), hintSize);
-                    break;
-                CASE_NPY_INT32:
-                    IsMemberHash32<int32_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int32_t *)pDataOut2, pDataOut1, sizeType1,
-                                            HASH_MODE(hashMode), hintSize);
-                    break;
-                CASE_NPY_INT64:
-                    IsMemberHash32<int64_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int64_t *)pDataOut2, pDataOut1, sizeType1,
-                                            HASH_MODE(hashMode), hintSize);
-                    break;
+                    LOGGING("Calling float!\n");
+                    sizeType1 += 100;
+                }
+
+                int dtype = NPY_INT8;
+
+                if (arraySize2 < 100)
+                {
+                    dtype = NPY_INT8;
+                }
+                else if (arraySize2 < 30000)
+                {
+                    dtype = NPY_INT16;
+                }
+                else if (arraySize2 < 2000000000)
+                {
+                    dtype = NPY_INT32;
+                }
+                else
+                {
+                    dtype = NPY_INT64;
+                }
+
+                indexArray = AllocateLikeNumpyArray(inArr1, dtype);
+
+                // make sure allocation succeeded
+                if (indexArray)
+                {
+                    void * pDataOut2 = PyArray_BYTES(indexArray);
+                    switch (dtype)
+                    {
+                    case NPY_INT8:
+                        IsMemberHash32<int8_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int8_t *)pDataOut2, pDataOut1,
+                                               sizeType1, HASH_MODE(hashMode), hintSize);
+                        break;
+                    case NPY_INT16:
+                        IsMemberHash32<int16_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int16_t *)pDataOut2, pDataOut1,
+                                                sizeType1, HASH_MODE(hashMode), hintSize);
+                        break;
+                    CASE_NPY_INT32:
+                        IsMemberHash32<int32_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int32_t *)pDataOut2, pDataOut1,
+                                                sizeType1, HASH_MODE(hashMode), hintSize);
+                        break;
+                    CASE_NPY_INT64:
+                        IsMemberHash32<int64_t>(arraySize1, pDataIn1, arraySize2, pDataIn2, (int64_t *)pDataOut2, pDataOut1,
+                                                sizeType1, HASH_MODE(hashMode), hintSize);
+                        break;
+                    }
                 }
             }
+
+            if (indexArray)
+            {
+                PyObject * retObject = Py_BuildValue("(OO)", boolArray, indexArray);
+                Py_DECREF((PyObject *)boolArray);
+                Py_DECREF((PyObject *)indexArray);
+
+                return (PyObject *)retObject;
+            }
         }
-
-        if (indexArray)
+        catch (std::runtime_error const & e)
         {
-            PyObject * retObject = Py_BuildValue("(OO)", boolArray, indexArray);
-            Py_DECREF((PyObject *)boolArray);
-            Py_DECREF((PyObject *)indexArray);
-
-            return (PyObject *)retObject;
+            PyErr_Format(PyExc_RuntimeError, e.what());
+            return NULL;
         }
     }
     // out of memory

--- a/src/HashLinear.h
+++ b/src/HashLinear.h
@@ -36,8 +36,8 @@ template <typename U>
 void * IsMemberHash32(int64_t size1, void * pInput1, int64_t size2, void * pInput2, U * pOutput, int8_t * pBooleanOutput,
                       int32_t sizeType, HASH_MODE hashMode, int64_t hintSize);
 
-dll_export void * IsMemberHash64(int64_t size1, void * pInput1, int64_t size2, void * pInput2, int64_t * pOutput, int8_t * pBooleanOutput,
-                      int32_t sizeType, HASH_MODE hashMode, int64_t hintSize);
+dll_export void * IsMemberHash64(int64_t size1, void * pInput1, int64_t size2, void * pInput2, int64_t * pOutput,
+                                 int8_t * pBooleanOutput, int32_t sizeType, HASH_MODE hashMode, int64_t hintSize);
 
 int64_t IsMemberCategoricalHashStringPre(PyArrayObject ** indexArray, PyArrayObject * inArr1, int64_t size1, int64_t strWidth1,
                                          const char * pInput1, int64_t size2, int64_t strWidth2, const char * pInput2,
@@ -264,10 +264,6 @@ public:
 
     void * AllocMemory(int64_t numberOfEntries, int64_t sizeofStruct, int64_t sizeofExtraArray, bool isFloat);
 
-#if 0
-    void MakeHash(int64_t numberOfEntries, T * pHashList);
-#endif
-
     //-----------------------------------------------
     //----------------------------------------------
     //-----------------------------------------------
@@ -378,27 +374,6 @@ public:
     template <typename V>
     void FindNextMatchMK(int64_t arraySize1, int64_t arraySize2, T * pKey1, T * pKey2, V * pVal1, V * pVal2, U * pLocationOutput,
                          int64_t totalItemSize, bool allowExact);
-    //-----------------------------------------------
-    //-----------------------------------------------
-
-#if 0
-    void MakeHashFindNth(int64_t arraySize, T * pHashList,
-
-                         // optional FOR boolEAN OR INDEX MASK
-                         int64_t size2, U * pInput2,
-
-                         int8_t * pBooleanOutput, int64_t n);
-
-    void MakeHashFindNthFloat(int64_t arraySize, T * pHashList,
-
-                              // optional FOR boolEAN OR INDEX MASK
-                              int64_t size2, U * pInput2,
-
-                              int8_t * pBooleanOutput, int64_t n);
-
-    void InternalSetFindNth(U i, FindNthEntry * pLocation, int8_t * pBooleanOutput, int64_t n, T item, uint64_t hash);
-#endif
-
     //-----------------------------------------------
     //-----------------------------------------------
 

--- a/src/HashLinear.h
+++ b/src/HashLinear.h
@@ -5,6 +5,12 @@ PyObject * IsMember32(PyObject * self, PyObject * args);
 PyObject * IsMember64(PyObject * self, PyObject * args);
 PyObject * IsMemberCategorical(PyObject * self, PyObject * args);
 
+#if defined(_WIN32) && ! defined(__GNUC__)
+    #define dll_export __declspec(dllexport)
+#else
+    #define dll_export
+#endif
+
 enum HASH_MODE
 {
     HASH_MODE_PRIME = 1,
@@ -30,7 +36,7 @@ template <typename U>
 void * IsMemberHash32(int64_t size1, void * pInput1, int64_t size2, void * pInput2, U * pOutput, int8_t * pBooleanOutput,
                       int32_t sizeType, HASH_MODE hashMode, int64_t hintSize);
 
-void * IsMemberHash64(int64_t size1, void * pInput1, int64_t size2, void * pInput2, int64_t * pOutput, int8_t * pBooleanOutput,
+dll_export void * IsMemberHash64(int64_t size1, void * pInput1, int64_t size2, void * pInput2, int64_t * pOutput, int8_t * pBooleanOutput,
                       int32_t sizeType, HASH_MODE hashMode, int64_t hintSize);
 
 int64_t IsMemberCategoricalHashStringPre(PyArrayObject ** indexArray, PyArrayObject * inArr1, int64_t size1, int64_t strWidth1,
@@ -247,26 +253,9 @@ public:
 public:
     // Parallel hashing does not want memory deallocated so it will set deallocate
     // to false
-    CHashLinear(HASH_MODE hashMode = HASH_MODE_PRIME, bool deallocate = true)
-    {
-        pHashTableAny = NULL;
-        pBitFields = NULL;
+    dll_export CHashLinear(HASH_MODE hashMode = HASH_MODE_PRIME, bool deallocate = true);
 
-        NumEntries = 0;
-        NumUnique = 0;
-        NumCollisions = 0;
-        HashSize = 0;
-        HashMode = hashMode;
-        Deallocate = deallocate;
-
-        // Can set bad index to 0?
-        // BAD_INDEX = (U)(1LL << (sizeof(U)*8-1));
-    }
-
-    ~CHashLinear()
-    {
-        FreeMemory(false);
-    }
+    dll_export ~CHashLinear();
 
     void FreeMemory(bool forceDeallocate);
 
@@ -275,7 +264,9 @@ public:
 
     void * AllocMemory(int64_t numberOfEntries, int64_t sizeofStruct, int64_t sizeofExtraArray, bool isFloat);
 
+#if 0
     void MakeHash(int64_t numberOfEntries, T * pHashList);
+#endif
 
     //-----------------------------------------------
     //----------------------------------------------
@@ -363,7 +354,7 @@ public:
     //-----------------------------------------------
     void MakeHashLocationMK(int64_t arraySize, T * pInput, int64_t totalItemSize, int64_t hintSize);
 
-    void MakeHashLocation(int64_t arraySize, T * pHashList, int64_t hintSize);
+    dll_export void MakeHashLocation(int64_t arraySize, T * pHashList, int64_t hintSize);
 
     void InternalSetLocation(U i, HashLocation * pLocation, T item, uint64_t hash);
 
@@ -390,6 +381,7 @@ public:
     //-----------------------------------------------
     //-----------------------------------------------
 
+#if 0
     void MakeHashFindNth(int64_t arraySize, T * pHashList,
 
                          // optional FOR boolEAN OR INDEX MASK
@@ -405,6 +397,7 @@ public:
                               int8_t * pBooleanOutput, int64_t n);
 
     void InternalSetFindNth(U i, FindNthEntry * pLocation, int8_t * pBooleanOutput, int64_t n, T item, uint64_t hash);
+#endif
 
     //-----------------------------------------------
     //-----------------------------------------------

--- a/src/Recycler.cpp
+++ b/src/Recycler.cpp
@@ -58,7 +58,6 @@ void * FmAlloc(size_t _Size)
         // Skip past guard
         return &pageGuard[2];
     }
-    std::cerr << _HEAP_MAXREQ << ", " << errno << "\n";
     return NULL;
 }
 

--- a/src/Recycler.cpp
+++ b/src/Recycler.cpp
@@ -58,6 +58,7 @@ void * FmAlloc(size_t _Size)
         // Skip past guard
         return &pageGuard[2];
     }
+    std::cerr << _HEAP_MAXREQ << ", " << errno << "\n";
     return NULL;
 }
 

--- a/src/RipTide.h
+++ b/src/RipTide.h
@@ -4,7 +4,7 @@
 
 // Undo the damage we're going to cause by undefining a reserved macro name
 #if defined(_MSC_VER) && defined(_DEBUG) && _MSC_VER >= 1930
-#include <corecrt.h>
+    #include <corecrt.h>
 #endif
 
 // Hack because debug builds force python36_d.lib

--- a/src/UnaryOps.cpp
+++ b/src/UnaryOps.cpp
@@ -655,7 +655,6 @@ static const inline __m256d SQRT_OP_256(__m256d x)
 
 //_mm256_xor_si256
 
-
 //-------------------------------------------------------------------
 // T = data type as input
 // MathOp operation to perform
@@ -668,8 +667,8 @@ static inline void UnaryOpFast(void * pDataIn, void * pDataOut, int64_t len, int
 
     int64_t chunkSize = sizeof(U256) / sizeof(T);
     LOGGING("unary op fast strides %lld %lld   sizeof: %lld\n", strideIn, strideOut, sizeof(T));
-    if (sizeof(T) == strideOut && sizeof(T) == strideIn && len >= chunkSize
-        && is_ptr_aligned_as<U256>(pDataIn) && is_ptr_aligned_as<U256>(pDataOut))
+    if (sizeof(T) == strideOut && sizeof(T) == strideIn && len >= chunkSize && is_ptr_aligned_as<U256>(pDataIn) &&
+        is_ptr_aligned_as<U256>(pDataOut))
     {
         // possible to align 32 bit boundary?
         // if (((int64_t)pDataOut & 31) != 0) {
@@ -726,8 +725,8 @@ static inline void UnaryOpFastStrided(void * pDataIn, void * pDataOut, int64_t l
 
     // TOOD: ensure stride*len < 2billion
     // assumes output not strided
-    if (sizeof(T) == strideOut && sizeof(T) == strideIn && len >= chunkSize
-        && is_ptr_aligned_as<U256>(pDataIn) && is_ptr_aligned_as<U256>(pDataOut))
+    if (sizeof(T) == strideOut && sizeof(T) == strideIn && len >= chunkSize && is_ptr_aligned_as<U256>(pDataIn) &&
+        is_ptr_aligned_as<U256>(pDataOut))
     {
         const int64_t innerloopLen = chunkSize * (len / chunkSize);
         T * pEnd = &pOut[innerloopLen];
@@ -780,8 +779,7 @@ static inline void UnaryNanFastFloat(MathFunctionPtr MATH_OP, void * pDataIn, vo
 
     int64_t chunkSize = sizeof(U256) / sizeof(T);
 
-    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize
-        && is_ptr_aligned_as<U256>(pDataIn))
+    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize && is_ptr_aligned_as<U256>(pDataIn))
     {
         bool * pEnd = &pOut[chunkSize * (len / chunkSize)];
         int64_t * pEnd_i64 = (int64_t *)pEnd;
@@ -828,8 +826,7 @@ static inline void UnaryNanFastDouble(MathFunctionPtr MATH_OP, void * pDataIn, v
     bool * pLastOut = (bool *)((char *)pOut + (strideOut * len));
 
     int64_t chunkSize = sizeof(U256) / sizeof(T);
-    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize
-        && is_ptr_aligned_as<U256>(pDataIn))
+    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize && is_ptr_aligned_as<U256>(pDataIn))
     {
         bool * pEnd = &pOut[chunkSize * (len / chunkSize)];
         int32_t * pEnd_i32 = (int32_t *)pEnd;
@@ -873,8 +870,7 @@ static inline void UnaryNotNanFastFloat(MathFunctionPtr MATH_OP, void * pDataIn,
 
     int64_t chunkSize = sizeof(U256) / sizeof(T);
 
-    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize
-        && is_ptr_aligned_as<U256>(pDataIn))
+    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize && is_ptr_aligned_as<U256>(pDataIn))
     {
         bool * pEnd = &pOut[chunkSize * (len / chunkSize)];
         int64_t * pEnd_i64 = (int64_t *)pEnd;
@@ -919,8 +915,7 @@ static inline void UnaryNotNanFastDouble(MathFunctionPtr MATH_OP, void * pDataIn
 
     int64_t chunkSize = sizeof(U256) / sizeof(T);
 
-    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize
-        && is_ptr_aligned_as<U256>(pDataIn))
+    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize && is_ptr_aligned_as<U256>(pDataIn))
     {
         bool * pEnd = &pOut[chunkSize * (len / chunkSize)];
         int32_t * pEnd_i32 = (int32_t *)pEnd;
@@ -963,8 +958,7 @@ static inline void UnaryFiniteFastFloat(MathFunctionPtr MATH_OP, void * pDataIn,
 
     int64_t chunkSize = sizeof(U256) / sizeof(T);
 
-    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize
-        && is_ptr_aligned_as<U256>(pDataIn))
+    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize && is_ptr_aligned_as<U256>(pDataIn))
     {
         bool * pEnd = &pOut[chunkSize * (len / chunkSize)];
         int64_t * pEnd_i64 = (int64_t *)pEnd;
@@ -1011,8 +1005,7 @@ static inline void UnaryFiniteFastDouble(MathFunctionPtr MATH_OP, void * pDataIn
     bool * pLastOut = (bool *)((char *)pOut + (strideOut * len));
 
     int64_t chunkSize = sizeof(U256) / sizeof(T);
-    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize
-        && is_ptr_aligned_as<U256>(pDataIn))
+    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize && is_ptr_aligned_as<U256>(pDataIn))
     {
         bool * pEnd = &pOut[chunkSize * (len / chunkSize)];
         int32_t * pEnd_i32 = (int32_t *)pEnd;
@@ -1059,8 +1052,7 @@ static inline void UnaryNotFiniteFastFloat(MathFunctionPtr MATH_OP, void * pData
 
     int64_t chunkSize = sizeof(U256) / sizeof(T);
 
-    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize
-        && is_ptr_aligned_as<U256>(pDataIn))
+    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize && is_ptr_aligned_as<U256>(pDataIn))
     {
         bool * pEnd = &pOut[chunkSize * (len / chunkSize)];
         int64_t * pEnd_i64 = (int64_t *)pEnd;
@@ -1108,8 +1100,7 @@ static inline void UnaryNotFiniteFastDouble(MathFunctionPtr MATH_OP, void * pDat
 
     int64_t chunkSize = sizeof(U256) / sizeof(T);
 
-    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize
-        && is_ptr_aligned_as<U256>(pDataIn))
+    if (sizeof(bool) == strideOut && sizeof(T) == strideIn && len >= chunkSize && is_ptr_aligned_as<U256>(pDataIn))
     {
         bool * pEnd = &pOut[chunkSize * (len / chunkSize)];
         int32_t * pEnd_i32 = (int32_t *)pEnd;

--- a/test/riptide_python_test/CMakeLists.txt
+++ b/test/riptide_python_test/CMakeLists.txt
@@ -29,6 +29,7 @@ set(CMAKE_VERBOSE_MAKEFILE on)
 
 set(SOURCES
 	ema_test.cpp
+	hash_linear_tests.cpp
     main.cpp
 	tests.cpp
 	reduce_tests.cpp

--- a/test/riptide_python_test/hash_linear_tests.cpp
+++ b/test/riptide_python_test/hash_linear_tests.cpp
@@ -42,5 +42,25 @@ namespace
                        }
                        ));
         };
+
+        "ismember64_type_coercion_effects_rip-254"_test = [&]
+        {
+            std::vector<uint64_t> haystack{ 3ULL, 0x7F'FF'FF'FF'FF'FF'FF'FEULL };
+            std::vector<int64_t> needles{ 0x7F'FF'FF'FF'FF'FF'FF'FEULL };
+    
+            expect(not throws<std::runtime_error>(
+                       [&]
+                       {
+                           IsMemberHash64(needles.size(), needles.data(), haystack.size(), haystack.data(), output.data(), bools.data(), 8, HASH_MODE(0), 0);
+                       }
+                       ));
+
+            expect(not throws<std::runtime_error>(
+                       [&]
+                       {
+                           IsMemberHash64(needles.size(), needles.data(), haystack.size(), haystack.data(), output.data(), bools.data(), 8, HASH_MODE(1), 0);
+                       }
+                       ));
+        };
     };
 }

--- a/test/riptide_python_test/hash_linear_tests.cpp
+++ b/test/riptide_python_test/hash_linear_tests.cpp
@@ -20,7 +20,7 @@ namespace
 {
     std::array<int64_t, 1024ULL * 1024ULL> output;
     std::array<int8_t, 1024ULL * 1024ULL> bools;
-    
+
     suite hash_linear_ops = []
     {
         "ismember64_uint64_too_many_uniques"_test = [&]
@@ -30,37 +30,37 @@ namespace
             std::random_device dev{};
             std::mt19937 engine(dev());
             std::uniform_int_distribution<uint64_t> dist(3002950000, haystack.size() + 3002950000);
-            
+
             std::iota(std::begin(haystack), std::end(haystack), 3002954000);
-            std::generate(std::begin(needles), std::end(needles), [&]{return dist(engine);});
-    
+            std::generate(std::begin(needles), std::end(needles), [&] { return dist(engine); });
+
             expect(throws<std::runtime_error>(
-                       [&]
-                       {
-                           // Note the reversed order of haystack and needles in this call - more unique needles than uniques in haystack
-                           IsMemberHash64(haystack.size(), haystack.data(), needles.size(), needles.data(), output.data(), bools.data(), 8, HASH_MODE(1), 0);
-                       }
-                       ));
+                [&]
+                {
+                    // Note the reversed order of haystack and needles in this call - more unique needles than uniques in haystack
+                    IsMemberHash64(haystack.size(), haystack.data(), needles.size(), needles.data(), output.data(), bools.data(),
+                                   8, HASH_MODE(1), 0);
+                }));
         };
 
         "ismember64_type_coercion_effects_rip-254"_test = [&]
         {
             std::vector<uint64_t> haystack{ 3ULL, 0x7F'FF'FF'FF'FF'FF'FF'FEULL };
             std::vector<int64_t> needles{ 0x7F'FF'FF'FF'FF'FF'FF'FEULL };
-    
-            expect(not throws<std::runtime_error>(
-                       [&]
-                       {
-                           IsMemberHash64(needles.size(), needles.data(), haystack.size(), haystack.data(), output.data(), bools.data(), 8, HASH_MODE(0), 0);
-                       }
-                       ));
 
             expect(not throws<std::runtime_error>(
-                       [&]
-                       {
-                           IsMemberHash64(needles.size(), needles.data(), haystack.size(), haystack.data(), output.data(), bools.data(), 8, HASH_MODE(1), 0);
-                       }
-                       ));
+                [&]
+                {
+                    IsMemberHash64(needles.size(), needles.data(), haystack.size(), haystack.data(), output.data(), bools.data(),
+                                   8, HASH_MODE(0), 0);
+                }));
+
+            expect(not throws<std::runtime_error>(
+                [&]
+                {
+                    IsMemberHash64(needles.size(), needles.data(), haystack.size(), haystack.data(), output.data(), bools.data(),
+                                   8, HASH_MODE(1), 0);
+                }));
         };
     };
 }

--- a/test/riptide_python_test/hash_linear_tests.cpp
+++ b/test/riptide_python_test/hash_linear_tests.cpp
@@ -1,0 +1,46 @@
+#include "riptide_python_test.h"
+
+#include "HashLinear.h"
+
+#define BOOST_UT_DISABLE_MODULE
+#include "../ut/include/boost/ut.hpp"
+
+#include <array>
+#include <vector>
+#include <numeric>
+#include <algorithm>
+#include <random>
+#include <iomanip>
+#include <exception>
+
+using namespace boost::ut;
+using boost::ut::suite;
+
+namespace
+{
+    std::array<int64_t, 1024ULL * 1024ULL> output;
+    std::array<int8_t, 1024ULL * 1024ULL> bools;
+    
+    suite hash_linear_ops = []
+    {
+        "ismember64_uint64_too_many_uniques"_test = [&]
+        {
+            std::vector<uint64_t> haystack(2 * 128 * 1024ULL * 1024ULL);
+            std::vector<uint64_t> needles(1024ULL * 1024ULL);
+            std::random_device dev{};
+            std::mt19937 engine(dev());
+            std::uniform_int_distribution<uint64_t> dist(3002950000, haystack.size() + 3002950000);
+            
+            std::iota(std::begin(haystack), std::end(haystack), 3002954000);
+            std::generate(std::begin(needles), std::end(needles), [&]{return dist(engine);});
+    
+            expect(throws<std::runtime_error>(
+                       [&]
+                       {
+                           // Note the reversed order of haystack and needles in this call - more unique needles than uniques in haystack
+                           IsMemberHash64(haystack.size(), haystack.data(), needles.size(), needles.data(), output.data(), bools.data(), 8, HASH_MODE(1), 0);
+                       }
+                       ));
+        };
+    };
+}


### PR DESCRIPTION
Trap after once around the eternal loop constructs, throw an exception that we catch at the top, and pass that back as the Python result object. In multi-threaded domains this may well just throw and exit the thread, in which case there's nothing to do I suspect.

Also the usual clang-format pickups.