### PR TITLE
Add joining of awoken workers

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,6 +113,8 @@ add_library(${TARGET_NAME} SHARED
     ${HEADERS}
     ${SOURCES})
 
+target_compile_definitions(${TARGET_NAME} PRIVATE BUILDING_RIPTIDE_CPP)
+
 get_target_property(RT_SOURCE_DIR riptide_cpp SOURCE_DIR)
 
 target_include_directories(${TARGET_NAME} PRIVATE

--- a/src/CommonInc.h
+++ b/src/CommonInc.h
@@ -11,6 +11,8 @@
 #include <cmath>
 #include <cstring>
 
+#include "Defs.h"
+
 #if defined(_WIN32) && ! defined(__GNUC__)
     #define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
     #define NOMINMAX
@@ -19,17 +21,6 @@
     #include <winnt.h>
 #else
 
-#endif
-
-// Export DLL section
-#if defined(_WIN32) && ! defined(__GNUC__)
-# ifdef BUILDING_RIPTIDE_CPP
-#  define DllExport __declspec(dllexport)
-# else
-#  define DllExport __declspec(dllimport)
-# endif
-#else
-# define DllExport
 #endif
 
 using HANDLE = void *;

--- a/src/CommonInc.h
+++ b/src/CommonInc.h
@@ -21,6 +21,17 @@
 
 #endif
 
+// Export DLL section
+#if defined(_WIN32) && ! defined(__GNUC__)
+# ifdef BUILDING_RIPTIDE_CPP
+#  define DllExport __declspec(dllexport)
+# else
+#  define DllExport __declspec(dllimport)
+# endif
+#else
+# define DllExport
+#endif
+
 using HANDLE = void *;
 
 #ifdef RtlEqualMemory

--- a/src/CommonInc.h
+++ b/src/CommonInc.h
@@ -108,6 +108,7 @@ using LPVOID = void *;
     // consider sync_add_and_fetch
     #define InterlockedAdd64(val, len) (__sync_fetch_and_add(val, len) + len)
     #define InterlockedIncrement64(val) (__sync_fetch_and_add(val, 1) + 1)
+    #define InterlockedDecrement64(val) (__sync_fetch_and_add(val, -1) - 1)
     #define YieldProcessor _mm_pause
     #define InterlockedIncrement(val) (__sync_fetch_and_add(val, 1) + 1)
     #define FMInterlockedOr(val, bitpos) (__sync_fetch_and_or(val, bitpos))

--- a/src/Defs.h
+++ b/src/Defs.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// Basic cross-platform definitions.
+
+// Export DLL section
+#if defined(_WIN32) && ! defined(__GNUC__)
+# ifdef BUILDING_RIPTIDE_CPP
+#  define DllExport __declspec(dllexport)
+# else
+#  define DllExport __declspec(dllimport)
+# endif
+#else
+# define DllExport
+#endif

--- a/src/HashLinear.h
+++ b/src/HashLinear.h
@@ -1,15 +1,11 @@
 #pragma once
 #include <assert.h>
 
+#include "Defs.h"
+
 PyObject * IsMember32(PyObject * self, PyObject * args);
 PyObject * IsMember64(PyObject * self, PyObject * args);
 PyObject * IsMemberCategorical(PyObject * self, PyObject * args);
-
-#if defined(_WIN32) && ! defined(__GNUC__)
-    #define dll_export __declspec(dllexport)
-#else
-    #define dll_export
-#endif
 
 enum HASH_MODE
 {
@@ -36,7 +32,7 @@ template <typename U>
 void * IsMemberHash32(int64_t size1, void * pInput1, int64_t size2, void * pInput2, U * pOutput, int8_t * pBooleanOutput,
                       int32_t sizeType, HASH_MODE hashMode, int64_t hintSize);
 
-dll_export void * IsMemberHash64(int64_t size1, void * pInput1, int64_t size2, void * pInput2, int64_t * pOutput,
+DllExport void * IsMemberHash64(int64_t size1, void * pInput1, int64_t size2, void * pInput2, int64_t * pOutput,
                                  int8_t * pBooleanOutput, int32_t sizeType, HASH_MODE hashMode, int64_t hintSize);
 
 int64_t IsMemberCategoricalHashStringPre(PyArrayObject ** indexArray, PyArrayObject * inArr1, int64_t size1, int64_t strWidth1,
@@ -253,9 +249,9 @@ public:
 public:
     // Parallel hashing does not want memory deallocated so it will set deallocate
     // to false
-    dll_export CHashLinear(HASH_MODE hashMode = HASH_MODE_PRIME, bool deallocate = true);
+    DllExport CHashLinear(HASH_MODE hashMode = HASH_MODE_PRIME, bool deallocate = true);
 
-    dll_export ~CHashLinear();
+    DllExport ~CHashLinear();
 
     void FreeMemory(bool forceDeallocate);
 
@@ -350,7 +346,7 @@ public:
     //-----------------------------------------------
     void MakeHashLocationMK(int64_t arraySize, T * pInput, int64_t totalItemSize, int64_t hintSize);
 
-    dll_export void MakeHashLocation(int64_t arraySize, T * pHashList, int64_t hintSize);
+    DllExport void MakeHashLocation(int64_t arraySize, T * pHashList, int64_t hintSize);
 
     void InternalSetLocation(U i, HashLocation * pLocation, T item, uint64_t hash);
 

--- a/src/MathThreads.cpp
+++ b/src/MathThreads.cpp
@@ -124,6 +124,7 @@ void * WorkerThreadFunction(void * lpParam)
             if (wakeup >= 0)
             {
                 didSomeWork = pWorkItem->DoWork(core, workIndex);
+                InterlockedIncrement64(&pWorkItem->ThreadCompleted);
             }
             else
             {
@@ -131,8 +132,9 @@ void * WorkerThreadFunction(void * lpParam)
                 // workIndex, workIndexCompleted); workIndex++;
             }
 #else
+            // On Linux futex guarantees at most requested waiters are awakened (TODO: trust but verify?)
             didSomeWork = pWorkItem->DoWork(core, workIndex);
-
+            InterlockedIncrement64(&pWorkItem->ThreadCompleted);
 #endif
         }
 

--- a/src/MathThreads.cpp
+++ b/src/MathThreads.cpp
@@ -117,7 +117,7 @@ void * WorkerThreadFunction(void * lpParam)
         if (workIndex > workIndexCompleted)
         {
             stMATH_WORKER_ITEM * pWorkItem = pWorkerRing->GetExistingWorkItem();
-            InterlockedIncrement64(&pWorkItem->ThreadWoken);
+            InterlockedIncrement64(&pWorkItem->ThreadAwakened);
 
 #if defined(RT_OS_WINDOWS)
             // Windows we check if the work was for our thread
@@ -134,7 +134,7 @@ void * WorkerThreadFunction(void * lpParam)
 #else
             didSomeWork = pWorkItem->DoWork(core, workIndex);
 #endif
-            InterlockedDecrement64(&pWorkItem->ThreadWoken);
+            InterlockedDecrement64(&pWorkItem->ThreadAwakened);
         }
 
         if (! didSomeWork)

--- a/src/MathThreads.h
+++ b/src/MathThreads.h
@@ -63,8 +63,8 @@ typedef void(WINAPI * WakeSingleAddress)(void *);
 typedef void(WINAPI * WakeAllAddress)(void *);
 typedef bool(WINAPI * WaitAddress)(volatile void *, void *, size_t, uint32_t);
 
-extern WakeSingleAddress g_WakeSingleAddress;
-extern WakeAllAddress g_WakeAllAddress;
+extern DllExport WakeSingleAddress g_WakeSingleAddress;
+extern DllExport WakeAllAddress g_WakeAllAddress;
 extern WaitAddress g_WaitAddress;
 
 // Forward declaration

--- a/src/MathThreads.h
+++ b/src/MathThreads.h
@@ -189,6 +189,7 @@ struct stMATH_WORKER_ITEM
 
     // How many threads to wake up (atomic decrement)
     int64_t ThreadWakeup;
+    int64_t ThreadCompleted; // How many awoken threads have completed
 
     // Used when calling MultiThreadedWork
     union

--- a/src/MathThreads.h
+++ b/src/MathThreads.h
@@ -189,7 +189,9 @@ struct stMATH_WORKER_ITEM
 
     // How many threads to wake up (atomic decrement)
     int64_t ThreadWakeup;
-    int64_t ThreadWoken; // How many threads have awoken
+
+    // How many threads have been awakened (possibly executing callbacks).
+    int64_t ThreadAwakened;
 
     // Used when calling MultiThreadedWork
     union

--- a/src/MathThreads.h
+++ b/src/MathThreads.h
@@ -189,7 +189,7 @@ struct stMATH_WORKER_ITEM
 
     // How many threads to wake up (atomic decrement)
     int64_t ThreadWakeup;
-    int64_t ThreadCompleted; // How many awoken threads have completed
+    int64_t ThreadWoken; // How many threads have awoken
 
     // Used when calling MultiThreadedWork
     union

--- a/src/MathWorker.h
+++ b/src/MathWorker.h
@@ -436,7 +436,7 @@ public:
 
         // only windows uses this for now
         pWorkItem->ThreadWakeup = threadWakeup;
-        pWorkItem->ThreadWoken = 0;
+        pWorkItem->ThreadAwakened = 0;
 
         if (bGenericMode)
         {
@@ -485,10 +485,10 @@ public:
             }
         }
 
-        // Join all awoken threads.
-        while (pWorkItem->ThreadWoken != 0)
+        // Join all awakened threads.
+        while (pWorkItem->ThreadAwakened != 0)
         {
-            MATHLOGGING("Joining %llu\n", pWorkItem->ThreadWoken);
+            MATHLOGGING("Joining %llu\n", pWorkItem->ThreadAwakened);
             YieldProcessor();
         }
 

--- a/src/MathWorker.h
+++ b/src/MathWorker.h
@@ -798,4 +798,4 @@ public:
 
 //------------------------------------------------------------
 // declare the global math worker
-extern CMathWorker * g_cMathWorker;
+extern DllExport CMathWorker * g_cMathWorker;

--- a/src/MathWorker.h
+++ b/src/MathWorker.h
@@ -436,7 +436,7 @@ public:
 
         // only windows uses this for now
         pWorkItem->ThreadWakeup = threadWakeup;
-        pWorkItem->ThreadCompleted = 0;
+        pWorkItem->ThreadWoken = 0;
 
         if (bGenericMode)
         {
@@ -487,9 +487,9 @@ public:
 
 #if 1
         // Join all active threads.
-        while (pWorkItem->ThreadCompleted != threadWakeup)
+        while (pWorkItem->ThreadWoken != 0)
         {
-            MATHLOGGING("Joining %llu\n", pWorkItem->ThreadCompleted);
+            MATHLOGGING("Joining %llu\n", pWorkItem->ThreadWoken);
             YieldProcessor();
         }
 #endif

--- a/src/MathWorker.h
+++ b/src/MathWorker.h
@@ -436,6 +436,7 @@ public:
 
         // only windows uses this for now
         pWorkItem->ThreadWakeup = threadWakeup;
+        pWorkItem->ThreadCompleted = 0;
 
         if (bGenericMode)
         {
@@ -483,6 +484,15 @@ public:
                 // Sleep(0);
             }
         }
+
+#if 1
+        // Join all active threads.
+        while (pWorkItem->ThreadCompleted != threadWakeup)
+        {
+            MATHLOGGING("Joining %llu\n", pWorkItem->ThreadCompleted);
+            YieldProcessor();
+        }
+#endif
 
         // Mark this as completed
         pWorkerRing->CompleteWorkItem();

--- a/src/MathWorker.h
+++ b/src/MathWorker.h
@@ -485,14 +485,12 @@ public:
             }
         }
 
-#if 1
-        // Join all active threads.
+        // Join all awoken threads.
         while (pWorkItem->ThreadWoken != 0)
         {
             MATHLOGGING("Joining %llu\n", pWorkItem->ThreadWoken);
             YieldProcessor();
         }
-#endif
 
         // Mark this as completed
         pWorkerRing->CompleteWorkItem();

--- a/test/riptide_python_test/CMakeLists.txt
+++ b/test/riptide_python_test/CMakeLists.txt
@@ -31,6 +31,7 @@ set(SOURCES
 	ema_test.cpp
 	hash_linear_tests.cpp
     main.cpp
+    math_worker_tests.cpp
 	tests.cpp
 	reduce_tests.cpp
 	utility_functions.cpp)

--- a/test/riptide_python_test/math_worker_tests.cpp
+++ b/test/riptide_python_test/math_worker_tests.cpp
@@ -6,6 +6,7 @@
 #include "../ut/include/boost/ut.hpp"
 
 #include <mutex>
+#include <condition_variable>
 
 using namespace boost::ut;
 using boost::ut::suite;

--- a/test/riptide_python_test/math_worker_tests.cpp
+++ b/test/riptide_python_test/math_worker_tests.cpp
@@ -7,6 +7,7 @@
 
 #include <mutex>
 #include <condition_variable>
+#include <thread>
 
 using namespace boost::ut;
 using boost::ut::suite;

--- a/test/riptide_python_test/math_worker_tests.cpp
+++ b/test/riptide_python_test/math_worker_tests.cpp
@@ -1,0 +1,134 @@
+#include "riptide_python_test.h"
+
+#include "MathWorker.h"
+
+#define BOOST_UT_DISABLE_MODULE
+#include "../ut/include/boost/ut.hpp"
+
+#include <mutex>
+
+using namespace boost::ut;
+using boost::ut::suite;
+
+namespace
+{
+    struct CALLBACK_INFO
+    {
+        std::mutex mutex_;
+
+        enum class WorkerState
+        {
+            INITIAL,
+            READY,
+            DONE
+        } workerState_{WorkerState::INITIAL};
+        std::condition_variable workerSignal_;
+
+        enum class MainState
+        {
+            INITIAL,
+            DONE
+        } mainState_{MainState::INITIAL};
+        std::condition_variable mainSignal_;
+    };
+
+    static bool Callback(struct stMATH_WORKER_ITEM * pstWorkerItem, int core, int64_t workIndex)
+    {
+        auto & callbackInfo{*static_cast<CALLBACK_INFO *>(pstWorkerItem->WorkCallbackArg)};
+
+        if (workIndex == 0) // main thread
+        {
+            // Wait for worker to be ready.
+            {
+                std::unique_lock lock{callbackInfo.mutex_};
+                callbackInfo.workerSignal_.wait(lock, [&]
+                {
+                    return callbackInfo.workerState_ == CALLBACK_INFO::WorkerState::READY;
+                });
+            }
+
+            bool didSomeWork{false};
+            int64_t lenX;
+            int64_t workBlock;
+
+            // As long as there is work to do
+            while ((lenX = pstWorkerItem->GetNextWorkBlock(&workBlock)) > 0)
+            {
+                // Indicate we completed a block
+                didSomeWork = true;
+
+                // tell others we completed this work block
+                pstWorkerItem->CompleteWorkBlock();
+            }
+
+            return didSomeWork;
+        }
+
+        else // worker thread(s)
+        {
+            {
+                std::lock_guard _{callbackInfo.mutex_};
+                if (callbackInfo.workerState_ != CALLBACK_INFO::WorkerState::INITIAL)
+                {
+                    return false;
+                }
+                callbackInfo.workerState_ = CALLBACK_INFO::WorkerState::READY;
+            }
+            callbackInfo.workerSignal_.notify_all();
+
+            {
+                std::unique_lock lock{callbackInfo.mutex_};
+                callbackInfo.mainSignal_.wait(lock, [&]
+                {
+                    return callbackInfo.mainState_ == CALLBACK_INFO::MainState::DONE;
+                });
+            }
+
+            {
+                std::lock_guard _{callbackInfo.mutex_};
+                callbackInfo.workerState_ = CALLBACK_INFO::WorkerState::DONE;
+            }
+            callbackInfo.workerSignal_.notify_all();
+
+            return false;
+        }
+    }
+
+    suite math_worker_ops = []
+    {
+        "work_main_waits"_test = [&]
+        {
+            expect(g_cMathWorker != nullptr);
+
+            CALLBACK_INFO callbackInfo{};
+
+            auto * workItem{g_cMathWorker->GetWorkItem(CMathWorker::WORK_ITEM_BIG)};
+            workItem->DoWorkCallback = Callback;
+            workItem->WorkCallbackArg = &callbackInfo;
+
+            int32_t const threadWakeup{0};
+            int64_t const len{1};
+            g_cMathWorker->WorkMain(workItem, len, threadWakeup);
+
+            // Ensure the worker thread is not running.
+
+            // Unblock worker if it's still running.
+            {
+                std::lock_guard _{callbackInfo.mutex_};
+                callbackInfo.mainState_ = CALLBACK_INFO::MainState::DONE;
+            }
+            callbackInfo.mainSignal_.notify_all();
+
+            {
+                std::unique_lock lock{callbackInfo.mutex_};
+                callbackInfo.workerSignal_.wait(lock, [&]
+                {
+                    return callbackInfo.workerState_ == CALLBACK_INFO::WorkerState::DONE;
+                });
+            }
+
+            int i{};
+            ++i;
+        };
+    };
+}


### PR DESCRIPTION
Ensures that no awoken worker threads are still running after the main work dispatch has returned.
Avoids spurious crashes in still-running worker threads due to dangling pointers.
Fixes #127 RIPTABLE-81