### PR TITLE
Add builds targeting numpy 1.22

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,13 @@ indent_size = 4
 tab_width = 4
 charset = utf-8
 #trim_trailing_whitespace = true
+
+# YAML config files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd, bat}]
+end_of_line = crlf

--- a/.github/workflows/native_sanity.yml
+++ b/.github/workflows/native_sanity.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==1.21
+        python -m pip install numpy==1.22
         python -m pip install riptable
       working-directory: ${{ env.working-directory }}
     - name: Create Cmake build directory
@@ -88,7 +88,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install numpy==1.21
+        python -m pip install numpy==1.22
         python -m pip install riptable
       working-directory: ${{ env.working-directory }}
     - name: Create Cmake build directory
@@ -188,6 +188,52 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install numpy==1.21
+        python -m pip install riptable
+      working-directory: ${{ env.working-directory }}
+    - name: Create Cmake build directory
+      run: |
+        cmake -E make_directory "build"
+      working-directory: ${{ env.working-directory }}
+    - name: Setup CMake Relase configuration
+      run: |
+        cmake -E chdir "build" cmake -DCMAKE_BUILD_TYPE=Release "-DRIPTIDE_PYTHON_VER=${{ matrix.python-version }}" ../
+      working-directory: ${{ env.working-directory }}
+    - name: Build Release via CMake
+      run: |
+        cmake --build "build" --config Release
+      working-directory: ${{ env.working-directory }}
+    - name: Run the Release tests and benchmarks
+      run: |
+        build/bench/riptide_bench/riptide_bench/riptide_bench
+        build/test/riptide_test/riptide_test
+        build/test/riptide_python_test/riptide_python_test
+      working-directory: ${{ env.working-directory }}
+
+  build-cmake-ubuntu-122:
+
+    runs-on: ${{ matrix.os }}
+    env:
+      working-directory: ./
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: ['3.10']
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+        # Set fetch-depth to 0 so all history is retrieved; this is needed so we get the git tags
+        # which we use for setting the package version (via setuptools-scm).
+        fetch-depth: 0
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install numpy==1.22
         python -m pip install riptable
       working-directory: ${{ env.working-directory }}
     - name: Create Cmake build directory

--- a/.github/workflows/python_package.yml
+++ b/.github/workflows/python_package.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-2019]
         python-version: [3.8, 3.9, '3.10']
-        numpy-version: [1.21]
+        numpy-version: [1.21, 1.22]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -123,9 +123,12 @@ jobs:
         zips: [
           { python: '3.8', numpy: '1.20' },
           { python: '3.8', numpy: '1.21' },
+          { python: '3.8', numpy: '1.22' },
           { python: '3.9', numpy: '1.20' },
           { python: '3.9', numpy: '1.21' },
-          { python: '3.10', numpy: '1.21' }
+          { python: '3.9', numpy: '1.22' },
+          { python: '3.10', numpy: '1.21' },
+          { python: '3.10', numpy: '1.22' }
           ]
     env:
       python_version: 3.9


### PR DESCRIPTION
numba 0.55.2 was recently released with compatibility for numpy 1.22; that means _riptide_cpp_ can now add builds targeting numpy 1.22 since _riptable_ will now be able to use it.